### PR TITLE
Signer: parse addresses to installed app name

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -78,7 +78,7 @@ class Wrapper extends React.Component {
   makeTransactionIntent(transaction = {}) {
     const { apps } = this.props
     const { description, to } = transaction
-    const toApp = apps.filter(app => addressesEqual(app.proxyAddress, to))[0]
+    const toApp = apps.find(app => addressesEqual(app.proxyAddress, to))
     const toName = (toApp && toApp.name) || ''
 
     return {

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -12,6 +12,7 @@ import ComingSoon from './components/ComingSoon/ComingSoon'
 import MenuPanel from './components/MenuPanel/MenuPanel'
 import SignerPanelContent from './components/SignerPanel/SignerPanelContent'
 import { getAppPath, staticApps } from './routing'
+import { addressesEqual } from './web3-utils'
 
 class Wrapper extends React.Component {
   static defaultProps = {
@@ -74,6 +75,19 @@ class Wrapper extends React.Component {
     // const { appId, } = this.state.appInstance
     // this.openApp(appId, params)
   }
+  makeTransactionIntent(transaction = {}) {
+    const { apps } = this.props
+    const { description, to } = transaction
+    const toApp = apps.filter(app => addressesEqual(app.proxyAddress, to))[0]
+    const toName = (toApp && toApp.name) || ''
+
+    return {
+      description,
+      to,
+      toName,
+      transaction,
+    }
+  }
   reshapeTransactionBag(bag) {
     // This is a temporary method to reshape the transaction bag
     // to the future format we expect from Aragon.js
@@ -81,16 +95,11 @@ class Wrapper extends React.Component {
     // replace search and replace this function with `bag`, although
     // it is probably only used in `handleTransaction`
     const transaction = bag.path[bag.path.length - 1]
-    const intent = {
-      to: transaction && transaction.to,
-      transaction,
-      description: transaction && transaction.description,
-    }
     const direct = bag.path.length === 1
 
     return {
-      intent,
       direct,
+      intent: this.makeTransactionIntent(transaction),
       paths: direct ? [] : [bag.path],
     }
   }
@@ -106,7 +115,8 @@ class Wrapper extends React.Component {
       this.handleSignerClose()
 
       if (err) {
-        this.showWeb3ActionSigner({ to: transaction.to }, { error: err })
+        const errorIntent = this.makeTransactionIntent(transaction)
+        this.showWeb3ActionSigner(errorIntent, { error: err })
         reject(err)
         console.error(err)
         return

--- a/src/components/SignerPanel/SignerPanelContent.js
+++ b/src/components/SignerPanel/SignerPanelContent.js
@@ -52,16 +52,17 @@ class ActionPathsContent extends React.Component {
     // to kick off the forwarding path
     onSign(direct ? intent.transaction : paths[selected][0])
   }
-  renderDescription(showPaths, description, transaction = {}, to = '') {
+  renderDescription(showPaths, { description, to, toName, transaction = {} }) {
     if (transaction.description) {
       return transaction.description
     }
     return (
       <span>
-        {`This transaction will ${
-          showPaths ? 'eventually' : ''
-        } ${description || 'perform an action on'}`}{' '}
-        <AddressLink to={to} />.
+        This transaction will {showPaths && 'eventually'} perform{' '}
+        {description ? `"${description}"` : 'an action'}
+        {' on '}
+        <AddressLink to={to}>{toName}</AddressLink>
+        .
       </span>
     )
   }
@@ -103,11 +104,7 @@ class ActionPathsContent extends React.Component {
     }
   }
   render() {
-    const {
-      intent: { description, to, transaction },
-      direct,
-      paths,
-    } = this.props
+    const { intent, direct, paths } = this.props
     const { selected } = this.state
     const showPaths = !direct
     const radioItems = paths.map(this.getPathRadioItem)
@@ -139,7 +136,7 @@ class ActionPathsContent extends React.Component {
           </DirectActionHeader>
         )}
         <Info.Action icon={null} title="Action to be triggered:">
-          {this.renderDescription(showPaths, description, transaction, to)}
+          {this.renderDescription(showPaths, intent)}
         </Info.Action>
         <SignerButton onClick={this.handleSign}>Sign Transaction</SignerButton>
       </React.Fragment>
@@ -147,26 +144,35 @@ class ActionPathsContent extends React.Component {
   }
 }
 
-const ImpossibleContent = ({ error, intent: { description, to }, onClose }) => (
+const ImpossibleContent = ({
+  error,
+  intent: { description, to, toName },
+  onClose,
+}) => (
   <React.Fragment>
     <Info.Permissions title="Action impossible">
-      You cannot {description || 'perform this action on'}{' '}
-      <AddressLink to={to} />
+      The action {description && `"${description}"`} failed to execute on{' '}
+      <AddressLink to={to}>{toName}</AddressLink>
       .{' '}
       {error
-        ? 'An error occurred when we tried to find a path for this action.'
+        ? 'An error occurred when we tried to find a path or send a transaction for this action.'
         : 'You do not have the necessary permissions.'}
     </Info.Permissions>
     <SignerButton onClick={onClose}>Close</SignerButton>
   </React.Fragment>
 )
 
-const NeedUnlockAccountContent = ({ intent: { description, to }, onClose }) => (
+const NeedUnlockAccountContent = ({
+  intent: { description, to, toName },
+  onClose,
+}) => (
   <React.Fragment>
     <Info.Action title="You can't perform any actions">
-      {`You need to unlock your account in order to ${description ||
-        'perform this action'}`}{' on '}
-      <AddressLink to={to} />.
+      You need to unlock your account in order to perform{' '}
+      {description ? `"${description}"` : 'this action'}
+      {' on '}
+      <AddressLink to={to}>{toName}</AddressLink>
+      .
       <InstallMessage>
         Please unlock or enable{' '}
         <SafeLink href="https://metamask.io/" target="_blank">
@@ -178,12 +184,14 @@ const NeedUnlockAccountContent = ({ intent: { description, to }, onClose }) => (
   </React.Fragment>
 )
 
-const NeedWeb3Content = ({ intent: { description, to }, onClose }) => (
+const NeedWeb3Content = ({ intent: { description, to, toName }, onClose }) => (
   <React.Fragment>
     <Info.Action title="You can't perform any actions">
-      {`You need to be connected to a Web3 instance in order to ${description ||
-        'perform this action on'}`}{' '}
-      <AddressLink to={to} />.
+      You need to be connected to a Web3 instance in order to perform{' '}
+      {description ? `"${description}"` : 'this action'}
+      {' on '}
+      <AddressLink to={to}>{toName}</AddressLink>
+      .
       <InstallMessage>
         Please install or enable{' '}
         <SafeLink href="https://metamask.io/" target="_blank">
@@ -195,13 +203,13 @@ const NeedWeb3Content = ({ intent: { description, to }, onClose }) => (
   </React.Fragment>
 )
 
-const AddressLink = ({ to }) =>
+const AddressLink = ({ children, to }) =>
   to ? (
     <EtherscanLink address={to}>
       {url =>
         url ? (
           <SafeLink href={url} target="_blank">
-            {to}
+            {children || to}
           </SafeLink>
         ) : (
           to

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -1,5 +1,12 @@
 import Web3 from 'web3'
 
+// Check address equality without checksums
+export function addressesEqual(first, second) {
+  first = first && first.toLowerCase()
+  second = second && second.toLowerCase()
+  return first === second
+}
+
 // Cache web3 instances used in the app
 const cache = new WeakMap()
 export function getWeb3(provider) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4166642/38020010-767e17f4-3279-11e8-9d21-20a1898e9d97.png)

Fixes #183, requires #175.

Tries to substitute a transaction's `to` address with an installed app's name, if possible.

Also modifies the signer panel's text to fit a little better with the current descriptions (now always in the form of `... perform "<description>" on ...`).