### PR TITLE
fix logo path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aragon ÐApp <img align="right" src="https://github.com/aragonone/issues/blob/master/logo.png" height="80px" />
+# Aragon ÐApp <img align="right" src="https://github.com/aragon/design/blob/master/readme-logo.png" height="80px" />
 
 [![Build Status](https://travis-ci.org/aragon/aragon.svg?branch=master)](https://travis-ci.org/aragon/aragon)
 


### PR DESCRIPTION
The previous link of logo is missing https://github.com/aragonone/issues/blob/master/logo.png
Use logo in `src/components/MenuPanel/assets/logo.svg` instead