### PR TITLE
Add asset bridge environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The app currently supports setting a few environment settings via environment va
 - `REACT_APP_DEFAULT_ETH_NODE`: Url of the default Ethereum node to read blockchain data from (must be WebSocket protocol). If you intend to connect to a local ganache instance, by default you should set this to `ws://localhost:8545`.
 - `REACT_APP_ENS_REGISTRY_ADDRESS`: Address of the ENS registry that APM repos were registered on. If you've deployed aragonOS to a local network, you can find the ENS registry's address in the migration's console output.
 - `REACT_APP_ETH_NETWORK_TYPE`: Expected network to connect to. Either one of `rinkeby` or `local`.
-- `REACT_APP_IPFS_GATEWAY`: Url of the IPFS gateway to load APM repos from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:8080`
+- `REACT_APP_IPFS_GATEWAY`: Url of the IPFS gateway to load APM repos from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:8080/ipfs`
 - `REACT_APP_IPFS_RPC`: Url of the IPFS API endpoint to fetch blobs from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:5001`
+- `REACT_APP_ASSET_BRIDGE`: Which source to load the app frontend assets from. Can be one of `apm-bridge` (`apm-serve`'s production hosts, e.g. `voting.aragonpm.eth`, `ipfs` (loads through the IPFS gateway configured), or `local` (local servers, running on `localhost:300x`). If you intend to serve from a local IPFS daemon, you should set this to `ipfs`.
 
-Without any settings, the app is configured to connect to our Rinkeby deployment.
+Without any settings, the app is configured to connect to our Rinkeby and `apm-serve` deployment.

--- a/scripts/dev-launch.sh
+++ b/scripts/dev-launch.sh
@@ -22,7 +22,7 @@ then
     echo "The app will be configured to connect and serve assets from from the default gateway ($DEFAULT_IPFS_GATEWAY) and rpc ($DEFAULT_IPFS_RPC)."
     export REACT_APP_IPFS_GATEWAY="$DEFAULT_IPFS_GATEWAY"
     export REACT_APP_IPFS_RPC="$DEFAULT_IPFS_RPC"
-    export REACT_APP_ASSETS_BRIDGE='ipfs'
+    export REACT_APP_ASSET_BRIDGE='ipfs'
 fi
 
 npm start

--- a/scripts/dev-launch.sh
+++ b/scripts/dev-launch.sh
@@ -8,6 +8,9 @@ echo "Running aragon/aragon on local environment settings..."
 # Error out if REACT_APP_ENS_REGISTRY_ADDRESS isn't set
 : ${REACT_APP_ENS_REGISTRY_ADDRESS:?"You need to export an REACT_APP_ENS_REGISTRY_ADDRESS set to your locally deployed ENS Registry's address before running aragon/aragon locally."}
 
+DEFAULT_IPFS_GATEWAY="http://localhost:8080/ipfs"
+DEFAULT_IPFS_RPC="http://localhost:5001"
+
 # Set up defaults for development environment
 export REACT_APP_DEFAULT_ETH_NODE='ws://localhost:8545'
 export REACT_APP_ETH_NETWORK_TYPE='local'
@@ -15,9 +18,11 @@ export REACT_APP_ETH_NETWORK_TYPE='local'
 # Test if ipfs is running locally before using local settings
 if pgrep -x "ipfs" > /dev/null
 then
-    echo "Found a local IPFS daemon running, so the app will be configured to connect to default gateway and rpc ports."
-    export REACT_APP_IPFS_GATEWAY='http://localhost:8080/ipfs'
-    export REACT_APP_IPFS_RPC='http://localhost:5001'
+    echo "Found a local IPFS daemon running..."
+    echo "The app will be configured to connect and serve assets from from the default gateway ($DEFAULT_IPFS_GATEWAY) and rpc ($DEFAULT_IPFS_RPC)."
+    export REACT_APP_IPFS_GATEWAY="$DEFAULT_IPFS_GATEWAY"
+    export REACT_APP_IPFS_RPC="$DEFAULT_IPFS_RPC"
+    export REACT_APP_ASSETS_BRIDGE='ipfs'
 fi
 
 npm start

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,5 +1,6 @@
 import Web3 from 'web3'
 import {
+  getAssetBridge,
   getDefaultEthNode,
   getEthNetworkType,
   getIpfsGateway,
@@ -15,6 +16,7 @@ export const appIds = {
     '0x6b20a3010614eeebf2138ccec99f028a61c811b3b1a3343b6ff635985c75c91f',
   Vault: '0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1',
   Voting: '0x9fa3927f639745e587912d4b0fea7ef9013bf93fb907d29faeab57417ba6e1d4',
+  Survey: '0x030b2ab880b88e228f2da5a3d19a2a31bc10dbf91fb1143776a6de489389471e',
 }
 
 const appsOrder = ['TokenManager', 'Finance', 'Voting', 'Vault']
@@ -48,9 +50,8 @@ export const sortAppsPair = (app1, app2) => {
 }
 
 let appLocator
-let appOverrides
-
-if (process.env.NODE_ENV !== 'production') {
+const assetBridge = getAssetBridge()
+if (assetBridge === 'local') {
   /******************
    * Local settings *
    ******************/
@@ -59,33 +60,28 @@ if (process.env.NODE_ENV !== 'production') {
     [appIds['TokenManager']]: 'http://localhost:3003/',
     [appIds['Voting']]: 'http://localhost:3001/',
   }
-  appOverrides = {
-    [appIds['Finance']]: {
-      script: '/script.js',
-      start_url: '/index.html',
-    },
-    [appIds['TokenManager']]: {
-      script: '/script.js',
-      start_url: '/index.html',
-    },
-    [appIds['Voting']]: {
-      script: '/script.js',
-      start_url: '/index.html',
-    },
-  }
+} else if (assetBridge === 'ipfs') {
+  // We don't need to provide any thing here as by default, the apps will be loaded from IPFS
+  appLocator = {}
 } else {
-  /***********************
-   * Production settings *
-   ***********************/
+  if (assetBridge && assetBridge !== 'apm-serve') {
+    console.error(
+      `The specified asset bridge (${assetBridge}) in the configuration is not one of 'apm-serve', 'ipfs', or 'local'. Defaulting to using apm-serve.`
+    )
+  }
+  /**********************
+   * apm-serve settings *
+   **********************/
   appLocator = {
     [appIds['Finance']]: 'https://finance.aragonpm.com/',
     [appIds['TokenManager']]: 'https://token-manager.aragonpm.com/',
     [appIds['Voting']]: 'https://voting.aragonpm.com/',
   }
-  appOverrides = {}
 }
+export { appLocator }
 
-export { appLocator, appOverrides }
+// Use appOverrides to override specific keys in an app instance, e.g. the start_url or script location
+export const appOverrides = {}
 
 export const ipfsDefaultConf = {
   gateway: getIpfsGateway(),

--- a/src/environment.js
+++ b/src/environment.js
@@ -16,7 +16,6 @@ export const appIds = {
     '0x6b20a3010614eeebf2138ccec99f028a61c811b3b1a3343b6ff635985c75c91f',
   Vault: '0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1',
   Voting: '0x9fa3927f639745e587912d4b0fea7ef9013bf93fb907d29faeab57417ba6e1d4',
-  Survey: '0x030b2ab880b88e228f2da5a3d19a2a31bc10dbf91fb1143776a6de489389471e',
 }
 
 const appsOrder = ['TokenManager', 'Finance', 'Voting', 'Vault']

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -1,4 +1,5 @@
 // List of configurable settings
+const ASSET_BRIDGE = 'ASSET_BRIDGE'
 const DEFAULT_ETH_NODE = 'DEFAULT_ETH_NODE'
 const ENS_REGISTRY_ADDRESS = 'ENS_REGISTRY_ADDRESS'
 const ETH_NETWORK_TYPE = 'ETH_NETWORK_TYPE'
@@ -6,6 +7,7 @@ const IPFS_GATEWAY = 'IPFS_GATEWAY'
 const IPFS_RPC = 'IPFS_RPC'
 
 const CONFIGURATION_KEYS = [
+  ASSET_BRIDGE,
   DEFAULT_ETH_NODE,
   ENS_REGISTRY_ADDRESS,
   ETH_NETWORK_TYPE,
@@ -35,6 +37,10 @@ function getLocalSetting(confKey, settingDefault) {
 function setLocalSetting(confKey, setting) {
   const keys = CONFIGURATION_KEYS[confKey]
   return window.localStorage.setItem(keys.storageKey, setting)
+}
+
+export function getAssetBridge() {
+  return getLocalSetting(ASSET_BRIDGE, '')
 }
 
 export function getDefaultEthNode() {

--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -16,6 +16,9 @@ const fetchUrl = async url => {
   const res = await fetch(url, {
     method: 'GET',
     mode: 'cors',
+    headers: {
+      'content-type': 'application/javascript',
+    },
   })
 
   // If status is not a 2xx (based on Response.ok), assume it's an error


### PR DESCRIPTION
Allows users to select where they'd like to load apps' frontends from.

Using `ipfs` does not work right now with a non-local gateway due to security warnings.