### PR TITLE
Use IdentityBadge in Settings

### DIFF
--- a/src/apps/Settings/DaoSettings.js
+++ b/src/apps/Settings/DaoSettings.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Button, Field, TextInput, Text, theme } from '@aragon/ui'
-import EtherscanLink from '../../components/Etherscan/EtherscanLink'
+import { Button, Field, Text, IdentityBadge } from '@aragon/ui'
 import { appIds, network, web3Providers } from '../../environment'
 import { sanitizeNetworkType } from '../../network-config'
 import { noop } from '../../utils'
@@ -11,25 +10,8 @@ import airdrop, { testTokensEnabled } from '../../testnet/airdrop'
 import Option from './Option'
 import Note from './Note'
 
-const LinkButton = styled(Button.Anchor).attrs({
-  compact: true,
-  mode: 'outline',
-})`
-  background: ${theme.contentBackground};
-`
-
 const AppsList = styled.ul`
   list-style: none;
-`
-
-const FieldTwoParts = styled.div`
-  display: flex;
-  align-items: center;
-  input {
-    margin-right: 10px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-  }
 `
 
 class DaoSettings extends React.Component {
@@ -74,18 +56,7 @@ class DaoSettings extends React.Component {
           text={`This organization is deployed on the ${network.name}.`}
         >
           <Field label="Address" style={{ marginBottom: 0 }}>
-            <FieldTwoParts>
-              <TextInput readOnly wide value={checksummedDaoAddr} />
-              <EtherscanLink address={checksummedDaoAddr}>
-                {url =>
-                  url ? (
-                    <LinkButton href={url} target="_blank">
-                      See on Etherscan
-                    </LinkButton>
-                  ) : null
-                }
-              </EtherscanLink>
-            </FieldTwoParts>
+            <IdentityBadge entity={checksummedDaoAddr} shorten={false} />
             <Note>
               <strong>Do not send ether or tokens to this address!</strong>
               <br />
@@ -149,22 +120,10 @@ class DaoSettings extends React.Component {
                 return (
                   <li title={description} key={checksummedProxyAddress}>
                     <Field label={name}>
-                      <FieldTwoParts>
-                        <TextInput
-                          readOnly
-                          wide
-                          value={checksummedProxyAddress}
-                        />
-                        <EtherscanLink address={checksummedProxyAddress}>
-                          {url =>
-                            url ? (
-                              <LinkButton href={url} target="_blank">
-                                See on Etherscan
-                              </LinkButton>
-                            ) : null
-                          }
-                        </EtherscanLink>
-                      </FieldTwoParts>
+                      <IdentityBadge
+                        entity={checksummedProxyAddress}
+                        shorten={false}
+                      />
                     </Field>
                   </li>
                 )


### PR DESCRIPTION
Removed about 15 lines of code thanks to this!

Also using `IdentityBadge` has the advantage that we can abstract over Etherscan/any other Ethereum block explorer we use, and not show the user a huge _See on Etherscan_ link

![image](https://user-images.githubusercontent.com/718208/49328622-2b85ca80-f574-11e8-93d4-91778d2a213d.png)
