### PR TITLE
Show final intent in signing panel

### DIFF
--- a/src/components/SignerPanel/SignerPanelContent.js
+++ b/src/components/SignerPanel/SignerPanelContent.js
@@ -54,19 +54,18 @@ class ActionPathsContent extends React.Component {
     const { selected } = this.state
     // In non-direct paths, the first transaction (0) is the one we need to sign
     // to kick off the forwarding path
-    onSign(direct ? intent.transaction : paths[selected][0])
+    onSign(direct ? intent.transaction : paths[selected][0], intent)
   }
-  renderDescription(showPaths, { description, to, toName, transaction = {} }) {
-    if (transaction.description) {
-      return transaction.description
-    }
+  renderDescription(showPaths, { description, name, to }) {
     return (
-      <span>
-        This transaction will {showPaths && 'eventually'} perform{' '}
-        {description ? `"${description}"` : 'an action'}
-        {' on '}
-        <AddressLink to={to}>{toName}</AddressLink>.
-      </span>
+      <React.Fragment>
+        <p>This transaction will {showPaths && 'eventually'} perform:</p>
+        <p>{description ? `"${description}"` : 'an action'}</p>
+        <p style={{ margin: '10px 0' }}>
+          {' on '}
+          <AddressLink to={to}>{name}</AddressLink>.
+        </p>
+      </React.Fragment>
     )
   }
   getPathRadioItem(path) {
@@ -151,13 +150,13 @@ class ActionPathsContent extends React.Component {
 
 const ImpossibleContent = ({
   error,
-  intent: { description, to, toName },
+  intent: { description, name, to },
   onClose,
 }) => (
   <React.Fragment>
     <Info.Permissions title="Action impossible">
       The action {description && `"${description}"`} failed to execute on{' '}
-      <AddressLink to={to}>{toName}</AddressLink>.{' '}
+      <AddressLink to={to}>{name}</AddressLink>.{' '}
       {error
         ? 'An error occurred when we tried to find a path or send a transaction for this action.'
         : 'You do not have the necessary permissions.'}
@@ -167,7 +166,7 @@ const ImpossibleContent = ({
 )
 
 const NeedUnlockAccountContent = ({
-  intent: { description, to, toName },
+  intent: { description, name, to },
   onClose,
 }) => (
   <React.Fragment>
@@ -175,7 +174,7 @@ const NeedUnlockAccountContent = ({
       You need to unlock your account in order to perform{' '}
       {description ? `"${description}"` : 'this action'}
       {' on '}
-      <AddressLink to={to}>{toName}</AddressLink>.
+      <AddressLink to={to}>{name}</AddressLink>.
       <InstallMessage>
         Please unlock or enable your Ethereum provider.
       </InstallMessage>
@@ -184,13 +183,13 @@ const NeedUnlockAccountContent = ({
   </React.Fragment>
 )
 
-const NeedWeb3Content = ({ intent: { description, to, toName }, onClose }) => (
+const NeedWeb3Content = ({ intent: { description, name, to }, onClose }) => (
   <React.Fragment>
     <Info.Action title="You can't perform any actions">
       You need to be connected to a Web3 instance in order to perform{' '}
       {description ? `"${description}"` : 'this action'}
       {' on '}
-      <AddressLink to={to}>{toName}</AddressLink>.
+      <AddressLink to={to}>{name}</AddressLink>.
       <InstallMessage>
         Please unlock or enable your Ethereum provider.
       </InstallMessage>


### PR DESCRIPTION
Show the description of the actual transaction path's intent (ie. its final action), rather than what the first action would do.

Right now, the description would basically always say "makes a new vote", whereas it would be nicer to show the final transaction's description (e.g. "mint tokens" or "transfer funds") since that's what the user actually wanted to accomplish.

The description looks something like this:

<img width="415" alt="screen shot 2018-10-25 at 12 35 50 am" src="https://user-images.githubusercontent.com/4166642/47466693-b72c6e80-d7f2-11e8-8a22-09bb001217c8.png">