### PR TITLE
Fix an onboarding crash happening with specific web3 provider setups

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import initWrapper, {
 } from './aragonjs-wrapper'
 import Wrapper from './Wrapper'
 import Onboarding from './onboarding/Onboarding'
-import { getWeb3 } from './web3-utils'
+import { getWeb3, getUnknownBalance } from './web3-utils'
 import { log } from './utils'
 import { PermissionsProvider } from './contexts/PermissionsContext'
 import { ModalProvider } from './components/ModalManager/ModalManager'
@@ -28,7 +28,7 @@ class App extends React.Component {
     prevLocator: null,
     wrapper: null,
     account: '',
-    balance: null,
+    balance: getUnknownBalance(),
     connected: false,
     apps: [],
     appsStatus: APPS_STATUS_LOADING,

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -117,11 +117,11 @@ const filterBalanceValue = value => {
   if (value === null) {
     return '-1'
   }
+  if (typeof value === 'object') {
+    value = String(value)
+  }
   if (typeof value === 'string') {
     return /^[0-9]+$/.test(value) ? value : '-1'
-  }
-  if (typeof value === 'object') {
-    return String(value)
   }
   return '-1'
 }

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Motion, spring } from 'react-motion'
 import { spring as springConf } from '@aragon/ui'
 import { noop } from '../utils'
+import { getUnknownBalance } from '../web3-utils'
 import { isNameAvailable } from '../aragonjs-wrapper'
 
 import * as Steps from './steps'
@@ -51,7 +52,7 @@ const initialState = {
 class Onboarding extends React.PureComponent {
   static defaultProps = {
     account: '',
-    balance: null,
+    balance: getUnknownBalance(),
     walletNetwork: '',
     visible: true,
     daoCreationStatus: 'none',

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -4,6 +4,7 @@
  * from this file.
  */
 import Web3 from 'web3'
+import BN from 'bn.js'
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -17,6 +18,34 @@ export function addressesEqual(first, second) {
   first = first && first.toLowerCase()
   second = second && second.toLowerCase()
   return first === second
+}
+
+/**
+ * Format the balance to a fixed number of decimals
+ *
+ * @param {BN} amount The total amount.
+ * @param {object} options The options object.
+ * @param {BN} options.base The decimals base.
+ * @param {number} options.precision Number of decimals to format.
+ *
+ * @returns {string} The formatted balance.
+ */
+export function formatBalance(
+  amount,
+  { base = new BN(10).pow(new BN(18)), precision = 2 } = {}
+) {
+  const baseLength = base.toString().length
+
+  const whole = amount.div(base).toString()
+  let fraction = amount.mod(base).toString()
+  const zeros = '0'.repeat(Math.max(0, baseLength - fraction.length - 1))
+  fraction = `${zeros}${fraction}`.replace(/0+$/, '').slice(0, precision)
+
+  if (fraction === '' || parseInt(fraction, 10) === 0) {
+    return whole
+  }
+
+  return `${whole}.${fraction}`
 }
 
 /**
@@ -71,6 +100,10 @@ export function isEmptyAddress(address) {
 
 export function getEmptyAddress() {
   return EMPTY_ADDRESS
+}
+
+export function getUnknownBalance() {
+  return new BN('-1')
 }
 
 // Re-export some utilities from web3-utils


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/440

When calling getBalance(), it was possible to sometimes get another value than an big integer as a string.

Having `null` as a result, and passing it to the BN.js constructor, [could lead to an infinite loop](https://github.com/indutny/bn.js/issues/186).

To prevent this issue to happen again:

- In the app, `balance` is now always represented by a BN.js instance. To represent an unknown balance, `new BN(-1)` is now used rather than `null`.

- The result of getbalance() is now filtered to ensure that we are passing an integer to BN.js. Otherwise, we pass `"-1"`.