### PR TITLE
Permissions: fix address equality checks to be less strict on checksums

### DIFF
--- a/src/apps/Permissions/Permissions.js
+++ b/src/apps/Permissions/Permissions.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { AppBar, AppView, NavigationBar, Button } from '@aragon/ui'
-import { shortenAddress, isAddress } from '../../web3-utils'
+import { addressesEqual, shortenAddress, isAddress } from '../../web3-utils'
 import Screen from './Screen'
 import Home from './Home/Home'
 import AppPermissions from './AppPermissions'
@@ -67,7 +67,9 @@ class Permissions extends React.Component {
     if (!proxyAddress) {
       return null
     }
-    return this.props.apps.find(app => app.proxyAddress === proxyAddress)
+    return this.props.apps.find(app =>
+      addressesEqual(app.proxyAddress, proxyAddress)
+    )
   }
 
   goToHome = () => {

--- a/src/contexts/PermissionsContext.js
+++ b/src/contexts/PermissionsContext.js
@@ -42,7 +42,7 @@ class PermissionsProvider extends React.Component {
       proxyAddress,
       roleBytes,
     ])
-    log('revoke tx:', transaction)
+    log('revokePermission tx:', transaction)
   }
 
   // create a permission (= set a manager + grant a permission)
@@ -56,7 +56,7 @@ class PermissionsProvider extends React.Component {
     if (wrapper === null) {
       return
     }
-    console.log('CREATE', [entityAddress, proxyAddress, roleBytes, manager])
+    log('createPermission', [entityAddress, proxyAddress, roleBytes, manager])
     const transaction = await wrapper.performACLIntent('createPermission', [
       entityAddress,
       proxyAddress,

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,5 +1,5 @@
 import memoize from 'lodash.memoize'
-import { isAnyAddress } from './web3-utils'
+import { addressesEqual, isAnyAddress } from './web3-utils'
 
 const KERNEL_ROLES = [
   {
@@ -94,7 +94,7 @@ function resolveRole(apps, proxyAddress, roleBytes) {
   if (knownRole) {
     return knownRole.role
   }
-  const app = apps.find(app => app.proxyAddress === proxyAddress)
+  const app = apps.find(app => addressesEqual(app.proxyAddress, proxyAddress))
   if (!app || !app.roles) {
     return null
   }
@@ -107,7 +107,7 @@ function resolveEntity(apps, address) {
   if (isAnyAddress(address)) {
     return { ...entity, type: 'any' }
   }
-  const app = apps.find(app => app.proxyAddress === address)
+  const app = apps.find(app => addressesEqual(app.proxyAddress, address))
   return app ? { ...entity, app, type: 'app' } : entity
 }
 

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -51,12 +51,12 @@ export function getWeb3(provider) {
 
 // Check if the address represents “Any address”
 export function isAnyAddress(address) {
-  return address === ANY_ADDRESS
+  return addressesEqual(address, ANY_ADDRESS)
 }
 
 // Check if the address represents an empty address
 export function isEmptyAddress(address) {
-  return address === EMPTY_ADDRESS
+  return addressesEqual(address, EMPTY_ADDRESS)
 }
 
 export function getAnyAddress() {


### PR DESCRIPTION
Loosens the strictness on comparing address strings.

I think it's mostly the `Kernel` that's affected by this, as we get it from the URL or ENS, but still nice to have until we find it's a large performance problem.

Before:

![image](https://user-images.githubusercontent.com/4166642/46733549-ee4a3e00-cc90-11e8-8d15-a1755a7732ec.png)

After:

![image](https://user-images.githubusercontent.com/4166642/46733557-f2765b80-cc90-11e8-833a-f2c04efba13d.png)
