### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aragon/templates-tokens": "^1.1.1",
     "@aragon/ui": "^0.16.0",
-    "@aragon/wrapper": "^2.0.0-beta.40",
+    "@aragon/wrapper": "^2.0.0-beta.41",
     "@babel/polyfill": "^7.0.0-beta.39",
     "bignumber.js": "^6.0.0",
     "date-fns": "^2.0.0-alpha.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "resolve-pathname": "^2.2.0",
     "styled-components": "3.2.6",
     "web3": "1.0.0-beta.33",
-    "web3-utils": "^1.0.0-beta.33"
+    "web3-utils": "1.0.0-beta.33"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8",
     "resolve-pathname": "^2.2.0",
-    "styled-components": "3.2.6",
+    "styled-components": "^3.3.3",
     "web3": "1.0.0-beta.33",
     "web3-utils": "1.0.0-beta.33"
   },


### PR DESCRIPTION
`@aragon/wrapper@2.0.0-beta.41` brings a number of dependency improvements, drastically decreasing the built size, and finally fixes the CORS issue with IPFS gateways on firefox.

`styled-components@3.3.3` seems to have fixed the issue with `styled()` and `extend()` breaking components (along with `@aragon/ui@0.15.0`).