### PR TITLE
Add a build:analyze script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,13 +63,15 @@
     "eslint-plugin-standard": "^3.0.1",
     "find-pkg": "^1.0.0",
     "prettier": "^1.11.1",
-    "react-scripts": "^2.0.0-next.9754a231"
+    "react-scripts": "^2.0.0-next.9754a231",
+    "webpack-bundle-analyzer": "^2.11.1"
   },
   "scripts": {
     "update-assets": "rm -rf public/aragon-ui && cp -r node_modules/@aragon/ui/dist public/aragon-ui",
     "lint": "eslint ./src",
     "start": "npm run update-assets && react-scripts start",
     "build": "npm run update-assets && PUBLIC_URL=/ react-scripts build && npm run copy-apm-artifacts",
+    "build:analyze": "node scripts/build-analyze.js",
     "copy-apm-artifacts": "cp arapp.json build/arapp.json && cp manifest.json build/manifest.json",
     "publish:rinkeby": "aragon publish --files build/ --no-contract=true --keyfile ~/.rinkebykey.json 0x0000000000000000000000000000000000000000",
     "test": "npm run lint",

--- a/scripts/build-analyze.js
+++ b/scripts/build-analyze.js
@@ -1,0 +1,14 @@
+process.env.NODE_ENV = 'production'
+const Analyzer = require('webpack-bundle-analyzer')
+
+const webpackConfigProd = require('react-scripts/config/webpack.config.prod')
+
+webpackConfigProd.plugins.push(
+  new Analyzer.BundleAnalyzerPlugin({
+    analyzerMode: 'static',
+    reportFilename: 'report.html',
+    generateStatsFile: true,
+  })
+)
+
+require('react-scripts/scripts/build')


### PR DESCRIPTION
It creates a page to vizualize the size of each dependency, and also generates a `build/stats.json` file that can be used by different viewers like [webpack-visualizer](https://chrisbateman.github.io/webpack-visualizer/).