### PR TITLE
Fix package.json's AGPL license

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Aragon DApp",
   "version": "0.5.0",
   "private": true,
-  "license": "AGPLv3",
+  "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/aragon/aragon.git"


### PR DESCRIPTION
Note that AGPL-3.0 by itself is considered deprecated: https://spdx.org/licenses/.