### PR TITLE
Add generic errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -157,10 +157,8 @@ class App extends React.Component {
     initWrapper(dao, contractAddresses.ensRegistry, {
       provider: web3Providers.default,
       walletProvider: web3Providers.wallet,
-      onError: name => {
-        if (name === 'NO_CONNECTION') {
-          log('No Ethereum connection detected.')
-        }
+      onError: err => {
+        log(`Wrapper init error: ${err.name}. ${err.message}.`)
       },
       onDaoAddress: daoAddress => {
         log('daoAddress', daoAddress)

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -14,6 +14,7 @@ import {
 import { noop, removeTrailingSlash } from './utils'
 import { getWeb3 } from './web3-utils'
 import { getBlobUrl, WorkerSubscriptionPool } from './worker-utils'
+import { InvalidAddress, NoConnection } from './errors'
 
 const POLL_DELAY_ACCOUNT = 2000
 const POLL_DELAY_NETWORK = 2000
@@ -265,7 +266,7 @@ const initWrapper = async (
     : dao
 
   if (!daoAddress) {
-    onError('INVALID_DAO_ADDRESS')
+    onError(new InvalidAddress('The provided DAO address is invalid'))
     return
   }
 
@@ -285,7 +286,11 @@ const initWrapper = async (
     await wrapper.init(account && [account])
   } catch (err) {
     if (err.message === 'connection not open') {
-      onError('NO_CONNECTION')
+      onError(
+        new NoConnection(
+          'The wrapper can not be initialized without a connection'
+        )
+      )
       return
     }
     throw err

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,14 @@
+const extendError = (name, { defaultMessage }) =>
+  class extends Error {
+    name = name
+    constructor(message = defaultMessage) {
+      super(message)
+    }
+  }
+
+export const InvalidAddress = extendError('InvalidAddress', {
+  defaultMessage: 'The address is invalid',
+})
+export const NoConnection = extendError('NoConnection', {
+  defaultMessage: 'There is no connection',
+})


### PR DESCRIPTION
Start using generic errors that can be used in the app.

An error type can be tested using `instanceof`, e.g. `err instanceof InvalidAddress`.