### PR TITLE
Allow location hash updates after a fatal error

### DIFF
--- a/src/GlobalErrorHandler.js
+++ b/src/GlobalErrorHandler.js
@@ -13,6 +13,19 @@ class GlobalErrorHandler extends React.Component {
         .replace(/^\n+|\n+$/g, '')
         .replace(/^ {4}/gm, ''),
     })
+
+    // Once this point is reached, the app can not recover because the routing
+    // system, being below this component in the tree, is not functional
+    // anymore. To make hash changes work despite this (e.g. by pressing the
+    // back button in the browser), the page need to be reloaded.
+    window.removeEventListener('hashchange', this.handleHashchange)
+    window.addEventListener('hashchange', this.handleHashchange)
+  }
+  componentWillUnmount() {
+    window.removeEventListener('hashchange', this.handleHashchange)
+  }
+  handleHashchange = () => {
+    window.location.reload()
   }
   render() {
     const { error, errorStack } = this.state


### PR DESCRIPTION
One of the most common reasons an app crashes is when an organization domain can not be resolved, either because it doesn’t exist or because the connection fails. Because it is handled using a a global error, everything stops working, including the routing system, and the user can’t use the back button of the browser or update the URL.

For the specific case of resolving an organization domain, the error need to be handled gracefully rather than using a fatal error (we used to have one for this case − https://github.com/aragon/aragon/pull/365). But for other cases, it would still be useful to react to URL changes, which is what this PR does (by reloading the page).

Note: another solution would be to move the router outside of the global error handler. It could also be an opportunity to pass the current route using a React context.
