### PR TITLE
Settings: use the current network on identity badges

### DIFF
--- a/src/apps/Settings/DaoSettings.js
+++ b/src/apps/Settings/DaoSettings.js
@@ -56,7 +56,11 @@ class DaoSettings extends React.Component {
           text={`This organization is deployed on the ${network.name}.`}
         >
           <Field label="Address" style={{ marginBottom: 0 }}>
-            <IdentityBadge entity={checksummedDaoAddr} shorten={false} />
+            <IdentityBadge
+              entity={checksummedDaoAddr}
+              networkType={network.type}
+              shorten={false}
+            />
             <Note>
               <strong>Do not send ether or tokens to this address!</strong>
               <br />
@@ -122,6 +126,7 @@ class DaoSettings extends React.Component {
                     <Field label={name}>
                       <IdentityBadge
                         entity={checksummedProxyAddress}
+                        networkType={network.type}
                         shorten={false}
                       />
                     </Field>


### PR DESCRIPTION
Oops, otherwise the links will always link to a mainnet block explorer.

cc @luisivan the other changes involving `IdentityBadge`s may also require this.