### PR TITLE
Allow all ENS names and error on invalid organization routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -259,6 +259,11 @@ class App extends React.Component {
 
     const { mode, dao } = locator
     if (!mode) return null
+    if (mode === 'invalid') {
+      throw new Error(
+        `URL contained invalid organization name or address (${dao}).\nPlease modify it to be a valid ENS name or address.`
+      )
+    }
 
     if (fatalError !== null) {
       throw fatalError

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -17,7 +17,7 @@ import {
   defaultGasPriceFn,
 } from './environment'
 import { noop, removeStartingSlash, appendTrailingSlash } from './utils'
-import { getWeb3, getUnknownBalance } from './web3-utils'
+import { getWeb3, getUnknownBalance, isValidEnsName } from './web3-utils'
 import { getBlobUrl, WorkerSubscriptionPool } from './worker-utils'
 import { NoConnection, DAONotFound } from './errors'
 
@@ -316,7 +316,7 @@ const initWrapper = async (
     onWeb3 = noop,
   } = {}
 ) => {
-  const isDomain = /[a-z0-9]+\.aragonid\.eth/.test(dao)
+  const isDomain = isValidEnsName(dao)
   const daoAddress = isDomain
     ? await resolveEnsDomain(dao, {
         provider,

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,5 +1,5 @@
 import { staticApps } from './static-apps'
-import { isAddress } from './web3-utils'
+import { isAddress, isValidEnsName } from './web3-utils'
 
 /*
  * Parse a path and a search query and return a “locator” object.
@@ -47,7 +47,7 @@ export const parsePath = (pathname, search = '') => {
   }
 
   const validAddress = isAddress(parts[0])
-  const validDomain = /[a-z0-9]+\.aragonid\.eth/.test(parts[0])
+  const validDomain = isValidEnsName(parts[0])
 
   // Exclude invalid DAO addresses
   if (!validAddress && !validDomain) {

--- a/src/routing.js
+++ b/src/routing.js
@@ -29,7 +29,7 @@ import { isAddress, isValidEnsName } from './web3-utils'
  *   - home: the screen you see when opening /.
  *   - setup: the onboarding screens.
  *   - app: when the path starts with a DAO address.
- *   - unknown: the mode can’t be determined.
+ *   - invalid: the DAO given is not valid
  */
 export const parsePath = (pathname, search = '') => {
   const locator = { path: pathname + search }
@@ -51,7 +51,7 @@ export const parsePath = (pathname, search = '') => {
 
   // Exclude invalid DAO addresses
   if (!validAddress && !validDomain) {
-    return { ...locator, mode: 'unknown' }
+    return { ...locator, dao: parts[0], mode: 'invalid' }
   }
 
   // App

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -106,5 +106,9 @@ export function getUnknownBalance() {
   return new BN('-1')
 }
 
+export function isValidEnsName(name) {
+  return /^([a-z0-9]+\.)+eth$/.test(name)
+}
+
 // Re-export some utilities from web3-utils
 export { fromWei, isAddress, toChecksumAddress, toWei } from 'web3-utils'

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -107,7 +107,7 @@ export function getUnknownBalance() {
 }
 
 export function isValidEnsName(name) {
-  return /^([a-z0-9]+\.)+eth$/.test(name)
+  return /^([\w-]+\.)+eth$/.test(name)
 }
 
 // Re-export some utilities from web3-utils


### PR DESCRIPTION
Fixes #459 and #408.

On invalid organization routes, the following error is shown (we can probably detect this better and show a nicer error state later on?):

![image](https://user-images.githubusercontent.com/4166642/48444106-4d6d0800-e793-11e8-8818-e2264d95b5d2.png)
