### PR TITLE
Remove the rinkeby-specific error when a DAO is not found

### DIFF
--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -1,29 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import { SafeLink, theme, Button } from '@aragon/ui'
+import { theme, Button } from '@aragon/ui'
 import ErrorCard from './ErrorCard'
 import { network } from '../../environment'
 import { isAddress } from '../../web3-utils'
 
-const { accent } = theme
-
-const CURRENT_DOMAIN = 'app.aragon.org'
-const OLD_DAO_DOMAIN = 'app-v05.aragon.org'
-const DEPRECATION_URL =
-  'https://blog.aragon.org/deprecation-notice-on-v0-5-rinkeby-daos'
-
 const DAONotFoundError = ({ dao }) => (
   <ErrorCard title="Organization not found">
-    {network.type === 'rinkeby' ? (
-      <RinkebyDAONotFoundContent dao={dao} />
-    ) : (
-      <GenericDAONotFoundContent />
-    )}
-  </ErrorCard>
-)
-
-const GenericDAONotFoundContent = ({ dao }) => (
-  <React.Fragment>
     <Paragraph>
       It looks like there's no organization associated with that{' '}
       {isAddress(dao) ? 'address' : 'name'} on the current network (
@@ -35,11 +18,8 @@ const GenericDAONotFoundContent = ({ dao }) => (
       the correct link.
     </Paragraph>
     <Paragraph>
-      Alternatively, you may create a new organization at{' '}
-      <StyledSafeLink href={`https://${CURRENT_DOMAIN}`} target="_blank">
-        {CURRENT_DOMAIN}
-      </StyledSafeLink>
-      .
+      Alternatively, you may{' '}
+      <StyledLink href="/">create a new organization</StyledLink>.
     </Paragraph>
     <ButtonBox>
       <IssueLink mode="text" href="/" style={{ color: theme.textSecondary }}>
@@ -56,38 +36,7 @@ const GenericDAONotFoundContent = ({ dao }) => (
         Try again
       </Button>
     </ButtonBox>
-  </React.Fragment>
-)
-
-const RinkebyDAONotFoundContent = ({ dao }) => (
-  <React.Fragment>
-    <Paragraph>
-      Rinkeby organizations created with Aragon Core 0.5 were deprecated on{' '}
-      <time dateTime="2018-10-29">Oct. 29, 2018</time> due to{' '}
-      <StyledSafeLink href={DEPRECATION_URL} target="_blank">
-        underlying smart contract upgrades with aragonOS
-      </StyledSafeLink>
-      .
-    </Paragraph>
-    <Paragraph>
-      If you were trying to access an organization created before{' '}
-      <time dateTime="2018-10-29">Oct. 29, 2018</time>, you can access it at{' '}
-      <StyledSafeLink
-        href={`https://${OLD_DAO_DOMAIN}/${dao ? `#/${dao}` : ''}`}
-        target="_blank"
-      >
-        {OLD_DAO_DOMAIN}
-      </StyledSafeLink>{' '}
-      until <time dateTime="2019-03">March, 2019</time>.
-    </Paragraph>
-    <Paragraph>
-      However, we recommend creating a new organization at{' '}
-      <StyledSafeLink href={`https://${CURRENT_DOMAIN}`} target="_blank">
-        {CURRENT_DOMAIN}
-      </StyledSafeLink>
-      .
-    </Paragraph>
-  </React.Fragment>
+  </ErrorCard>
 )
 
 const Paragraph = styled.p`
@@ -96,9 +45,9 @@ const Paragraph = styled.p`
   }
 `
 
-const StyledSafeLink = styled(SafeLink)`
-  text-decoration-color: ${accent};
-  color: ${accent};
+const StyledLink = styled.a`
+  text-decoration-color: ${theme.accent};
+  color: ${theme.accent};
 `
 
 const ButtonsSpacer = styled.span`


### PR DESCRIPTION
- Remove the Rinkeby warning.
- On the DAO not found screen, replace `app.aragon.org` by `/`.