### PR TITLE
Capitalize SOON in 'coming soon' apps

### DIFF
--- a/src/components/MenuPanel/MenuPanelAppGroup.js
+++ b/src/components/MenuPanel/MenuPanelAppGroup.js
@@ -52,7 +52,7 @@ class MenuPanelAppGroup extends React.Component {
               </span>
               {comingSoon && (
                 <span>
-                  <Badge shape="compact">soon</Badge>
+                  <Badge shape="compact">SOON</Badge>
                 </span>
               )}
             </ButtonItem>


### PR DESCRIPTION
soon -> SOON

Purely visual preference. @bpierre @jounih opinions?
<img width="257" alt="2018-03-29 at 12 58 11 pm" src="https://user-images.githubusercontent.com/447328/38085452-e3aeab2c-3350-11e8-96f5-c1cab94db6ce.png">
