### PR TITLE
correct the license to AGPLv3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Aragon DApp",
   "version": "0.5.0",
   "private": true,
-  "license": "GPLv3",
+  "license": "AGPLv3",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aragon/aragon.git"


### PR DESCRIPTION
According to https://github.com/aragon/aragon/blob/master/LICENSE aragon/aragon use AGPLv3

Since `AGPLv3` has some different attribute with `GPLv3`, we should show the right license in npm