### PR TITLE
Permissions: show all available roles in assign role panel

### DIFF
--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -32,10 +32,8 @@ class AssignPermissionPanel extends React.PureComponent {
   }
 
   getRoles() {
-    const { getAppRoles } = this.props
     const app = this.getSelectedApp()
-    const appRoles = app ? getAppRoles(app) : []
-    return appRoles.map(({ role }) => role)
+    return (app && app.roles) || []
   }
 
   appsLabels() {
@@ -183,11 +181,8 @@ class AssignPermissionPanel extends React.PureComponent {
 
 export default props => (
   <PermissionsConsumer>
-    {({ getAppRoles, createPermission, grantPermission }) => (
-      <AssignPermissionPanel
-        {...props}
-        {...{ getAppRoles, createPermission, grantPermission }}
-      />
+    {({ createPermission, grantPermission }) => (
+      <AssignPermissionPanel {...props} createPermission grantPermission />
     )}
   </PermissionsConsumer>
 )


### PR DESCRIPTION
Right now, the assign permissions panel only shows roles that have already been created.

Before:

<img src="https://user-images.githubusercontent.com/4166642/46688587-091fa280-cbfe-11e8-8ac9-b5ae11e7e74b.png" height=300>


After: 

<img src="https://user-images.githubusercontent.com/4166642/46688584-0624b200-cbfe-11e8-945b-47bfd3703676.png" height=300>