### PR TITLE
Unify MenuPanel and Home's navigation API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ class App extends React.Component {
     super()
     this.history = createHistory()
     this.state.path = this.history.location.pathname
-    this.history.listen(this.handleNavigation)
+    this.history.listen(this.onNavigate)
   }
   appInstance() {
     const matches = this.state.path.match(/^\/?([a-z]+)\/?([a-zA-Z0-9]+)?/)
@@ -28,8 +28,6 @@ class App extends React.Component {
     }
   }
   openApp = (appId, instanceId) => {
-    const app = apps.find(app => app.id === appId)
-
     if (appId === 'home') {
       this.changePath('/')
       return
@@ -41,31 +39,22 @@ class App extends React.Component {
     }
 
     // Get the first instance found if instanceId is not passed
+    const app = apps.find(app => app.id === appId)
+
     const instances = (app && app.instances) || []
     const instance = instanceId
       ? instances.find(({ id }) => id === instanceId)
       : instances[0]
 
-    this.changePath(`/${app.id}${instance ? `/${instance.id}` : ''}`)
+    this.changePath(`/${appId}${instance ? `/${instance.id}` : ''}`)
   }
   changePath = path => {
     if (path !== this.state.path) {
       this.history.push(path)
     }
   }
-  handleNavigation = location => {
+  onNavigate = location => {
     this.setState({ path: location.pathname })
-  }
-  handlePathChange = path => {
-    if (path !== this.state.path) {
-      this.history.push(path)
-    }
-  }
-  handleAction = id => {
-    const action = homeActions.find(action => action.id === id)
-    if (action) {
-      this.openApp(action.app)
-    }
   }
   openSidePanel = () => {
     this.setState({ sidePanelOpened: true })
@@ -83,8 +72,8 @@ class App extends React.Component {
             apps={apps}
             activeApp={app}
             activeInstance={instance}
+            handleAppNavigation={this.openApp}
             notifications={notifications}
-            onOpenApp={this.openApp}
           />
           <AppScreen>
             {app === 'home' && (
@@ -92,7 +81,7 @@ class App extends React.Component {
                 tokens={tokens}
                 prices={prices}
                 actions={homeActions}
-                onAction={this.handleAction}
+                handleAppNavigation={this.openApp}
               />
             )}
           </AppScreen>

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ class App extends React.Component {
     super()
     this.history = createHistory()
     this.state.path = this.history.location.pathname
-    this.history.listen(this.onNavigate)
+    this.history.listen(this.handleNavigation)
   }
   appInstance() {
     const matches = this.state.path.match(/^\/?([a-z]+)\/?([a-zA-Z0-9]+)?/)
@@ -27,7 +27,7 @@ class App extends React.Component {
       instanceId: matches[2],
     }
   }
-  openApp = (appId, instanceId) => {
+  handleOpenApp = (appId, instanceId) => {
     if (appId === 'home') {
       this.changePath('/')
       return
@@ -53,7 +53,7 @@ class App extends React.Component {
       this.history.push(path)
     }
   }
-  onNavigate = location => {
+  handleNavigation = location => {
     this.setState({ path: location.pathname })
   }
   openSidePanel = () => {
@@ -72,8 +72,8 @@ class App extends React.Component {
             apps={apps}
             activeAppId={appId}
             activeInstanceId={instanceId}
-            handleAppNavigation={this.openApp}
             notifications={notifications}
+            onOpenApp={this.handleOpenApp}
           />
           <AppScreen>
             {appId === 'home' && (
@@ -81,7 +81,7 @@ class App extends React.Component {
                 tokens={tokens}
                 prices={prices}
                 actions={homeActions}
-                handleAppNavigation={this.openApp}
+                onOpenApp={this.handleOpenApp}
               />
             )}
           </AppScreen>

--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,14 @@ class App extends React.Component {
       instanceId: matches[2],
     }
   }
+  changePath = path => {
+    if (path !== this.state.path) {
+      this.history.push(path)
+    }
+  }
+  handleNavigation = location => {
+    this.setState({ path: location.pathname })
+  }
   handleOpenApp = (appId, instanceId) => {
     if (appId === 'home') {
       this.changePath('/')
@@ -47,14 +55,6 @@ class App extends React.Component {
       : instances[0]
 
     this.changePath(`/${appId}${instance ? `/${instance.id}` : ''}`)
-  }
-  changePath = path => {
-    if (path !== this.state.path) {
-      this.history.push(path)
-    }
-  }
-  handleNavigation = location => {
-    this.setState({ path: location.pathname })
   }
   openSidePanel = () => {
     this.setState({ sidePanelOpened: true })

--- a/src/App.js
+++ b/src/App.js
@@ -20,11 +20,11 @@ class App extends React.Component {
   appInstance() {
     const matches = this.state.path.match(/^\/?([a-z]+)\/?([a-zA-Z0-9]+)?/)
     if (!matches) {
-      return { app: 'home', instance: '' }
+      return { appId: 'home', instanceId: '' }
     }
     return {
-      app: matches[1],
-      instance: matches[2],
+      appId: matches[1],
+      instanceId: matches[2],
     }
   }
   openApp = (appId, instanceId) => {
@@ -64,19 +64,19 @@ class App extends React.Component {
   }
   render() {
     const { notifications } = this.state
-    const { app, instance } = this.appInstance()
+    const { appId, instanceId } = this.appInstance()
     return (
       <AragonApp publicUrl="/aragon-ui/">
         <Main>
           <MenuPanel
             apps={apps}
-            activeApp={app}
-            activeInstance={instance}
+            activeAppId={appId}
+            activeInstanceId={instanceId}
             handleAppNavigation={this.openApp}
             notifications={notifications}
           />
           <AppScreen>
-            {app === 'home' && (
+            {appId === 'home' && (
               <Home
                 tokens={tokens}
                 prices={prices}

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -29,10 +29,10 @@ imgActions.set('new-payment', imgPayment)
 
 class Home extends React.Component {
   handleCardAction = actionId => {
-    const { actions, handleAppNavigation } = this.props
+    const { actions, onOpenApp } = this.props
     const action = actions.find(action => action.id === actionId)
     if (action) {
-      handleAppNavigation(action.app)
+      onOpenApp(action.app)
     }
   }
   render() {

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -28,8 +28,15 @@ imgActions.set('check-finance', imgFinance)
 imgActions.set('new-payment', imgPayment)
 
 class Home extends React.Component {
+  handleCardAction = actionId => {
+    const { actions, handleAppNavigation } = this.props
+    const action = actions.find(action => action.id === actionId)
+    if (action) {
+      handleAppNavigation(action.app)
+    }
+  }
   render() {
-    const { tokens, prices, actions, onAction } = this.props
+    const { tokens, prices, actions } = this.props
     return (
       <Main>
         <AppBarWrapper>
@@ -46,7 +53,7 @@ class Home extends React.Component {
                       id={id}
                       title={label}
                       icon={imgActions.get(id)}
-                      onActivate={onAction}
+                      onActivate={this.handleCardAction}
                     />
                   </CardWrap>
                 ))}

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -32,8 +32,8 @@ class MenuPanel extends React.Component {
     const {
       apps,
       notifications,
-      activeApp,
-      activeInstance,
+      activeAppId,
+      activeInstanceId,
       handleAppNavigation,
     } = this.props
     const { notificationsOpened } = this.state
@@ -66,9 +66,9 @@ class MenuPanel extends React.Component {
                       name={name}
                       icon={icon}
                       appId={id}
-                      active={id === activeApp}
+                      active={id === activeAppId}
                       instances={instances}
-                      activeInstance={activeInstance}
+                      activeInstanceId={activeInstanceId}
                       onActivate={handleAppNavigation}
                     />
                   </li>

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -34,7 +34,7 @@ class MenuPanel extends React.Component {
       notifications,
       activeApp,
       activeInstance,
-      onOpenApp,
+      handleAppNavigation,
     } = this.props
     const { notificationsOpened } = this.state
     const menuApps = [appHome, ...apps, appSettings]
@@ -69,7 +69,7 @@ class MenuPanel extends React.Component {
                       active={id === activeApp}
                       instances={instances}
                       activeInstance={activeInstance}
-                      onActivate={onOpenApp}
+                      onActivate={handleAppNavigation}
                     />
                   </li>
                 ))}

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -34,7 +34,7 @@ class MenuPanel extends React.Component {
       notifications,
       activeAppId,
       activeInstanceId,
-      handleAppNavigation,
+      onOpenApp,
     } = this.props
     const { notificationsOpened } = this.state
     const menuApps = [appHome, ...apps, appSettings]
@@ -69,7 +69,7 @@ class MenuPanel extends React.Component {
                       active={id === activeAppId}
                       instances={instances}
                       activeInstanceId={activeInstanceId}
-                      onActivate={handleAppNavigation}
+                      onActivate={onOpenApp}
                     />
                   </li>
                 ))}

--- a/src/components/MenuPanel/MenuPanelAppGroup.js
+++ b/src/components/MenuPanel/MenuPanelAppGroup.js
@@ -20,7 +20,14 @@ class MenuPanelAppGroup extends React.Component {
     this.props.onActivate(this.props.appId, instanceId)
   }
   render() {
-    const { appId, icon, name, instances, active, activeInstance } = this.props
+    const {
+      appId,
+      icon,
+      name,
+      instances,
+      active,
+      activeInstanceId,
+    } = this.props
     const image = icon || <img src={`/apps-icons/${appId}.svg`} alt="" />
     return (
       <Motion
@@ -62,7 +69,7 @@ class MenuPanelAppGroup extends React.Component {
                   <MenuPanelInstance
                     id={id}
                     name={name}
-                    active={id === activeInstance}
+                    active={id === activeInstanceId}
                     onClick={this.handleInstanceClick}
                   />
                 </li>


### PR DESCRIPTION
Small refactor:

- App only passes `handleNavigation()` to any component that _could_ control the wrapper's navigation
- Usages of ids for apps or instances are made explicit