### PR TITLE
Check to make sure an app doesn't have a running worker instance before starting one

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -81,23 +81,27 @@ const subscribe = (
             return
           }
 
-          const worker = new Worker(workerUrl)
-          worker.addEventListener(
-            'error',
-            err =>
-              console.error(
-                `Error from worker for ${name}(${proxyAddress}):`,
-                err
-              ),
-            false
-          )
+          // If another execution context already loaded this app's worker before we got to it here,
+          // let's short circuit
+          if (!workerSubscriptionPool.hasWorker(proxyAddress)) {
+            const worker = new Worker(workerUrl)
+            worker.addEventListener(
+              'error',
+              err =>
+                console.error(
+                  `Error from worker for ${name}(${proxyAddress}):`,
+                  err
+                ),
+              false
+            )
 
-          const provider = new providers.MessagePortMessage(worker)
-          workerSubscriptionPool.addWorker({
-            app,
-            worker,
-            subscription: wrapper.runApp(provider, proxyAddress).shutdown,
-          })
+            const provider = new providers.MessagePortMessage(worker)
+            workerSubscriptionPool.addWorker({
+              app,
+              worker,
+              subscription: wrapper.runApp(provider, proxyAddress).shutdown,
+            })
+          }
 
           // Clean up the url we created to spawn the worker
           URL.revokeObjectURL(workerUrl)


### PR DESCRIPTION
Oops, let's pretend I knew that<sup>1</sup> could happen.

<sup>1</sup>`await` gives up the current context, so if the `apps` stream emits faster than we can fetch the worker scripts, it's possible more than one context could be on their way to starting worker scripts for the apps.