### PR TITLE
[WIP] Allow apps to sign arbitrary data via a RPC call 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,7 @@ class App extends React.Component {
     daoCreationStatus: 'none', // none / success / error
     buildData: null, // data returned by aragon.js when a DAO is created
     transactionBag: null,
+    signatureBag: null,
     walletNetwork: '',
     showDeprecatedBanner: false,
     selectorNetworks: [
@@ -208,6 +209,10 @@ class App extends React.Component {
         log('transaction bag', transactionBag)
         this.setState({ transactionBag })
       },
+      onSignatures: signatureBag => {
+        log('signature bag', signatureBag)
+        this.setState({ signatureBag })
+      },
     })
       .then(wrapper => {
         log('wrapper', wrapper)
@@ -246,6 +251,7 @@ class App extends React.Component {
       balance,
       walletNetwork,
       transactionBag,
+      signatureBag,
       daoCreationStatus,
       walletWeb3,
       web3,
@@ -286,6 +292,7 @@ class App extends React.Component {
             web3={web3}
             daoAddress={daoAddress}
             transactionBag={transactionBag}
+            signatureBag={signatureBag}
             connected={connected}
             onRequestAppsReload={this.handleRequestAppsReload}
           />

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -24,6 +24,7 @@ class Wrapper extends React.Component {
     locator: {},
     walletNetwork: '',
     transactionBag: null,
+    signatureBag: null,
     wrapper: null,
     walletWeb3: null,
     web3: null,
@@ -94,6 +95,7 @@ class Wrapper extends React.Component {
       banner,
       onRequestAppsReload,
       transactionBag,
+      signatureBag,
     } = this.props
 
     return (
@@ -116,6 +118,7 @@ class Wrapper extends React.Component {
           walletWeb3={walletWeb3}
           walletNetwork={walletNetwork}
           transactionBag={transactionBag}
+          signatureBag={signatureBag}
           apps={apps}
           account={account}
         />

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -203,10 +203,10 @@ export const pollNetwork = pollEvery((provider, onNetwork) => {
 // Subscribe to aragon.js observables
 const subscribe = (
   wrapper,
-  { onApps, onPermissions, onForwarders, onTransaction },
+  { onApps, onPermissions, onForwarders, onTransaction, onSignatures },
   { ipfsConf }
 ) => {
-  const { apps, permissions, forwarders, transactions } = wrapper
+  const { apps, permissions, forwarders, transactions, signatures } = wrapper
 
   const workerSubscriptionPool = new WorkerSubscriptionPool()
 
@@ -221,6 +221,7 @@ const subscribe = (
     connectedWorkers: workerSubscriptionPool,
     forwarders: forwarders.subscribe(onForwarders),
     transactions: transactions.subscribe(onTransaction),
+    signatures: signatures.subscribe(onSignatures),
     workers: apps.subscribe(apps => {
       // Asynchronously launch webworkers for each new app that has a background
       // script defined
@@ -312,6 +313,7 @@ const initWrapper = async (
     onPermissions = noop,
     onForwarders = noop,
     onTransaction = noop,
+    onSignatures = noop,
     onDaoAddress = noop,
     onWeb3 = noop,
   } = {}
@@ -367,7 +369,7 @@ const initWrapper = async (
 
   const subscriptions = subscribe(
     wrapper,
-    { onApps, onPermissions, onForwarders, onTransaction },
+    { onApps, onPermissions, onForwarders, onTransaction, onSignatures },
     { ipfsConf }
   )
 


### PR DESCRIPTION
This is a work in progress PR to fix this [issue](https://github.com/aragon/aragon.js/issues/124) 

This PR will allow an app to send a sign request to a server and then subscribe to the server to get the signed data once the server does the signing.