### PR TITLE
Add app/ to returned app src path

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -28,7 +28,7 @@ const appSrc = (app, gateway = ipfsDefaultConf.gateway) => {
     return appLocator[app.appId]
   }
 
-  return `${gateway}/${hash}/`
+  return `${gateway}/${hash}/app/`
 }
 
 const applyAppOverrides = apps =>


### PR DESCRIPTION
Following the pattern in the rest of aragons apps, where frontend is
stored under app folder.
Maybe it would a better solution to change publish so it only stores frontend.