### PR TITLE
Separate account and balance into two callbacks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,11 +41,16 @@ class App extends React.Component {
       return
     }
 
-    pollMainAccount(web3Providers.wallet, (account = null, balance) => {
-      this.setState({ account, balance })
-      if (account && this.state.wrapper) {
-        this.state.wrapper.setAccounts([account])
-      }
+    pollMainAccount(web3Providers.wallet, {
+      onAccount: (account = null) => {
+        this.setState({ account })
+        if (account && this.state.wrapper) {
+          this.state.wrapper.setAccounts([account])
+        }
+      },
+      onBalance: balance => {
+        this.setState({ balance })
+      },
     })
 
     pollNetwork(web3Providers.wallet, network => {

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -79,7 +79,7 @@ export const pollMainAccount = pollEvery(
   (provider, { onAccount = () => {}, onBalance = () => {} } = {}) => {
     const web3 = getWeb3(provider)
     let lastAccount = null
-    let lastBalance = null
+    let lastBalance = -1
     return {
       request: () =>
         getMainAccount(web3)
@@ -93,14 +93,14 @@ export const pollMainAccount = pollEvery(
             }))
           })
           .catch(() => {
-            return { account: null, balance: BigNumber(0) }
+            return { account: null, balance: BigNumber(-1) }
           }),
       onResult: ({ account, balance }) => {
         if (account !== lastAccount) {
           lastAccount = account
           onAccount(account)
         }
-        if (!balance.isEqualTo(lastBalance || 0)) {
+        if (!balance.isEqualTo(lastBalance)) {
           lastBalance = balance
           onBalance(balance)
         }

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -75,34 +75,40 @@ const pollEvery = (fn, delay) => {
 
 // Keep polling the main account.
 // See https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#ear-listening-for-selected-account-changes
-export const pollMainAccount = pollEvery((provider, onAccount) => {
-  const web3 = getWeb3(provider)
-  let lastAccount = null
-  let lastBalance = null
-  return {
-    request: () =>
-      getMainAccount(web3)
-        .then(account => {
-          if (!account) {
-            throw new Error('no account')
-          }
-          return web3.eth.getBalance(account).then(balance => ({
-            account,
-            balance: BigNumber(balance),
-          }))
-        })
-        .catch(() => {
-          return { account: null, balance: BigNumber(0) }
-        }),
-    onResult: ({ account, balance }) => {
-      if (account !== lastAccount || balance !== lastBalance) {
-        lastAccount = account
-        lastBalance = balance
-        onAccount(account, balance)
-      }
-    },
-  }
-}, POLL_DELAY_ACCOUNT)
+export const pollMainAccount = pollEvery(
+  (provider, { onAccount = () => {}, onBalance = () => {} } = {}) => {
+    const web3 = getWeb3(provider)
+    let lastAccount = null
+    let lastBalance = null
+    return {
+      request: () =>
+        getMainAccount(web3)
+          .then(account => {
+            if (!account) {
+              throw new Error('no account')
+            }
+            return web3.eth.getBalance(account).then(balance => ({
+              account,
+              balance: BigNumber(balance),
+            }))
+          })
+          .catch(() => {
+            return { account: null, balance: BigNumber(0) }
+          }),
+      onResult: ({ account, balance }) => {
+        if (account !== lastAccount) {
+          lastAccount = account
+          onAccount(account)
+        }
+        if (!balance.isEqualTo(lastBalance || 0)) {
+          lastBalance = balance
+          onBalance(balance)
+        }
+      },
+    }
+  },
+  POLL_DELAY_ACCOUNT
+)
 
 // Keep polling the network.
 export const pollNetwork = pollEvery((provider, onNetwork) => {


### PR DESCRIPTION
We shouldn't use `wrapper.setAccount()` more than we have to; its subscribers will be constantly getting executed.

Also fixes a [equality check](https://github.com/aragon/aragon/pull/148/files#diff-c1957ab402163ee0da348f170f242479R103) due to web3 using BN for the balance (but for nothing else??? wtf?)