### PR TITLE
Permissions: change role management panel to view-only when role is burned

### DIFF
--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -12,6 +12,7 @@ import Section from './Section'
 import EmptyBlock from './EmptyBlock'
 import AppInstanceLabel from './AppInstanceLabel'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
+import { isBurnEntity } from '../../permissions'
 import { isEmptyAddress } from '../../web3-utils'
 
 class AppRoles extends React.PureComponent {
@@ -77,7 +78,7 @@ class RoleRow extends React.Component {
         <AppInstanceLabel app={manager.app} proxyAddress={manager.address} />
       )
     }
-    if (manager.type === 'burned') {
+    if (manager.type === 'burn') {
       return <IdentityBadge entity={'Discarded'} />
     }
     return <IdentityBadge entity={manager.address} />
@@ -86,6 +87,7 @@ class RoleRow extends React.Component {
     const { role, manager } = this.props
     const name = (role && role.name) || 'Unknown action'
     const emptyManager = isEmptyAddress(manager.address)
+    const discardedManager = isBurnEntity(manager.address)
 
     return (
       <TableRow>
@@ -96,8 +98,13 @@ class RoleRow extends React.Component {
           {emptyManager ? 'No manager set' : this.renderManager()}
         </TableCell>
         <TableCell align="right">
-          <Button mode="outline" compact onClick={this.handleManageClick}>
-            {emptyManager ? 'Initialize' : 'Manage'}
+          <Button
+            compact
+            mode="outline"
+            style={{ minWidth: '80px' }}
+            onClick={this.handleManageClick}
+          >
+            {emptyManager ? 'Initialize' : discardedManager ? 'View' : 'Manage'}
           </Button>
         </TableCell>
       </TableRow>

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { DropDown, Field, TextInput } from '@aragon/ui'
-import { getAnyAddress } from '../../permissions'
+import { getAnyEntity } from '../../permissions'
 import { getEmptyAddress } from '../../web3-utils'
 import AppInstanceLabel from './AppInstanceLabel'
 
@@ -50,7 +50,7 @@ class EntitySelector extends React.Component {
     }
 
     if (index === items.length - 2) {
-      return getAnyAddress()
+      return getAnyEntity()
     }
 
     const app = this.getApps()[index - 1]

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,8 +1,13 @@
 import memoize from 'lodash.memoize'
 import { addressesEqual } from './web3-utils'
 
-const ANY_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
-const BURNED_ADDRESS = '0x0000000000000000000000000000000000000001'
+// Note that these two terms are slightly confusing artifacts of the ACL:
+//   Any entity: If a permission is granted to "any entity", then any address can be seen as holding
+//               that permission
+//   Burn entity: If a permission manager is set as "burn entity", then it is assumed to be a
+//               discarded and frozen permission
+const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+const BURN_ENTITY = '0x0000000000000000000000000000000000000001'
 const KERNEL_ROLES = [
   {
     name: 'Manage apps',
@@ -12,22 +17,22 @@ const KERNEL_ROLES = [
   },
 ]
 
-export function getAnyAddress() {
-  return ANY_ADDRESS
+export function getAnyEntity() {
+  return ANY_ENTITY
 }
 
-export function getBurnedAddress() {
-  return BURNED_ADDRESS
+export function getBurnEntity() {
+  return BURN_ENTITY
 }
 
 // Check if the address represents “Any address”
-export function isAnyAddress(address) {
-  return addressesEqual(address, ANY_ADDRESS)
+export function isAnyEntity(address) {
+  return addressesEqual(address, ANY_ENTITY)
 }
 
 // Check if the address represents the “Burned address”
-export function isBurnedAddress(address) {
-  return addressesEqual(address, BURNED_ADDRESS)
+export function isBurnEntity(address) {
+  return addressesEqual(address, BURN_ENTITY)
 }
 
 // Get a role from the known roles (kernel)
@@ -131,11 +136,11 @@ function resolveRole(apps, proxyAddress, roleBytes) {
 // Resolves an entity using the provided apps
 function resolveEntity(apps, address) {
   const entity = { address, type: 'address' }
-  if (isAnyAddress(address)) {
+  if (isAnyEntity(address)) {
     return { ...entity, type: 'any' }
   }
-  if (isBurnedAddress(address)) {
-    return { ...entity, type: 'burned' }
+  if (isBurnEntity(address)) {
+    return { ...entity, type: 'burn' }
   }
   const app = apps.find(app => addressesEqual(app.proxyAddress, address))
   return app ? { ...entity, app, type: 'app' } : entity


### PR DESCRIPTION
Aligns the permissions' constants more with the ACL contract's constants, and disables the role management panel to view only when a permission manager is burned.

![image](https://user-images.githubusercontent.com/4166642/47579574-b27bcd80-d94c-11e8-8b58-62bfba4a24be.png)

<img src="https://user-images.githubusercontent.com/4166642/47579581-b4de2780-d94c-11e8-81c0-1299bdc348af.png" height=400>