### PR TITLE
Remove apm-serve asset bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The app can be configured in a number of ways via environment variables:
 - `REACT_APP_ENS_REGISTRY_ADDRESS`: Address of the ENS registry that [APM](https://hack.aragon.org/docs/apm.html) repos were registered on. If you've deployed [aragonOS](https://github.com/aragon/aragonOS) to a local network, you can find the ENS registry's address in the migration's console output.
 - `REACT_APP_ETH_NETWORK_TYPE`: Expected network to connect to. Either one of `mainnet`, `rinkeby` or `local`.
 - `REACT_APP_IPFS_GATEWAY`: Url of the [IPFS](https://ipfs.io) gateway to load APM repos from. If you intend to connect to a local IPFS daemon, by default you should set this to `http://localhost:8080/ipfs`
-- `REACT_APP_ASSET_BRIDGE`: Which source to load the app frontend assets from. Can be one of `apm-bridge` (`apm-serve`'s production hosts, e.g. `voting.aragonpm.eth`), `ipfs` (loads through the IPFS gateway configured), or `local` (local servers, running on `localhost:300x`). If you intend to serve from a local IPFS daemon, you should set this to `ipfs`.
+- `REACT_APP_ASSET_BRIDGE`: Which source to load app frontend assets from. Can be one of `ipfs` (uses the configured IPFS gateway) or `local` (local development servers, running on `localhost:300x`). If you intend to serve assets from a local IPFS daemon, you should set this to `ipfs`.
 
-Without any settings, the app is configured to connect to our Rinkeby deployment using the `apm-serve` bridge.
+Without any settings, the app is configured to connect to our Rinkeby deployment fetching assets from IPFS.
 
 ## Issues
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -86,31 +86,10 @@ if (assetBridge === 'local') {
   })
 } else if (assetBridge === 'ipfs') {
   // We don't need to provide any thing here as by default, the apps will be loaded from IPFS
-} else {
-  if (assetBridge && assetBridge !== 'apm-serve') {
+  if (assetBridge && assetBridge !== 'ipfs') {
     console.error(
-      `The specified asset bridge (${assetBridge}) in the configuration is not one of 'apm-serve', 'ipfs', or 'local'. Defaulting to using apm-serve.`
+      `The specified asset bridge (${assetBridge}) in the configuration is not one of 'ipfs', or 'local'. Defaulting to using 'ipfs'.`
     )
-  }
-
-  if (networkType === 'mainnet') {
-    /******************************
-     * Mainnet apm-serve settings *
-     ******************************/
-    Object.assign(appLocator, {
-      // Cloudflare doesn't let us use our certificate down to mainnet.survey.aragonpm, so we'll
-      // downgrade to HTTP for now
-      [appIds['Survey']]: 'http://mainnet.survey.aragonpm.com/',
-    })
-  } else if (networkType === 'rinkeby') {
-    /******************************
-     * Rinkeby apm-serve settings *
-     ******************************/
-    Object.assign(appLocator, {
-      [appIds['Finance']]: 'https://finance.aragonpm.com/',
-      [appIds['TokenManager']]: 'https://token-manager.aragonpm.com/',
-      [appIds['Voting']]: 'https://voting.aragonpm.com/',
-    })
   }
 }
 export { appLocator, appOverrides }

--- a/src/environment.js
+++ b/src/environment.js
@@ -85,12 +85,11 @@ if (assetBridge === 'local') {
     },
   })
 } else if (assetBridge === 'ipfs') {
-  // We don't need to provide any thing here as by default, the apps will be loaded from IPFS
-  if (assetBridge && assetBridge !== 'ipfs') {
-    console.error(
-      `The specified asset bridge (${assetBridge}) in the configuration is not one of 'ipfs', or 'local'. Defaulting to using 'ipfs'.`
-    )
-  }
+  // We don't need to provide anything here as by default, the apps will be loaded from IPFS
+} else if (assetBridge) {
+  console.error(
+    `The specified asset bridge (${assetBridge}) in the configuration is not one of 'ipfs', or 'local'. Defaulting to using 'ipfs'.`
+  )
 }
 export { appLocator, appOverrides }
 


### PR DESCRIPTION
Maintaining the asset bridge to with `apm-serve` makes the app more centralized than it could be (when using the CLI with Kits we are already running apps directly from an IPFS gateway without problem) and it is going to be a pain to maintain with multiple environments.

Currently having some issues when running with Rinkeby settings ~because [the manifest](http://voting.aragonpm.com/manifest.json) of the apps uses absolute URLs to the resources. I think updating the manifest should be enough for the apps that have been published recently, but we may have to redeploy them all.~ Edit: The issue is actually with the resources that get loaded inside the frontend, the wrapper already removes the starting slash from the manifest values if found.

> GET https://ipfs.io/static/js/main.6b4a1a10.js net::ERR_ABORTED 404