### PR TITLE
aragon-wrapper: remove KERNEL_BASE

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -18,21 +18,6 @@ import { getWeb3 } from './web3-utils'
 import { getBlobUrl, WorkerSubscriptionPool } from './worker-utils'
 import { InvalidAddress, NoConnection } from './errors'
 
-const KERNEL_BASE = {
-  name: 'Kernel',
-  appId: 'kernel',
-  isAragonOsInternalApp: true,
-  roles: [
-    {
-      name: 'Manage apps',
-      id: 'APP_MANAGER_ROLE',
-      params: [],
-      bytes:
-        '0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0',
-    },
-  ],
-}
-
 const POLL_DELAY_ACCOUNT = 2000
 const POLL_DELAY_NETWORK = 2000
 const POLL_DELAY_CONNECTIVITY = 2000
@@ -73,29 +58,22 @@ const applyAppOverrides = apps =>
 
 // Sort apps, apply URL overrides, and attach data useful to the frontend
 const prepareFrontendApps = (apps, daoAddress, gateway) => {
-  return [
-    {
-      ...KERNEL_BASE,
-      proxyAddress: daoAddress,
-      hasWebApp: false,
-    },
-    ...applyAppOverrides(apps)
-      .map(app => {
-        const baseUrl = appBaseUrl(app, gateway)
-        // Remove the starting slash from the start_url field
-        // so the absolute path can be resolved from baseUrl.
-        const startUrl = removeStartingSlash(app['start_url'] || '')
-        const src = baseUrl ? resolvePathname(startUrl, baseUrl) : ''
+  return applyAppOverrides(apps)
+    .map(app => {
+      const baseUrl = appBaseUrl(app, gateway)
+      // Remove the starting slash from the start_url field
+      // so the absolute path can be resolved from baseUrl.
+      const startUrl = removeStartingSlash(app['start_url'] || '')
+      const src = baseUrl ? resolvePathname(startUrl, baseUrl) : ''
 
-        return {
-          ...app,
-          src,
-          baseUrl,
-          hasWebApp: Boolean(app['start_url']),
-        }
-      })
-      .sort(sortAppsPair),
-  ]
+      return {
+        ...app,
+        src,
+        baseUrl,
+        hasWebApp: Boolean(app['start_url']),
+      }
+    })
+    .sort(sortAppsPair)
 }
 
 const getMainAccount = async web3 => {


### PR DESCRIPTION
Removes the Kernel app injection in `prepareFrontendApps`, as `aragon.js` now includes the `Kernel` in the `apps` stream.

Depends on [aragon.js PR](https://github.com/aragon/aragon.js/pull/178)