### PR TITLE
Add Signer panel UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,8 @@ import initWrapper from './aragonjs-wrapper'
 import Web3 from 'web3'
 
 import {
-  actionIntent,
-  actionPaths,
+  // actionIntent,
+  // actionPaths,
   notifications,
   tokens,
   prices,
@@ -35,14 +35,8 @@ class App extends React.Component {
     path: '',
     search: '',
     notifications,
-    // signerOpened: false,
-    // web3Action: {},
-    signerOpened: true,
-    web3Action: {
-      error: null,
-      intent: actionIntent,
-      paths: actionPaths,
-    },
+    signerOpened: false,
+    web3Action: {},
   }
   constructor() {
     super()

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
 import createHistory from 'history/createHashHistory'
-import { AragonApp } from '@aragon/ui'
+import { AragonApp, SidePanel } from '@aragon/ui'
 import AppIFrame from './components/App/AppIFrame'
 import App404 from './components/App404/App404'
 import Home from './components/Home/Home'
 import MenuPanel from './components/MenuPanel/MenuPanel'
+import SignerPanelContent from './components/SignerPanel/SignerPanelContent'
 import Permissions from './apps/Permissions/Permissions'
 import initWrapper from './aragonjs-wrapper'
 import Web3 from 'web3'
 
 import {
+  actionIntent,
+  actionPaths,
   notifications,
   tokens,
   prices,
@@ -31,8 +34,15 @@ class App extends React.Component {
     lastPath: '',
     path: '',
     search: '',
-    sidePanelOpened: false,
     notifications,
+    // signerOpened: false,
+    // web3Action: {},
+    signerOpened: true,
+    web3Action: {
+      error: null,
+      intent: actionIntent,
+      paths: actionPaths,
+    },
   }
   constructor() {
     super()
@@ -45,6 +55,9 @@ class App extends React.Component {
     this.state.search = search
     this.state.appInstance = this.appInstance(path, search)
     this.state.apps = this.getCache().apps || []
+
+    // TODO: initialize web3 instance with browser-provided provider
+    this.web3 = {}
 
     initWrapper(DAO, ENS, { provider: PROVIDER }).then(wrapper => {
       this.setState({ wrapper })
@@ -139,6 +152,23 @@ class App extends React.Component {
       params ? encodeURIComponent(JSON.stringify(params)) : null
     )
   }
+  handleSignerClose = () => {
+    this.setState({
+      signerOpened: false,
+    })
+  }
+  handleSignerTransitionEnd = opened => {
+    // Reset signer state only after it has finished transitioning out
+    if (!opened) {
+      this.setState({
+        web3Action: {},
+      })
+    }
+  }
+  handleSigningWeb3Tx = ({ data, from, to }) => {
+    // TODO: handle web3 signing before reseting signing state
+    Promise.resolve().then(this.handleSignerClose)
+  }
   isAppInstalled(appId) {
     const { apps } = this.state
     return (
@@ -173,17 +203,23 @@ class App extends React.Component {
       params ? `?params=${params}` : ''
     )
   }
-  openSidePanel = () => {
-    this.setState({ sidePanelOpened: true })
-  }
-  closeSidePanel = () => {
-    this.setState({ sidePanelOpened: false })
+  showWeb3ActionSigner = (intent, { error, paths }) => {
+    this.setState({
+      signerOpened: true,
+      web3Action: {
+        error,
+        intent,
+        paths,
+      },
+    })
   }
   render() {
     const {
-      appInstance: { appId, instanceId, params },
-      notifications,
       apps,
+      notifications,
+      signerOpened,
+      web3Action,
+      appInstance: { appId, instanceId, params },
     } = this.state
     return (
       <AragonApp publicUrl="/aragon-ui/">
@@ -197,6 +233,19 @@ class App extends React.Component {
           />
           <AppScreen>{this.renderApp(appId, params)}</AppScreen>
         </Main>
+        <SidePanel
+          onClose={this.handleSignerClose}
+          onTransitionEnd={this.handleSignerTransitionEnd}
+          opened={signerOpened}
+          title="Sign Transaction"
+        >
+          <SignerPanelContent
+            onClose={this.handleSignerClose}
+            onSign={this.handleSigningWeb3Tx}
+            web3={this.web3}
+            {...web3Action}
+          />
+        </SidePanel>
       </AragonApp>
     )
   }

--- a/src/components/SignerPanel/SignerPanelContent.js
+++ b/src/components/SignerPanel/SignerPanelContent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Button, Info, RadioGroup, SafeLink } from '@aragon/ui'
+import { Button, Info, RadioList, SafeLink } from '@aragon/ui'
 import { network } from '../../demo-state'
 
 const etherscanBaseUrl = `https://${
@@ -63,7 +63,7 @@ class ActionPathsContent extends React.Component {
               necessary permissions.
             </Info.Permissions>
             <Actions>
-              <RadioGroup
+              <RadioList
                 title="Action Requirement"
                 description={
                   paths.length > 1

--- a/src/components/SignerPanel/SignerPanelContent.js
+++ b/src/components/SignerPanel/SignerPanelContent.js
@@ -1,0 +1,156 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Button, Info, RadioGroup, SafeLink } from '@aragon/ui'
+import { network } from '../../demo-state'
+
+const etherscanBaseUrl = `https://${
+  network === 'mainnet' ? '' : `${network}.`
+}etherscan.io`
+
+const SignerPanelContent = ({
+  error,
+  intent,
+  paths,
+  onClose,
+  onSign,
+  web3,
+}) => {
+  if (!web3) {
+    return <NeedWeb3Content intent={intent} onClose={onClose} />
+  }
+
+  const possible =
+    (intent.tx || (Array.isArray(paths) && paths.length)) && !error
+  return possible ? (
+    <ActionPathsContent intent={intent} paths={paths} onSign={onSign} />
+  ) : (
+    <ImpossibleContent error={error} intent={intent} onClose={onClose} />
+  )
+}
+SignerPanelContent.defaultProps = {
+  intent: {},
+  paths: [],
+  onClose: () => {},
+  onSign: () => {},
+}
+
+class ActionPathsContent extends React.Component {
+  state = {
+    selected: 0,
+  }
+  handleOnSelect = selected => {
+    this.setState({ selected })
+  }
+  handleSign = () => {
+    const { intent, paths, onSign } = this.props
+    const { selected } = this.state
+    onSign(intent.tx || paths[selected].tx)
+  }
+  render() {
+    const { intent: { description, to, tx }, paths } = this.props
+    const { selected } = this.state
+    const radioItems = paths.map(({ appName, description }) => ({
+      description,
+      title: appName,
+    }))
+    const showPaths = !tx && paths.length
+    return (
+      <React.Fragment>
+        {showPaths ? (
+          <ActionContainer>
+            <Info.Permissions title="Permission note:">
+              You cannot directly perform this action. You do not have the
+              necessary permissions.
+            </Info.Permissions>
+            <Actions>
+              <RadioGroup
+                title="Action Requirement"
+                description={
+                  paths.length > 1
+                    ? 'Here are some options you can use to perform it:'
+                    : 'You can perform this action through:'
+                }
+                items={radioItems}
+                onChange={this.handleOnSelect}
+                selected={selected}
+              />
+            </Actions>
+          </ActionContainer>
+        ) : (
+          <DirectActionHeader>
+            You can directly perform this action:
+          </DirectActionHeader>
+        )}
+        <Info.Action icon={null} title="Action to be triggered">
+          {`This transaction will ${
+            showPaths ? 'eventually' : ''
+          } ${description || 'perform an action on'}`}{' '}
+          {to ? <AddressLink to={to} /> : 'this app'}.
+        </Info.Action>
+        <SignerButton onClick={this.handleSign}>Sign Transaction</SignerButton>
+      </React.Fragment>
+    )
+  }
+}
+
+const ImpossibleContent = ({ error, intent: { description, to }, onClose }) => (
+  <React.Fragment>
+    <Info.Permissions title="Action impossible">
+      You cannot {description || 'perform this action on'}{' '}
+      {to ? <AddressLink to={to} /> : 'this app'}
+      .{' '}
+      {error
+        ? 'An error occurred when we tried to find a path for this action.'
+        : 'You do not have the necessary permissions.'}
+    </Info.Permissions>
+    <SignerButton onClick={onClose}>Close</SignerButton>
+  </React.Fragment>
+)
+
+const NeedWeb3Content = ({ intent: { description, to }, onClose }) => (
+  <React.Fragment>
+    <Info.Action title="You can't perform any actions">
+      {`You need to be connected to a Web3 instance in order to ${description ||
+        'perform an action on'}`}{' '}
+      {to ? <AddressLink to={to} /> : 'this app'}.
+      <InstallMessage>
+        Please install or enable{' '}
+        <SafeLink href="https://metamask.io/" target="_blank">
+          MetaMask
+        </SafeLink>.
+      </InstallMessage>
+    </Info.Action>
+    <SignerButton onClick={onClose}>Close</SignerButton>
+  </React.Fragment>
+)
+
+const AddressLink = ({ to }) => (
+  <SafeLink href={`${etherscanBaseUrl}/address/${to}`} target="_blank">
+    {to}
+  </SafeLink>
+)
+
+const ActionContainer = styled.div`
+  margin-bottom: 40px;
+`
+
+const Actions = styled.div`
+  margin-top: 25px;
+`
+
+const DirectActionHeader = styled.h2`
+  margin-bottom: 10px;
+`
+
+const InstallMessage = styled.p`
+  margin-top: 15px;
+`
+
+const SignerButton = styled(Button).attrs({
+  mode: 'strong',
+  wide: true,
+})`
+  margin-top: 20px;
+`
+
+export default SignerPanelContent

--- a/src/demo-state.js
+++ b/src/demo-state.js
@@ -170,3 +170,23 @@ export const permissions = {
     },
   ],
 }
+
+export const network = 'rinkeby'
+export const actionIntent = {
+  description: 'perform a payment to',
+  to: '0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be',
+}
+export const actionPaths = [
+  {
+    appName: 'Voting (ANT)',
+    description:
+      'The Voting (ANT) app will create a new voting for ANT holders to decide whether to perform this action or not.',
+    tx: { from: null, to: null, data: null },
+  },
+  {
+    appName: 'Tokens (XVT) -> Voting (ANT)',
+    description:
+      '1. The Tokens (XVT) app will forward actions requested by XVT holders.\n2. The Voting (ANT) app will create a new voting for ANT holders to decide whether to perform this action or not.',
+    tx: { from: null, to: null, data: null },
+  },
+]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4166642/36307048-9d52cc68-131a-11e8-8aa2-e49d4b323848.png)

Fixes #64.

Requires https://github.com/aragon/aragon-ui/pull/116, https://github.com/aragon/aragon-ui/pull/117, https://github.com/aragon/aragon-ui/pull/118 (merged branch: https://github.com/aragon/aragon-ui/tree/signer-ui-merged).

Not yet hooked up to a web3 instance, but I can do that after the aragon.js integration (🤞this should just be hooking up the browser-provided web3 provider and then a `.sendTransaction()`).

Currently expects the following data format (see [demo state](https://github.com/aragon/aragon/commit/a374171f71379bbc8be473446baa76ff0c4b0c36#diff-897cda2bfa1893ce533ee6ee00aff957R175)):

```
intent: {
  description: description of action's intent, usually in the form of "perform <action> to"
  to: contract addr,
  tx: [optional] if provided, the action is assumed to be directly invokable by the current user; in the format of { from, to, data }
}
paths: [
  {
    appName: names of the apps being forwarded to,
    description: description of what the forwarding process will be like,
    tx: forwarding transaction; in the format of { from, to, data }
  },
  ...
]
error: any error that results from finding the transaction pathing (i.e. a catch-all for any errors thrown by aragon.js)
```

The signer providers a number of different "views", depending on how much information gets passed in (note `$r` is the `<App />` instance):

### Directly performable

<img src="https://user-images.githubusercontent.com/4166642/36307640-56028e68-131d-11e8-8065-46925108d2b3.png" height=250>

```js
$r.setState({
    web3Action: {
		intent: {
			description: "perform a payment to",
			to: '0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be',
			tx: { }
        }
    }
})
```

### Error

<img src="https://user-images.githubusercontent.com/4166642/36307648-5b6127c0-131d-11e8-92b9-edfe74094226.png" height=250>

```js
$r.setState({
    web3Action: {
        error: new Error(),
		intent: {
			description: 'perform a payment to',
			to: '0x3f5ce5fbfe3e9af3971dd833d26ba9b5c936f0be'
        }
    }
})
```

-------------------------

In general, if the intent isn't given, the text defaults to "perform this action on this app":

<img src="https://user-images.githubusercontent.com/4166642/36307634-51ad508c-131d-11e8-8de9-54c3f46a4ed0.png" height=250>

```js
$r.setState({
    web3Action: {
        error: new Error(),
    }
})
```