### PR TITLE
Refactor app loading to correctly take into account start_url and relative asset locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^16.3.2",
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8",
+    "resolve-pathname": "^2.2.0",
     "styled-components": "^3.2.6",
     "web3": "1.0.0-beta.21",
     "web3-utils": "^1.0.0-beta.30"

--- a/src/components/App/AppIFrame.js
+++ b/src/components/App/AppIFrame.js
@@ -57,13 +57,13 @@ class AppIFrame extends React.Component {
   }
   componentDidMount() {
     window.addEventListener('message', this.handleReceiveMessage, false)
-    this.navigateIFrame(this.props.app.appSrc)
+    this.navigateIFrame(this.props.app.src)
   }
   componentWillReceiveProps(nextProps) {
     const { app: nextApp } = nextProps
-    if (nextApp.appSrc !== this.props.app.appSrc) {
+    if (nextApp.src !== this.props.app.src) {
       this.resetProgress(() => {
-        this.navigateIFrame(nextApp.appSrc)
+        this.navigateIFrame(nextApp.src)
       })
     }
   }
@@ -73,7 +73,7 @@ class AppIFrame extends React.Component {
   }
   isHidden = () => {
     const { hidden, app } = this.props
-    return !app || !app.appSrc || hidden
+    return !app || !app.src || hidden
   }
   navigateIFrame = src => {
     // Rather than load src=undefined, this component hides itself. That way,

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { spring, Motion } from 'react-motion'
+import resolvePathname from 'resolve-pathname'
 import styled from 'styled-components'
 import {
   theme,
@@ -40,7 +41,9 @@ const appApps = {
 const addIcons = apps =>
   apps.map(app => ({
     ...app,
-    icon: <img src={`${app.appSrc}images/icon.svg`} alt="" />,
+    icon: (
+      <img src={`${resolvePathname('images/icon.svg', app.baseUrl)}`} alt="" />
+    ),
   }))
 
 class MenuPanel extends React.Component {

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,8 @@ export function makeEtherscanBaseUrl(network) {
 
 export function noop() {}
 
-export function removeTrailingSlash(str) {
-  return str.replace(/\/+$/, '')
+export function removeStartingSlash(str) {
+  return str.replace(/^\/+/, '')
 }
 
 export function log(...params) {


### PR DESCRIPTION
Correctly factor in `start_url` for the app's source location.

Also forces the `start_url` and `script` assets to be loaded relative to the resolved base url of the app (either an ipfs gateway or our own bridge).