### PR TITLE
chore: add preset-react to babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,8 @@
         },
         "useBuiltIns": false
       }
-    ]
+    ],
+    "@babel/preset-react"
   ],
   "plugins": [
     ["styled-components", { "displayName": true }],


### PR DESCRIPTION
Hmm, not sure how we got away with not including this up to now 🤔 