### PR TITLE
App: allow wider range of app names

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ class App extends React.Component {
     this.history.listen(this.handleNavigation)
   }
   appInstance() {
-    const matches = this.state.path.match(/^\/?([a-z]+)\/?([a-zA-Z0-9]+)?/)
+    const matches = this.state.path.match(/^\/?(\w+)\/?(\w+)?/)
     if (!matches) {
       return { app: 'home', instance: '' }
     }


### PR DESCRIPTION
Allow app names to have upper case, numbers, and `_` (`\w` matches `[a-zA-Z0-9_]`).

@onbjerg @izqui do we have a spec on what apps (and their instances) can be named?