### PR TITLE
fix: properly format mainnet Etherscan URLs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ export function makeEtherscanBaseUrl(network) {
     network === 'rinkeby' ||
     network === 'ropsten'
   ) {
-    return `https://${network === 'mainnet' ? '' : `${network}.`}etherscan.io`
+    return `https://${network === 'main' ? '' : `${network}.`}etherscan.io`
   }
 }
 


### PR DESCRIPTION
Will later be replaced by [`blockExplorerUrl`](https://github.com/aragon/aragon-ui/blob/master/src/utils/web3.js#L69).