### PR TITLE
Hide wallet icon

### DIFF
--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -50,9 +50,9 @@ class MenuPanel extends React.Component {
           <Header>
             <img src={logo} alt="Aragon" height="36" />
             <div className="actions">
-              <a role="button" tabIndex="0">
+              {/* <a role="button" tabIndex="0">
                 <IconWallet />
-              </a>
+              </a> */}
               <a
                 role="button"
                 tabIndex="0"


### PR DESCRIPTION
We're not using this yet. Let's re-enable it once we do.