### PR TITLE
SignerPanel: fix RadioList select handler

### DIFF
--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -97,7 +97,7 @@ class ActionPathsContent extends React.Component {
                     : 'You can perform this action through:'
                 }
                 items={radioItems}
-                onChange={this.handleOnSelect}
+                onSelect={this.handleOnSelect}
                 selected={selected}
               />
             </Actions>


### PR DESCRIPTION
Oops 😅. Turns out this was using the wrong handler the whole time (never detected because we never show more than one transaction path).

See https://github.com/aragon/aragon-ui/blob/master/src/components/Radio/RadioListItem.js#L33.