### PR TITLE
Simplify routing

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -53,16 +53,12 @@ class Wrapper extends React.Component {
       wrapper,
       locator: { instanceId },
     } = this.props
-    const app =
-      wrapper &&
-      apps.find(
-        app =>
-          addressesEqual(app.instanceId, instanceId) ||
-          addressesEqual(app.proxyAddress, instanceId)
-      )
-
-    if (!app || !wrapper) {
+    if (
+      !wrapper ||
+      !apps.find(app => addressesEqual(app.proxyAddress, instanceId))
+    ) {
       console.error('The app cannot be connected to aragon.js')
+      return
     }
 
     wrapper.connectAppIFrame(event.target, instanceId)
@@ -150,11 +146,7 @@ class Wrapper extends React.Component {
     const { apps } = this.props
     return (
       staticApps.has(instanceId) &&
-      !!apps.find(
-        app =>
-          addressesEqual(app.instanceId, instanceId) ||
-          addressesEqual(app.proxyAddress, instanceId)
-      )
+      !!apps.find(app => addressesEqual(app.proxyAddress, instanceId))
     )
   }
   showWeb3ActionSigner = (intent, { direct, error, paths }) => {
@@ -278,13 +270,7 @@ class Wrapper extends React.Component {
       return <LoadingApps />
     }
 
-    const app =
-      wrapper &&
-      apps.find(
-        app =>
-          addressesEqual(app.instanceId, instanceId) ||
-          addressesEqual(app.proxyAddress, instanceId)
-      )
+    const app = apps.find(app => addressesEqual(app.proxyAddress, instanceId))
 
     return app ? (
       <AppIFrame
@@ -292,10 +278,8 @@ class Wrapper extends React.Component {
         ref={this.handleAppIFrameRef}
         onLoad={this.handleAppIFrameLoad}
       />
-    ) : apps.length ? (
-      <App404 onNavigateBack={this.props.historyBack} />
     ) : (
-      <LoadingApps />
+      <App404 onNavigateBack={this.props.historyBack} />
     )
   }
 }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -11,7 +11,8 @@ import Home from './components/Home/Home'
 import ComingSoon from './components/ComingSoon/ComingSoon'
 import MenuPanel from './components/MenuPanel/MenuPanel'
 import SignerPanelContent from './components/SignerPanel/SignerPanelContent'
-import { getAppPath, staticApps } from './routing'
+import { getAppPath } from './routing'
+import { staticApps } from './static-apps'
 import { addressesEqual } from './web3-utils'
 
 class Wrapper extends React.Component {

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -97,7 +97,15 @@ class MenuPanel extends React.PureComponent {
           <Content>
             <div className="in">
               <h1>Apps</h1>
-              <div>{menuApps.map(app => this.renderAppGroup(app, false))}</div>
+              <div>
+                {menuApps.map(
+                  app =>
+                    // If it's an array, it's the group being loaded from the ACL
+                    Array.isArray(app)
+                      ? this.renderLoadedAppGroup(app)
+                      : this.renderAppGroup(app, false)
+                )}
+              </div>
             </div>
           </Content>
         </In>
@@ -131,20 +139,7 @@ class MenuPanel extends React.PureComponent {
     )
   }
   renderAppGroup = (app, readyToExpand) => {
-    const { activeInstanceId, onOpenApp, appsLoading } = this.props
-
-    // Wrap the DAO apps in the loader
-    if (Array.isArray(app)) {
-      return (
-        <MenuPanelAppsLoader
-          key="menu-apps"
-          loading={appsLoading}
-          itemsCount={app.length}
-        >
-          {done => app.map(app => this.renderAppGroup(app, done))}
-        </MenuPanelAppsLoader>
-      )
-    }
+    const { activeInstanceId, onOpenApp } = this.props
 
     const { appId, name, icon, instances = [] } = app
     const isActive =
@@ -165,6 +160,20 @@ class MenuPanel extends React.PureComponent {
           comingSoon={['permissions', 'apps'].includes(appId)}
         />
       </div>
+    )
+  }
+  renderLoadedAppGroup = apps => {
+    const { appsLoading } = this.props
+
+    // Wrap the DAO apps in the loader
+    return (
+      <MenuPanelAppsLoader
+        key="menu-apps"
+        loading={appsLoading}
+        itemsCount={apps.length}
+      >
+        {done => apps.map(app => this.renderAppGroup(app, done))}
+      </MenuPanelAppsLoader>
     )
   }
 }

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -6,45 +6,22 @@ import {
   theme,
   unselectable,
   spring as springConf,
-  IconHome,
-  IconSettings,
-  IconPermissions,
-  IconApps,
   // IconWallet,
   // IconNotifications,
 } from '@aragon/ui'
 import ClickOutHandler from 'react-onclickout'
 import NotificationsPanel from '../NotificationsPanel/NotificationsPanel'
 import { lerp } from '../../math-utils'
+import { staticApps } from '../../static-apps'
 import MenuPanelAppGroup from './MenuPanelAppGroup'
 import MenuPanelAppsLoader from './MenuPanelAppsLoader'
 
 import logo from './assets/logo.svg'
 
-const appHome = {
-  appId: 'home',
-  name: 'Home',
-  icon: <IconHome />,
-  instances: [{ instanceId: 'home' }],
-}
-const appSettings = {
-  appId: 'settings',
-  name: 'Settings',
-  icon: <IconSettings />,
-  instances: [{ instanceId: 'settings' }],
-}
-const appPermissions = {
-  appId: 'permissions',
-  name: 'Permissions',
-  icon: <IconPermissions />,
-  instances: [{ instanceId: 'permissions' }],
-}
-const appApps = {
-  appId: 'apps',
-  name: 'Apps',
-  icon: <IconApps />,
-  instances: [{ instanceId: 'apps' }],
-}
+const APP_APPS_CENTER = staticApps.get('apps').app
+const APP_HOME = staticApps.get('home').app
+const APP_PERMISSIONS = staticApps.get('permissions').app
+const APP_SETTINGS = staticApps.get('settings').app
 
 const prepareAppGroups = apps =>
   apps.reduce((groups, app) => {
@@ -96,7 +73,13 @@ class MenuPanel extends React.PureComponent {
     const { notificationsOpened } = this.state
 
     const appGroups = prepareAppGroups(apps)
-    const menuApps = [appHome, appGroups, appPermissions, appApps, appSettings]
+    const menuApps = [
+      APP_HOME,
+      appGroups,
+      APP_PERMISSIONS,
+      APP_APPS_CENTER,
+      APP_SETTINGS,
+    ]
 
     return (
       <Main>

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,12 +1,5 @@
 import { isAddress } from 'web3-utils'
-
-export const staticApps = new Map(
-  Object.entries({
-    home: '/',
-    settings: '/settings',
-    permissions: '/permissions',
-  })
-)
+import { staticApps } from './static-apps'
 
 /*
  * Parse a path and a search query and return a “locator” object.
@@ -78,7 +71,7 @@ export const parsePath = (pathname, search = '') => {
 // Return a path string for an app instance
 export const getAppPath = ({ dao, instanceId = 'home', params } = {}) => {
   if (staticApps.has(instanceId)) {
-    return `/${dao}${staticApps.get(instanceId)}`
+    return `/${dao}${staticApps.get(instanceId).route}`
   }
   return `/${dao}/${instanceId}${
     params ? `?params=${encodeURIComponent(JSON.stringify(params))}` : ``

--- a/src/static-apps.js
+++ b/src/static-apps.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { IconHome, IconSettings, IconPermissions, IconApps } from '@aragon/ui'
+
+export const staticApps = new Map(
+  Object.entries({
+    apps: {
+      app: {
+        appId: 'apps',
+        name: 'Apps',
+        icon: <IconApps />,
+        instances: [{ instanceId: 'apps' }],
+      },
+      route: '/apps',
+    },
+    home: {
+      app: {
+        appId: 'home',
+        name: 'Home',
+        icon: <IconHome />,
+        instances: [{ instanceId: 'home' }],
+      },
+      route: '/',
+    },
+    permissions: {
+      app: {
+        appId: 'permissions',
+        name: 'Permissions',
+        icon: <IconPermissions />,
+        instances: [{ instanceId: 'permissions' }],
+      },
+      route: '/permissions',
+    },
+    settings: {
+      app: {
+        appId: 'settings',
+        name: 'Settings',
+        icon: <IconSettings />,
+        instances: [{ instanceId: 'settings' }],
+      },
+      route: '/settings',
+    },
+  })
+)


### PR DESCRIPTION
Simplifies a number of items related to routing:

- Removes the `app.instanceId` check from loaded apps, as that isn't set (90172b4)
- Move all static app-related settings to its own module (60f65d4)
- Render the `MenuPanelGroup`s in a simpler way, without unnecessary recurious

cc @bpierre @bingen 