### PR TITLE
Improvements to local configuration settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "update-assets": "rm -rf public/aragon-ui && cp -r node_modules/@aragon/ui/dist public/aragon-ui",
     "lint": "eslint ./src",
     "start": "npm run update-assets && react-scripts start",
+    "start:local": "scripts/dev-launch.sh",
     "build": "npm run update-assets && PUBLIC_URL=/ react-scripts build && npm run copy-apm-artifacts",
     "build:analyze": "node scripts/build-analyze.js",
     "copy-apm-artifacts": "cp arapp.json build/arapp.json && cp manifest.json build/manifest.json",

--- a/scripts/dev-launch.sh
+++ b/scripts/dev-launch.sh
@@ -16,7 +16,7 @@ export REACT_APP_ETH_NETWORK_TYPE='local'
 if pgrep -x "ipfs" > /dev/null
 then
     echo "Found a local IPFS daemon running, so the app will be configured to connect to default gateway and rpc ports."
-    export REACT_APP_IPFS_GATEWAY='http://localhost:8080'
+    export REACT_APP_IPFS_GATEWAY='http://localhost:8080/ipfs'
     export REACT_APP_IPFS_RPC='http://localhost:5001'
 fi
 

--- a/scripts/dev-launch.sh
+++ b/scripts/dev-launch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -o errexit
+
+echo "Running aragon/aragon on local environment settings..."
+
+# Error out if REACT_APP_ENS_REGISTRY_ADDRESS isn't set
+: ${REACT_APP_ENS_REGISTRY_ADDRESS:?"You need to export an REACT_APP_ENS_REGISTRY_ADDRESS set to your locally deployed ENS Registry's address before running aragon/aragon locally."}
+
+# Set up defaults for development environment
+export REACT_APP_DEFAULT_ETH_NODE='ws://localhost:8545'
+export REACT_APP_ETH_NETWORK_TYPE='local'
+
+# Test if ipfs is running locally before using local settings
+if pgrep -x "ipfs" > /dev/null
+then
+    echo "Found a local IPFS daemon running, so the app will be configured to connect to default gateway and rpc ports."
+    export REACT_APP_IPFS_GATEWAY='http://localhost:8080'
+    export REACT_APP_IPFS_RPC='http://localhost:5001'
+fi
+
+npm start

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -23,9 +23,6 @@ const CONFIGURATION_KEYS = [
   {}
 )
 
-// (protocol)://(host):(port)
-const IPFS_RPC_REGEX = /^([\w]*):\/\/(.*):(\d*)$/
-
 export function getDefaultEthNode() {
   const keys = CONFIGURATION_KEYS[DEFAULT_ETH_NODE]
   return (
@@ -79,14 +76,15 @@ export function getIpfsRpc() {
     process.env[keys.environmentKey] ||
     ''
 
-  const parsed = rpc.match(IPFS_RPC_REGEX)
-  if (parsed) {
+  try {
+    const url = new URL(rpc)
     return {
-      host: parsed[2],
-      port: parsed[3],
-      protocol: parsed[1],
+      host: url.hostname,
+      port: url.port,
+      // The URL.protocol includes the final :, but ipfs-js doesn't like that so we trim it off
+      protocol: url.protocol.slice(0, -1),
     }
-  } else {
+  } catch (err) {
     if (rpc && process.env.NODE_ENV !== 'production') {
       console.error(
         `The provided IPFS RPC url (${rpc}) in the environment is incorrectly formatted.`,

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -23,58 +23,49 @@ const CONFIGURATION_KEYS = [
   {}
 )
 
-export function getDefaultEthNode() {
-  const keys = CONFIGURATION_KEYS[DEFAULT_ETH_NODE]
+function getLocalSetting(confKey, settingDefault) {
+  const keys = CONFIGURATION_KEYS[confKey]
   return (
     window.localStorage.getItem(keys.storageKey) ||
     process.env[keys.environmentKey] ||
-    'ws://rinkeby.aragon.network:8546'
+    settingDefault
   )
 }
 
+function setLocalSetting(confKey, setting) {
+  const keys = CONFIGURATION_KEYS[confKey]
+  return window.localStorage.setItem(keys.storageKey, setting)
+}
+
+export function getDefaultEthNode() {
+  return getLocalSetting(DEFAULT_ETH_NODE, 'ws://rinkeby.aragon.network:8546')
+}
+
 export function setDefaultEthNode(node) {
-  const keys = CONFIGURATION_KEYS[DEFAULT_ETH_NODE]
-  return window.localStorage.setItem(keys.storageKey, node)
+  return setLocalSetting(DEFAULT_ETH_NODE, node)
 }
 
 export function getEnsRegistryAddress() {
-  const keys = CONFIGURATION_KEYS[ENS_REGISTRY_ADDRESS]
-  return (
-    window.localStorage.getItem(keys.storageKey) ||
-    process.env[keys.environmentKey] ||
+  return getLocalSetting(
+    ENS_REGISTRY_ADDRESS,
     '' // Let the network configuration handle contract address defaults
   )
 }
 
 export function getEthNetworkType() {
-  const keys = CONFIGURATION_KEYS[ETH_NETWORK_TYPE]
-  return (
-    window.localStorage.getItem(keys.storageKey) ||
-    process.env[keys.environmentKey] ||
-    'rinkeby'
-  )
+  return getLocalSetting(ETH_NETWORK_TYPE, 'rinkeby')
 }
 
 export function getIpfsGateway() {
-  const keys = CONFIGURATION_KEYS[IPFS_GATEWAY]
-  return (
-    window.localStorage.getItem(keys.storageKey) ||
-    process.env[keys.environmentKey] ||
-    'https://gateway.ipfs.io/ipfs'
-  )
+  return getLocalSetting(IPFS_GATEWAY, 'https://gateway.ipfs.io/ipfs')
 }
 
 export function setIpfsGateway(gateway) {
-  const keys = CONFIGURATION_KEYS[IPFS_GATEWAY]
-  return window.localStorage.setItem(keys.storageKey, gateway)
+  return setLocalSetting(IPFS_GATEWAY, gateway)
 }
 
 export function getIpfsRpc() {
-  const keys = CONFIGURATION_KEYS[IPFS_RPC]
-  const rpc =
-    window.localStorage.getItem(keys.storageKey) ||
-    process.env[keys.environmentKey] ||
-    ''
+  const rpc = getLocalSetting(IPFS_RPC, '')
 
   try {
     const url = new URL(rpc)

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -1,52 +1,82 @@
-const DEFAULT_ETH_NODE_KEY = 'ETH_NODE_KEY'
-const ENS_REGISTRY_ADDRESS_KEY = 'ENS_REGISTRY_ADDRESS_KEY'
-const ETH_NETWORK_TYPE_KEY = 'ETH_NETWORK_TYPE_KEY'
-const IPFS_GATEWAY_KEY = 'IPFS_GATEWAY_KEY'
-const IPFS_RPC_KEY = 'IPFS_RPC_KEY'
+// List of configurable settings
+const DEFAULT_ETH_NODE = 'DEFAULT_ETH_NODE'
+const ENS_REGISTRY_ADDRESS = 'ENS_REGISTRY_ADDRESS'
+const ETH_NETWORK_TYPE = 'ETH_NETWORK_TYPE'
+const IPFS_GATEWAY = 'IPFS_GATEWAY'
+const IPFS_RPC = 'IPFS_RPC'
+
+const CONFIGURATION_KEYS = [
+  DEFAULT_ETH_NODE,
+  ENS_REGISTRY_ADDRESS,
+  ETH_NETWORK_TYPE,
+  IPFS_GATEWAY,
+  IPFS_RPC,
+].reduce(
+  (acc, option) => ({
+    ...acc,
+    [option]: {
+      storageKey: `${option}_KEY`,
+      // REACT_APP_ prefix required for react-scripts
+      environmentKey: `REACT_APP_${option}`,
+    },
+  }),
+  {}
+)
 
 // (protocol)://(host):(port)
 const IPFS_RPC_REGEX = /^([\w]*):\/\/(.*):(\d*)$/
 
 export function getDefaultEthNode() {
+  const keys = CONFIGURATION_KEYS[DEFAULT_ETH_NODE]
   return (
-    window.localStorage.getItem(DEFAULT_ETH_NODE_KEY) ||
-    process.env.REACT_APP_DEFAULT_ETH_NODE ||
+    window.localStorage.getItem(keys.storageKey) ||
+    process.env[keys.environmentKey] ||
     'ws://rinkeby.aragon.network:8546'
   )
 }
 
 export function setDefaultEthNode(node) {
-  return window.localStorage.setItem(DEFAULT_ETH_NODE_KEY, node)
+  const keys = CONFIGURATION_KEYS[DEFAULT_ETH_NODE]
+  return window.localStorage.setItem(keys.storageKey, node)
 }
 
 export function getEnsRegistryAddress() {
+  const keys = CONFIGURATION_KEYS[ENS_REGISTRY_ADDRESS]
   return (
-    window.localStorage.getItem(ENS_REGISTRY_ADDRESS_KEY) ||
-    process.env.REACT_APP_ENS_REGISTRY_ADDRESS ||
+    window.localStorage.getItem(keys.storageKey) ||
+    process.env[keys.environmentKey] ||
     '' // Let the network configuration handle contract address defaults
   )
 }
 
 export function getEthNetworkType() {
+  const keys = CONFIGURATION_KEYS[ETH_NETWORK_TYPE]
   return (
-    window.localStorage.getItem(ETH_NETWORK_TYPE_KEY) ||
-    process.env.REACT_APP_ETH_NETWORK_TYPE ||
+    window.localStorage.getItem(keys.storageKey) ||
+    process.env[keys.environmentKey] ||
     'rinkeby'
   )
 }
 
 export function getIpfsGateway() {
+  const keys = CONFIGURATION_KEYS[IPFS_GATEWAY]
   return (
-    window.localStorage.getItem(IPFS_GATEWAY_KEY) ||
-    process.env.REACT_APP_IPFS_GATEWAY ||
+    window.localStorage.getItem(keys.storageKey) ||
+    process.env[keys.environmentKey] ||
     'https://gateway.ipfs.io/ipfs'
   )
 }
 
+export function setIpfsGateway(gateway) {
+  const keys = CONFIGURATION_KEYS[IPFS_GATEWAY]
+  return window.localStorage.setItem(keys.storageKey, gateway)
+}
+
 export function getIpfsRpc() {
+  const keys = CONFIGURATION_KEYS[IPFS_RPC]
   const rpc =
-    window.localStorage.getItem(IPFS_RPC_KEY) ||
-    process.env.REACT_APP_IPFS_RPC ||
+    window.localStorage.getItem(keys.storageKey) ||
+    process.env[keys.environmentKey] ||
     ''
 
   const parsed = rpc.match(IPFS_RPC_REGEX)
@@ -70,8 +100,4 @@ export function getIpfsRpc() {
       protocol: 'https',
     }
   }
-}
-
-export function setIpfsGateway(gateway) {
-  return window.localStorage.setItem(IPFS_GATEWAY_KEY, gateway)
 }


### PR DESCRIPTION
Fixes #239.

Refactors the local configuration's constants for a simpler API to add more options, and uses `URL()` instead of a regex for parsing urls.

Also includes a quality of life local development script, `start:local`, that will set all the local options to their defaults. `REACT_APP_ENS_REGISTRY_ADDRESS` is still required as it'll most likely change between users.

@izqui `start:local` may also be useful for simplifying the dev tools.