### PR TITLE
AppIFrame: handle message passing

### DIFF
--- a/src/components/App/AppIFrame.js
+++ b/src/components/App/AppIFrame.js
@@ -48,6 +48,7 @@ class AppIFrame extends React.Component {
     loadProgress: 0,
   }
   componentDidMount() {
+    window.addEventListener('message', this.handleReceiveMessage, false)
     this.navigateIFrame(this.props.src)
   }
   componentWillReceiveProps(nextProps) {
@@ -59,6 +60,7 @@ class AppIFrame extends React.Component {
     }
   }
   componentWillUnmount() {
+    window.removeEventListener('message', this.handleReceiveMessage, false)
     this.clearProgressTimeout()
   }
   isHidden = () => {
@@ -119,11 +121,26 @@ class AppIFrame extends React.Component {
     this.clearProgressTimeout()
     this.setState({ hideProgressBar: true, loadProgress: 0 }, cb)
   }
+  sendMessage = data => {
+    // Must use '*' for origin as we've sandboxed the iframe's origin
+    this.iframe.contentWindow.postMessage(data, '*')
+  }
   handleOnLoad = (...args) => {
     const { onLoad } = this.props
     this.endProgress()
     if (typeof onLoad === 'function') {
       onLoad(...args)
+    }
+  }
+  handleReceiveMessage = event => {
+    const { onMessage } = this.props
+    if (
+      typeof onMessage === 'function' &&
+      // Make sure the event actually came from the iframe window
+      // We can't use event.origin as it's always null due to the origin sandboxing
+      event.source === this.iframe.contentWindow
+    ) {
+      onMessage(event)
     }
   }
   render() {
@@ -145,6 +162,7 @@ class AppIFrame extends React.Component {
       <React.Fragment>
         {progressBar}
         <StyledIFrame
+          name="AppIFrame"
           frameBorder={0}
           onLoad={this.handleOnLoad}
           ref={iframe => {


### PR DESCRIPTION
Adds some functionality to `AppIFrame` to send and receive messages from the parent.

Due to how aragon-js handles message passing, `sendMessage()` may not be used in the future,  but I've included it in case we find ourselves needing to manually pass some messages in the future.