### PR TITLE
Default `start_url` to `index.html`

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -29,7 +29,7 @@ const appSrc = (app, gateway = ipfsDefaultConf.gateway) => {
 const prepareFrontendApps = (apps, gateway) =>
   apps
     .map(app => ({ ...(appDefaults[app.appId] || {}), ...app }))
-    .filter(app => app && app['short_url'])
+    .map(app => app && (app['start_url'] || '/index.html'))
     .map(app => ({ ...app, appSrc: appSrc(app, gateway) }))
 
 const getMainAccount = async web3 => {

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -29,7 +29,7 @@ const appSrc = (app, gateway = ipfsDefaultConf.gateway) => {
 const prepareFrontendApps = (apps, gateway) =>
   apps
     .map(app => ({ ...(appDefaults[app.appId] || {}), ...app }))
-    .map(app => app && (app['start_url'] || '/index.html'))
+    .filter(app => app && app['start_url'])
     .map(app => ({ ...app, appSrc: appSrc(app, gateway) }))
 
 const getMainAccount = async web3 => {


### PR DESCRIPTION
We're filtering out all the apps because it filters for `short_url`, but it's actually called `start_url`.

Furthermore, I think we should default to `/index.html` as opposed to filtering out the app.