### PR TITLE
Add ability to change ethereum and IPFS node

### DIFF
--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -17,6 +17,12 @@ import provideNetwork from '../../context/provideNetwork'
 import { compose } from '../../utils'
 import { getWeb3 } from '../../web3-utils'
 import { web3Providers, network, appIds } from '../../environment'
+import {
+  getDefaultEthNode,
+  getIpfsGateway,
+  setDefaultEthNode,
+  setIpfsGateway,
+} from '../../local-settings'
 import airdrop from '../../testnet/airdrop'
 
 // const AVAILABLE_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'RMB', 'JPY']
@@ -60,10 +66,14 @@ const Note = styled.p`
 
 class Settings extends React.Component {
   static defaultProps = {
+    account: '',
     apps: [],
     currencies: [],
-    account: '',
     network: '',
+  }
+  state = {
+    defaultEthNode: getDefaultEthNode(),
+    ipfsGateway: getIpfsGateway(),
   }
   constructor(props) {
     super(props)
@@ -97,6 +107,19 @@ class Settings extends React.Component {
       airdrop(getWeb3(web3Providers.wallet), finance.proxyAddress, account)
     }
   }
+  handleDefaultEthNodeChange = event => {
+    this.setState({ defaultEthNode: event.target.value })
+  }
+  handleIpfsGatewayChange = event => {
+    this.setState({ ipfsGateway: event.target.value })
+  }
+  handleNodeSettingsSave = () => {
+    const { defaultEthNode, ipfsGateway } = this.state
+    setDefaultEthNode(defaultEthNode)
+    setIpfsGateway(ipfsGateway)
+    // For now, we have to reload the page to propagate the changes
+    window.location.reload()
+  }
   handleRefreshCache = () => {
     window.localStorage.clear()
     window.location.reload()
@@ -110,6 +133,7 @@ class Settings extends React.Component {
       selectedCurrency,
       apps,
     } = this.props
+    const { defaultEthNode, ipfsGateway } = this.state
 
     const enableTransactions = !!account && userNetwork === network.type
     const financeApp = apps.find(({ name }) => name === 'Finance')
@@ -246,6 +270,28 @@ class Settings extends React.Component {
                 </Field>
               </Option>
             )}
+          <Option
+            name="Node settings (advanced)"
+            text="Change which Ethereum and IPFS clients this app is connected to"
+          >
+            <Field label="Ethereum node">
+              <TextInput
+                onChange={this.handleDefaultEthNodeChange}
+                wide
+                value={defaultEthNode}
+              />
+            </Field>
+            <Field label="IPFS gateway">
+              <TextInput
+                onChange={this.handleIpfsGatewayChange}
+                wide
+                value={ipfsGateway}
+              />
+            </Field>
+            <Button mode="secondary" onClick={this.handleNodeSettingsSave}>
+              Save settings
+            </Button>
+          </Option>
           <Option
             name="Troubleshooting"
             text="Press this button to refresh the cache of the application in your browser."

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,4 +1,5 @@
 import Web3 from 'web3'
+import { getDefaultEthNode, getIpfsGateway } from './local-settings'
 import { makeEtherscanBaseUrl } from './utils'
 
 // TODO: make all these depend on env variables / URL
@@ -83,11 +84,11 @@ export { appLocator, appOverrides }
 
 export const contractAddresses = {
   // Aragon's Rinkeby ENS
-  ensRegistry: '0xfbae32d1cde62858bc45f51efc8cc4fa1415447e',
+  ensRegistry: '0x6b5f2b72ed649a5018701eb2b71c4fd8f472595c',
 }
 
 export const ipfsDefaultConf = {
-  gateway: 'https://gateway.ipfs.io/ipfs',
+  gateway: getIpfsGateway(),
   rpc: {
     host: 'ipfs.infura.io',
     port: '5001',
@@ -103,8 +104,6 @@ export const network = {
 }
 
 export const web3Providers = {
-  default: new Web3.providers.WebsocketProvider(
-    'ws://rinkeby.aragon.network:8546'
-  ),
+  default: new Web3.providers.WebsocketProvider(getDefaultEthNode()),
   wallet: window.web3 && window.web3.currentProvider,
 }

--- a/src/environment.js
+++ b/src/environment.js
@@ -84,7 +84,7 @@ export { appLocator, appOverrides }
 
 export const contractAddresses = {
   // Aragon's Rinkeby ENS
-  ensRegistry: '0x6b5f2b72ed649a5018701eb2b71c4fd8f472595c',
+  ensRegistry: '0xfbae32d1cde62858bc45f51efc8cc4fa1415447e',
 }
 
 export const ipfsDefaultConf = {

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -1,0 +1,18 @@
+const DEFAULT_ETH_NODE_KEY = 'ETH_NODE_KEY'
+const IPFS_GATEWAY_KEY = 'IPFS_GATEWAY_KEY'
+
+export function getDefaultEthNode() {
+  return (
+    window.localStorage.getItem(DEFAULT_ETH_NODE_KEY) ||
+    process.env.REACT_APP_DEFAULT_ETH_NODE ||
+    'ws://rinkeby.aragon.network:8546'
+  )
+}
+
+export function getIpfsGateway() {
+  return (
+    window.localStorage.getItem(IPFS_GATEWAY_KEY) ||
+    process.env.REACT_APP_IPFS_GATEWAY ||
+    'https://gateway.ipfs.io/ipfs'
+  )
+}

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -9,10 +9,18 @@ export function getDefaultEthNode() {
   )
 }
 
+export function setDefaultEthNode(node) {
+  return window.localStorage.setItem(DEFAULT_ETH_NODE_KEY, node)
+}
+
 export function getIpfsGateway() {
   return (
     window.localStorage.getItem(IPFS_GATEWAY_KEY) ||
     process.env.REACT_APP_IPFS_GATEWAY ||
     'https://gateway.ipfs.io/ipfs'
   )
+}
+
+export function setIpfsGateway(gateway) {
+  return window.localStorage.setItem(IPFS_GATEWAY_KEY, gateway)
 }


### PR DESCRIPTION
Temporary solution to #113 and #114.

Allows you to use `REACT_APP_DEFAULT_ETH_NODE` and `REACT_APP_IPFS_GATEWAY` to control the nodes the wrapper connects to. Also exposes inputs in the Settings app to change them (however, see below).

Example CLI usage:

```
REACT_APP_DEFAULT_ETH_NODE=ws://localhost:8545 REACT_APP_IPFS_GATEWAY=localhost:8080 yarn start
```

--------------

![image](https://user-images.githubusercontent.com/4166642/39043480-86b594d8-44c8-11e8-9498-35df30d4f697.png)

--------------

The Settings app currently requires at least a connection to a ETH node to load, which means the UI fields aren't super useful (ideally you could access them even without any DAO loading; they're more of a "client" setting than "org" setting).