### PR TITLE
Upgrade @aragon/wrapper to 2.0.0-beta.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aragon/templates-tokens": "^1.1.1",
     "@aragon/ui": "^0.11.0",
-    "@aragon/wrapper": "^2.0.0-beta.33",
+    "@aragon/wrapper": "^2.0.0-beta.35",
     "@babel/polyfill": "^7.0.0-beta.39",
     "bignumber.js": "^6.0.0",
     "date-fns": "^2.0.0-alpha.7",


### PR DESCRIPTION
Upgrading should allow us to avoid weird issues where web3.js was passing events back to the error handler rather than event handler.