### PR TITLE
Fix empty list of transaction paths

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -91,19 +91,18 @@ class Wrapper extends React.Component {
       transaction,
     }
   }
-  reshapeTransactionBag(bag) {
+  reshapeTransactionBag({ path, transaction }) {
     // This is a temporary method to reshape the transaction bag
     // to the future format we expect from Aragon.js
     // When Aragon.js starts returning the new format, we can simply
     // replace search and replace this function with `bag`, although
     // it is probably only used in `handleTransaction`
-    const transaction = bag.path[bag.path.length - 1]
-    const direct = bag.path.length === 1
+    const direct = path.length === 1
 
     return {
-      direct,
-      intent: this.makeTransactionIntent(transaction),
-      paths: direct ? [] : [bag.path],
+      direct: path.length === 1,
+      intent: transaction && this.makeTransactionIntent(transaction),
+      paths: path.length ? [path] : [],
     }
   }
   handleTransaction = bag => {

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -97,7 +97,6 @@ class Wrapper extends React.Component {
     // When Aragon.js starts returning the new format, we can simply
     // replace search and replace this function with `bag`, although
     // it is probably only used in `handleTransaction`
-    const direct = path.length === 1
 
     return {
       direct: path.length === 1,


### PR DESCRIPTION
Fixes cases where no path is found:

![image](https://user-images.githubusercontent.com/4166642/44797566-cb1b7180-abaf-11e8-8e65-bdd6363ba89e.png)

Fixes #260.