### PR TITLE
Burned permissions

### DIFF
--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -77,6 +77,9 @@ class RoleRow extends React.Component {
         <AppInstanceLabel app={manager.app} proxyAddress={manager.address} />
       )
     }
+    if (manager.type === 'burned') {
+      return <IdentityBadge entity={'Discarded'} />
+    }
     return <IdentityBadge entity={manager.address} />
   }
   render() {

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DropDown, Field, TextInput } from '@aragon/ui'
-import { getAnyAddress, getEmptyAddress } from '../../web3-utils'
+import { getAnyAddress } from '../../permissions'
+import { getEmptyAddress } from '../../web3-utils'
 import AppInstanceLabel from './AppInstanceLabel'
 
 class EntitySelector extends React.Component {

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,6 +1,8 @@
 import memoize from 'lodash.memoize'
-import { addressesEqual, isAnyAddress } from './web3-utils'
+import { addressesEqual } from './web3-utils'
 
+const ANY_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+const BURNED_ADDRESS = '0x0000000000000000000000000000000000000001'
 const KERNEL_ROLES = [
   {
     name: 'Manage apps',
@@ -9,6 +11,24 @@ const KERNEL_ROLES = [
     bytes: '0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0',
   },
 ]
+
+export function getAnyAddress() {
+  return ANY_ADDRESS
+}
+
+export function getBurnedAddress() {
+  return BURNED_ADDRESS
+}
+
+// Check if the address represents “Any address”
+export function isAnyAddress(address) {
+  return addressesEqual(address, ANY_ADDRESS)
+}
+
+// Check if the address represents the “Burned address”
+export function isBurnedAddress(address) {
+  return addressesEqual(address, BURNED_ADDRESS)
+}
 
 // Get a role from the known roles (kernel)
 export const getKnownRole = roleBytes => {
@@ -113,6 +133,9 @@ function resolveEntity(apps, address) {
   const entity = { address, type: 'address' }
   if (isAnyAddress(address)) {
     return { ...entity, type: 'any' }
+  }
+  if (isBurnedAddress(address)) {
+    return { ...entity, type: 'burned' }
   }
   const app = apps.find(app => addressesEqual(app.proxyAddress, address))
   return app ? { ...entity, app, type: 'app' } : entity

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -71,7 +71,7 @@ export const appPermissions = (
   transform = (entity, role) => [entity, role]
 ) => {
   const roles = permissions[app.proxyAddress]
-  const rolesReducer = (roles, [role, { allowedEntities }]) =>
+  const rolesReducer = (roles, [role, { allowedEntities = [] }]) =>
     roles.concat(allowedEntities.map(entity => transform(entity, role)))
 
   return roles

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -5,7 +5,6 @@
  */
 import Web3 from 'web3'
 
-const ANY_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 /**
@@ -65,18 +64,9 @@ export function getWeb3(provider) {
   return web3
 }
 
-// Check if the address represents “Any address”
-export function isAnyAddress(address) {
-  return addressesEqual(address, ANY_ADDRESS)
-}
-
 // Check if the address represents an empty address
 export function isEmptyAddress(address) {
   return addressesEqual(address, EMPTY_ADDRESS)
-}
-
-export function getAnyAddress() {
-  return ANY_ADDRESS
 }
 
 export function getEmptyAddress() {


### PR DESCRIPTION
With `aragonOS@4` we have have the standard notion of a "burned" permission manager, i.e. a permission with its manager thrown away so that it's forever frozen (from the state it was in when it was "burned").

This fixes the app crashing when no `allowedEntities` exist, but the manager does (likely because the permission's been completely thrown away), and also adds detection for these managers. I've opted to use `Discarded` as the label name, and think it doesn't look too out of place:

![image](https://user-images.githubusercontent.com/4166642/47501116-f693a300-d864-11e8-8c7a-b2a498ab526e.png)
