### PR TITLE
Permissions: fix crash when trying to render entity permissions too quickly after initialization

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -28,7 +28,9 @@ export function permissionsByEntity(permissions) {
   // apps
   for (const [app, appPermissions] of Object.entries(permissions)) {
     // roles
-    for (const [role, { allowedEntities }] of Object.entries(appPermissions)) {
+    for (const [role, { allowedEntities = [] }] of Object.entries(
+      appPermissions
+    )) {
       // entities
       for (const entity of allowedEntities) {
         if (!results[entity]) {


### PR DESCRIPTION
Fixes an uncommon crash where we attempt to render an entity's permissions without receiving enough info from aragon.js.