### PR TITLE
Onboarding: avoid bottom text in signing screen from being cut off in smaller screens

### DIFF
--- a/src/onboarding/Sign.js
+++ b/src/onboarding/Sign.js
@@ -193,6 +193,7 @@ const TransactionTitle = styled.h2`
 
 const Note = styled.p`
   max-width: 55%;
+  min-width: 325px;
   margin-top: 40px;
   text-align: center;
 `


### PR DESCRIPTION
Avoids:

![image](https://user-images.githubusercontent.com/4166642/47023102-3967c380-d15f-11e8-8af5-38b87fe2a78c.png)
