### PR TITLE
Support new aragon.js permissions data structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aragon/templates-tokens": "^1.1.1",
     "@aragon/ui": "^0.17.0-alpha1",
-    "@aragon/wrapper": "^2.0.0-beta.41",
+    "@aragon/wrapper": "^2.0.0-beta.42",
     "@babel/polyfill": "^7.0.0-beta.39",
     "bn.js": "4.11.6",
     "date-fns": "^2.0.0-alpha.7",

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -48,9 +48,9 @@ export function permissionsByEntity(permissions) {
   // apps
   for (const [app, appPermissions] of Object.entries(permissions)) {
     // roles
-    for (const [role, entities] of Object.entries(appPermissions)) {
+    for (const [role, { allowedEntities }] of Object.entries(appPermissions)) {
       // entities
-      for (const entity of entities) {
+      for (const entity of allowedEntities) {
         if (!results[entity]) {
           results[entity] = {}
         }
@@ -83,11 +83,12 @@ export const appRoles = (
 ) =>
   Object.entries(permissions[app.proxyAddress])
     .reduce(
-      (roles, [role, entities]) =>
-        roles.concat(entities.map(entity => transform(entity, role))),
+      (roles, [role, { allowedEntities }]) =>
+        roles.concat(allowedEntities.map(entity => transform(entity, role))),
       []
     )
     .filter(Boolean)
+  
 
 // Returns a function that resolves a role
 // using the provided apps, and caching the result.


### PR DESCRIPTION
See https://github.com/aragon/aragon.js/pull/137 (requires releasing `@aragon/wrapper` before merging this)

This also makes the manager address accessible so it can be shown in the UI to denote the entity that can grant and revoke the permission!

I don't think this needs to be modified anywhere else, but PTAL @bpierre :)