### PR TITLE
Fix DropDown in multisig onboarding

### DIFF
--- a/src/onboarding/templates/multisig/ConfigureMultisigAddresses.js
+++ b/src/onboarding/templates/multisig/ConfigureMultisigAddresses.js
@@ -82,7 +82,9 @@ class ConfigureMultisigAddressesContent extends React.PureComponent {
       onSignerChange,
       onNeededSignaturesChange,
     } = this.props
-    const neededSignaturesItems = fields.signers.map((signer, i) => i + 1)
+    const neededSignaturesItems = fields.signers.map((signer, i) =>
+      String(i + 1)
+    )
     return (
       <Content>
         <Title>Token project with multisig</Title>


### PR DESCRIPTION
`DropDown` now requires a string for its `items`.