### PR TITLE
Downgrade mainnet survey to http due to cloudflare

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -89,7 +89,9 @@ if (assetBridge === 'local') {
      * Mainnet apm-serve settings *
      ******************************/
     Object.assign(appLocator, {
-      [appIds['Survey']]: 'https://mainnet.survey.aragonpm.com/',
+      // Cloudflare doesn't let us use our certificate down to mainnet.survey.aragonpm, so we'll
+      // downgrade to HTTP for now
+      [appIds['Survey']]: 'http://mainnet.survey.aragonpm.com/',
     })
   } else if (networkType === 'rinkeby') {
     /******************************


### PR DESCRIPTION
Looks like cloudflare doesn't support certs down to `mainnet.survey.aragonpm.com`, so we'll downgrade to HTTP for now.