### PR TITLE
Set accounts on aragon.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,9 @@ class App extends React.Component {
     this.history.listen(this.handleHistoryChange)
     pollMainAccount(web3Providers.wallet, (account = null) => {
       this.setState({ account })
+      if (this.state.wrapper) {
+        this.state.wrapper.setAccounts([account])
+      }
     })
   }
 

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -199,7 +199,7 @@ const initWrapper = async (
   }
 
   try {
-    await wrapper.init()
+    await wrapper.init([account])
   } catch (err) {
     if (err.message === 'connection not open') {
       onError('NO_CONNECTION')


### PR DESCRIPTION
Requires https://github.com/aragon/aragon.js/pull/93.

Sets the available accounts on the aragon.js wrapper.