### PR TITLE
chore: actually run the CI tasks we defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
+sudo: required
 language: node_js
-
-node_js:
-  - "8"
 
 cache:
   directories:
     - "node_modules"
 
+node_js:
+  - "8"
+
 env:
   - TASK=lint
   - TASK=build
+
+script:
+  - npm run $TASK


### PR DESCRIPTION
Oops, it was always just running `npm run lint` 😅 