### PR TITLE
Permissions: render permission managers as app labels when possible

### DIFF
--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -10,6 +10,7 @@ import {
 import IdentityBadge from '../../components/IdentityBadge'
 import Section from './Section'
 import EmptyBlock from './EmptyBlock'
+import AppInstanceLabel from './AppInstanceLabel'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
 import { isEmptyAddress } from '../../web3-utils'
 
@@ -70,6 +71,15 @@ class RoleRow extends React.Component {
   handleManageClick = () => {
     this.props.onManage(this.props.role.bytes)
   }
+  renderManager() {
+    const { manager } = this.props
+    if (manager.type === 'app') {
+      return (
+        <AppInstanceLabel app={manager.app} proxyAddress={manager.address} />
+      )
+    }
+    return <IdentityBadge entity={manager.address} />
+  }
   render() {
     const { role, manager } = this.props
 
@@ -77,7 +87,7 @@ class RoleRow extends React.Component {
     const name = (role && role.name) || 'Unknown role'
     const bytes = role && role.bytes
 
-    const emptyManager = isEmptyAddress(manager)
+    const emptyManager = isEmptyAddress(manager.address)
 
     return (
       <TableRow>
@@ -86,7 +96,7 @@ class RoleRow extends React.Component {
         </TableCell>
         <TableCell title={bytes}>{id}</TableCell>
         <TableCell>
-          {emptyManager ? 'No manager set' : <IdentityBadge entity={manager} />}
+          {emptyManager ? 'No manager set' : this.renderManager()}
         </TableCell>
         <TableCell align="right">
           <Button mode="outline" compact onClick={this.handleManageClick}>

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -73,7 +73,7 @@ class ManageRolePanel extends React.PureComponent {
   getCurrentAction() {
     const { updateAction } = this.state
     const manager = this.getManager()
-    return isEmptyAddress(manager) ? CREATE_PERMISSION : updateAction
+    return isEmptyAddress(manager.address) ? CREATE_PERMISSION : updateAction
   }
 
   getUpdateAction(index) {
@@ -91,7 +91,7 @@ class ManageRolePanel extends React.PureComponent {
 
   getManager() {
     const { getRoleManager, app, role } = this.props
-    return app && role ? getRoleManager(app, role && role.bytes) : null
+    return getRoleManager(app, role && role.bytes)
   }
 
   getNamedApps() {
@@ -195,11 +195,23 @@ class ManageRolePanel extends React.PureComponent {
     this.setState({ assignEntityIndex: index, assignEntityAddress: address })
   }
 
+  renderManager = () => {
+    const manager = this.getManager()
+    const emptyManager = isEmptyAddress(manager.address)
+    if (emptyManager) {
+      return 'No manager'
+    }
+    if (manager.type === 'app') {
+      return (
+        <AppInstanceLabel app={manager.app} proxyAddress={manager.address} />
+      )
+    }
+    return <IdentityBadge entity={manager.address} />
+  }
+
   render() {
     const { opened, onClose, app, role } = this.props
     const { newRoleManagerValue, assignEntityIndex } = this.state
-
-    const manager = this.getManager()
 
     const updateActionsItems = this.getUpdateActionsItems()
     const updateActionIndex = this.getUpdateActionIndex()
@@ -231,9 +243,7 @@ class ManageRolePanel extends React.PureComponent {
           {UPDATE_ACTIONS.has(action) && (
             <React.Fragment>
               <Field label="Role manager">
-                <FlexRow>
-                  {manager ? <IdentityBadge entity={manager} /> : 'No manager'}
-                </FlexRow>
+                <FlexRow>{this.renderManager()}</FlexRow>
               </Field>
               <Field label="Action">
                 <DropDown

--- a/src/contexts/PermissionsContext.js
+++ b/src/contexts/PermissionsContext.js
@@ -150,10 +150,11 @@ class PermissionsProvider extends React.Component {
 
   // Get the manager of a role
   getRoleManager = (app, roleBytes) => {
+    const { resolveEntity } = this.state
     const role = this.getAppRoles(app).find(
       role => role.roleBytes === roleBytes
     )
-    return (role && role.manager) || getEmptyAddress()
+    return resolveEntity((role && role.manager) || getEmptyAddress())
   }
 
   // Get a list of entities with the roles assigned to them

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -106,7 +106,7 @@ function resolveEntity(apps, address) {
     return { ...entity, type: 'any' }
   }
   const app = apps.find(app => app.proxyAddress === address)
-  return app ? { ...entity, type: 'app', app } : entity
+  return app ? { ...entity, app, type: 'app' } : entity
 }
 
 // Returns a function that resolves an entity, caching the results


### PR DESCRIPTION
Includes #376.

Not sure if we explicitly decided to only use the entity badge for managers, but it is confusing when they're apps.

Before:
![image](https://user-images.githubusercontent.com/4166642/46698304-f796c480-cc16-11e8-9c89-65e5e582178c.png)

After:
<img width="1185" alt="screen shot 2018-10-09 at 10 58 29 pm" src="https://user-images.githubusercontent.com/4166642/46698285-e352c780-cc16-11e8-8676-6cc7a8c943b1.png">
