### PR TITLE
Permissions: Use proxyAddress for AppCard key instead of appId

### DIFF
--- a/src/apps/Permissions/Home/BrowseByApp.js
+++ b/src/apps/Permissions/Home/BrowseByApp.js
@@ -19,7 +19,7 @@ class BrowseByApp extends React.Component {
           return (
             <Apps>
               {apps.map(app => (
-                <AppCard key={app.appId} app={app} onOpen={onOpenApp} />
+                <AppCard key={app.proxyAddress} app={app} onOpen={onOpenApp} />
               ))}
             </Apps>
           )


### PR DESCRIPTION
`appId` is not a unique identifier for apps in a DAO as multiple instances of the same app can be installed.