### PR TITLE
Readme: added links for acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ For connecting to other chains / deployments, a few useful npm scripts are provi
 The app can be configured in a number of ways via environment variables:
 
 - `REACT_APP_DEFAULT_ETH_NODE`: Url of the default Ethereum node to read blockchain data from (must be WebSocket protocol). If you intend to connect to a local ganache instance, by default you should set this to `ws://localhost:8545`.
-- `REACT_APP_ENS_REGISTRY_ADDRESS`: Address of the ENS registry that APM repos were registered on. If you've deployed aragonOS to a local network, you can find the ENS registry's address in the migration's console output.
+- `REACT_APP_ENS_REGISTRY_ADDRESS`: Address of the ENS registry that [APM](https://hack.aragon.org/docs/apm.html) repos were registered on. If you've deployed [aragonOS] to a local network, you can find the ENS registry's address in the migration's console output.
 - `REACT_APP_ETH_NETWORK_TYPE`: Expected network to connect to. Either one of `mainnet`, `rinkeby` or `local`.
-- `REACT_APP_IPFS_GATEWAY`: Url of the IPFS gateway to load APM repos from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:8080/ipfs`
+- `REACT_APP_IPFS_GATEWAY`: Url of the [IPFS](https://ipfs.io) gateway to load APM repos from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:8080/ipfs`
 - `REACT_APP_ASSET_BRIDGE`: Which source to load the app frontend assets from. Can be one of `apm-bridge` (`apm-serve`'s production hosts, e.g. `voting.aragonpm.eth`), `ipfs` (loads through the IPFS gateway configured), or `local` (local servers, running on `localhost:300x`). If you intend to serve from a local IPFS daemon, you should set this to `ipfs`.
 
 Without any settings, the app is configured to connect to our Rinkeby deployment using the `apm-serve` bridge.


### PR DESCRIPTION
Readme is the first document visible when you open a github repo.
I think some acronyms need to be linked to their official project websites (if you never heard about them).
For example:
1) APM: what is is? [Atom Package Manager](https://github.com/atom/apm) or [Aragon Package Manager](https://hack.aragon.org/docs/apm.html)? (OK, I know that APM is about Aragon here - but first links in search results will lead you to Atom repo. It's confusing)
2) IPFS is another JAFA for any person who never heard about this amazing technology. Let's tell everyone about it.
3) ENS confuses even me. What does it stands for? I never worked with blockchain name systems. When I try to search "ENS" I found this: https://ens.domains/
Is it an official site for Ethereum Name System technology?
(Is ENS is about Ethereum Name System here in the first place?)
I am not sure about ENS, because [official ethereum site](https://www.ethereum.org/) has 0 results for "ENS" (seriously - try page search {space}ENS{space} - no results. Why?)
I am don't want to link people to wrong URL - so can you provide a link to the official Ethereum Name System project website or protocol description?