### PR TITLE
Fix the alignment of the MenuPanel “SOON” badge on Chrome

### DIFF
--- a/src/components/MenuPanel/MenuPanelAppGroup.js
+++ b/src/components/MenuPanel/MenuPanelAppGroup.js
@@ -60,9 +60,7 @@ class MenuPanelAppGroup extends React.PureComponent {
               </span>
               {comingSoon && (
                 <span>
-                  <Badge shape="compact" style={{ fontVariant: 'small-caps' }}>
-                    soon
-                  </Badge>
+                  <Soon />
                 </span>
               )}
             </ButtonItem>
@@ -167,6 +165,12 @@ const MenuItemBar = styled.div`
   width: 4px;
   height: 100%;
   background: ${theme.accent};
+`
+
+const Soon = styled(Badge).attrs({ shape: 'compact', children: 'Soon' })`
+  text-transform: uppercase;
+  font-size: 9px;
+  font-weight: 300;
 `
 
 export default MenuPanelAppGroup


### PR DESCRIPTION
<img width="239" alt="image" src="https://user-images.githubusercontent.com/36158/40586416-a9112282-61b9-11e8-90c0-cc1f4b06fe94.png">
