### PR TITLE
Fix issue with cloudflare non-checksummed addresses

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -55,7 +55,7 @@ class Wrapper extends React.Component {
     const app =
       wrapper &&
       apps.find(
-        app => app.instanceId === instanceId || app.proxyAddress === instanceId
+        app => addressesEqual(app.instanceId, instanceId) || addressesEqual(app.proxyAddress, instanceId)
       )
 
     if (!app || !wrapper) {
@@ -148,7 +148,7 @@ class Wrapper extends React.Component {
     return (
       staticApps.has(instanceId) &&
       !!apps.find(
-        app => app.instanceId === instanceId || app.proxyAddress === instanceId
+        app => addressesEqual(app.instanceId, instanceId) || addressesEqual(app.proxyAddress, instanceId)
       )
     )
   }
@@ -282,7 +282,7 @@ class Wrapper extends React.Component {
     const app =
       wrapper &&
       apps.find(
-        app => app.instanceId === instanceId || app.proxyAddress === instanceId
+        app => addressesEqual(app.instanceId, instanceId) || addressesEqual(app.proxyAddress, instanceId)
       )
 
     return app ? (


### PR DESCRIPTION
Adding `addressesEqual` comparison everywhere to ensure that checks
pass even if only one of the compared addresses are not checksummed.