### PR TITLE
Include *lock files in releases to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+!package-lock.json
+!yarn.lock


### PR DESCRIPTION
In reference to the following issue: https://github.com/aragon/aragon/issues/223

I'm not entirely sure why you want to exclude the lock files from git in the first place, however if you would like to include the lock files in the NPM package when publishing this fix should do the trick.

You can test it by running:
```
npm pack --dry-run --json
```
That will output a list of all the files that will be bundled into the npm package when publishing and you'll notice that the 2 lock files are now including in the package... but still ignored in the git repo.

If you need help finding the lock files in the output, you can always run:
```
npm pack --dry-run --json | grep lock
```

Closes #223