### PR TITLE
Use relative URL for aragon-ui publicUrl

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -237,7 +237,7 @@ class App extends React.Component {
     if (!mode) return null
 
     return (
-      <AragonApp publicUrl="/aragon-ui/">
+      <AragonApp publicUrl="./aragon-ui/">
         <PermissionsProvider
           wrapper={wrapper}
           apps={apps}


### PR DESCRIPTION
#372 was missing this in order for aragon-ui resources to properly load.