### PR TITLE
Responsive menu panel for wrapper and iframe apps

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import { getWeb3, getUnknownBalance, identifyProvider } from './web3-utils'
 import { log } from './utils'
 import { PermissionsProvider } from './contexts/PermissionsContext'
 import { FavoriteDaosProvider } from './contexts/FavoriteDaosContext'
+import { ScreenSizeProvider } from './contexts/ScreenSize'
 import { ModalProvider } from './components/ModalManager/ModalManager'
 import DeprecatedBanner from './components/DeprecatedBanner/DeprecatedBanner'
 import {
@@ -303,48 +304,50 @@ class App extends React.Component {
     return (
       <ModalProvider>
         <FavoriteDaosProvider>
-          <PermissionsProvider
-            wrapper={wrapper}
-            apps={apps}
-            permissions={permissions}
-          >
-            <Wrapper
-              banner={showDeprecatedBanner && <DeprecatedBanner dao={dao} />}
-              historyBack={this.historyBack}
-              historyPush={this.historyPush}
-              locator={locator}
+          <ScreenSizeProvider>
+            <PermissionsProvider
               wrapper={wrapper}
               apps={apps}
-              appsStatus={appsStatus}
-              permissionsLoading={permissionsLoading}
-              account={account}
-              walletNetwork={walletNetwork}
-              walletWeb3={walletWeb3}
-              daoAddress={daoAddress}
-              transactionBag={transactionBag}
-              connected={connected}
-              onRequestAppsReload={this.handleRequestAppsReload}
-            />
-          </PermissionsProvider>
+              permissions={permissions}
+            >
+              <Wrapper
+                banner={showDeprecatedBanner && <DeprecatedBanner dao={dao} />}
+                historyBack={this.historyBack}
+                historyPush={this.historyPush}
+                locator={locator}
+                wrapper={wrapper}
+                apps={apps}
+                appsStatus={appsStatus}
+                permissionsLoading={permissionsLoading}
+                account={account}
+                walletNetwork={walletNetwork}
+                walletWeb3={walletWeb3}
+                daoAddress={daoAddress}
+                transactionBag={transactionBag}
+                connected={connected}
+                onRequestAppsReload={this.handleRequestAppsReload}
+              />
+            </PermissionsProvider>
 
-          <Onboarding
-            banner={
-              showDeprecatedBanner && <DeprecatedBanner dao={dao} lightMode />
-            }
-            visible={mode === 'home' || mode === 'setup'}
-            account={account}
-            balance={balance}
-            walletNetwork={walletNetwork}
-            walletProviderId={walletProviderId}
-            onBuildDao={this.handleBuildDao}
-            daoCreationStatus={daoCreationStatus}
-            onComplete={this.handleCompleteOnboarding}
-            onOpenOrganization={this.handleOpenOrganization}
-            onResetDaoBuilder={this.handleResetDaoBuilder}
-            onRequestEnable={this.handleRequestEnable}
-            selectorNetworks={selectorNetworks}
-            walletWeb3={walletWeb3}
-          />
+            <Onboarding
+              banner={
+                showDeprecatedBanner && <DeprecatedBanner dao={dao} lightMode />
+              }
+              visible={mode === 'home' || mode === 'setup'}
+              account={account}
+              balance={balance}
+              walletNetwork={walletNetwork}
+              walletProviderId={walletProviderId}
+              onBuildDao={this.handleBuildDao}
+              daoCreationStatus={daoCreationStatus}
+              onComplete={this.handleCompleteOnboarding}
+              onOpenOrganization={this.handleOpenOrganization}
+              onResetDaoBuilder={this.handleResetDaoBuilder}
+              onRequestEnable={this.handleRequestEnable}
+              selectorNetworks={selectorNetworks}
+              walletWeb3={walletWeb3}
+            />
+          </ScreenSizeProvider>
         </FavoriteDaosProvider>
       </ModalProvider>
     )

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Apps, Permissions, Settings } from './apps'
 import ethereumLoadingAnimation from './assets/ethereum-loading.svg'
+import { ScreenSizeConsumer, SMALL } from './contexts/ScreenSize'
 import AppIFrame from './components/App/AppIFrame'
 import App404 from './components/App404/App404'
 import Home from './components/Home/Home'
@@ -13,7 +14,7 @@ import { DaoAddressType } from './prop-types'
 import { getAppPath } from './routing'
 import { staticApps } from './static-apps'
 import { addressesEqual } from './web3-utils'
-import { noop, isMobile } from './utils'
+import { noop } from './utils'
 import {
   APPS_STATUS_ERROR,
   APPS_STATUS_READY,
@@ -42,6 +43,7 @@ class Wrapper extends React.Component {
     locator: PropTypes.object.isRequired,
     onRequestAppsReload: PropTypes.func.isRequired,
     permissionsLoading: PropTypes.bool.isRequired,
+    screenSize: PropTypes.symbol.isRequired,
     transactionBag: PropTypes.object,
     walletNetwork: PropTypes.string.isRequired,
     walletWeb3: PropTypes.object,
@@ -68,10 +70,10 @@ class Wrapper extends React.Component {
   }
   state = {
     appInstance: {},
-    menuPanelOpened: !isMobile(),
+    menuPanelOpened: this.props.screenSize !== SMALL,
   }
   openApp = (instanceId, params) => {
-    if (isMobile()) {
+    if (this.props.screenSize === SMALL) {
       this.handleMenuPanelClose()
     }
 
@@ -311,4 +313,8 @@ const LoadingApps = () => (
   </div>
 )
 
-export default Wrapper
+export default props => (
+  <ScreenSizeConsumer>
+    {({ screenSize }) => <Wrapper {...props} screenSize={screenSize} />}
+  </ScreenSizeConsumer>
+)

--- a/src/apps/Apps/Apps.js
+++ b/src/apps/Apps/Apps.js
@@ -125,7 +125,14 @@ const AppsGrid = styled.div`
   grid-auto-flow: row;
   grid-gap: 25px;
   justify-items: start;
-  grid-template-columns: repeat(auto-fill, 224px);
+  grid-template-columns: 1fr;
+
+  ${breakpoint(
+    'medium',
+    `
+      grid-template-columns: repeat(auto-fill, 224px);
+    `
+  )};
 `
 
 const Main = styled(Card).attrs({ width: '100%', height: '288px' })`

--- a/src/apps/Apps/Apps.js
+++ b/src/apps/Apps/Apps.js
@@ -9,18 +9,35 @@ import {
   theme,
   colors,
   unselectable,
+  font,
+  breakpoint,
+  BreakPoint,
 } from '@aragon/ui'
 import AppLayout from '../../components/AppLayout/AppLayout'
+import MenuButton from '../../components/MenuPanel/MenuButton'
 
 import defaultIcon from './icons/default.png'
 import payrollIcon from './icons/payroll.png'
 import espressoIcon from './icons/espresso.png'
 
 class Apps extends React.Component {
+  handleMenuPanelOpen = () => {
+    this.props.onMessage({
+      data: { from: 'app', name: 'menuPanel', value: true },
+    })
+  }
+
   render() {
     return (
       <AppLayout
-        title="Apps"
+        title={
+          <AppBarTitle>
+            <BreakPoint to="medium">
+              <MenuButton onClick={this.handleMenuPanelOpen} />
+            </BreakPoint>
+            <AppBarLabel>Apps</AppBarLabel>
+          </AppBarTitle>
+        }
         endContent={
           <DevPortalAnchor
             mode="strong"
@@ -71,6 +88,24 @@ class Apps extends React.Component {
     )
   }
 }
+
+const AppBarTitle = styled.span`
+  display: flex;
+  align-items: center;
+  margin-left: -30px;
+`
+
+const AppBarLabel = styled.span`
+  margin-left: 8px;
+  ${font({ size: 'xxlarge' })};
+
+  ${breakpoint(
+    'medium',
+    `
+      margin-left: 24px;
+    `
+  )};
+`
 
 const DevPortalAnchor = styled(Button.Anchor)`
   display: block;

--- a/src/apps/Permissions/Permissions.js
+++ b/src/apps/Permissions/Permissions.js
@@ -1,7 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { AppBar, AppView, NavigationBar, Button, BreakPoint } from '@aragon/ui'
+import {
+  AppBar,
+  AppView,
+  NavigationBar,
+  Button,
+  font,
+  breakpoint,
+  BreakPoint,
+} from '@aragon/ui'
 import { addressesEqual, shortenAddress, isAddress } from '../../web3-utils'
 import Screen from './Screen'
 import Home from './Home/Home'
@@ -10,6 +18,7 @@ import EntityPermissions from './EntityPermissions'
 import NavigationItem from './NavigationItem'
 import AssignPermissionPanel from './AssignPermissionPanel'
 import ManageRolePanel from './ManageRolePanel'
+import MenuButton from '../../components/MenuPanel/MenuButton'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
 
 class Permissions extends React.Component {
@@ -200,18 +209,6 @@ class Permissions extends React.Component {
               <AppView
                 appBar={
                   <AppBar
-                    title={
-                      <BreakPoint to="medium">
-                        {navigationItems.length === 1 && (
-                          <React.Fragment>
-                            <button onClick={this.handleMenuPanelOpen}>
-                              M
-                            </button>
-                            Permissions
-                          </React.Fragment>
-                        )}
-                      </BreakPoint>
-                    }
                     endContent={
                       <Button
                         mode="strong"
@@ -222,6 +219,19 @@ class Permissions extends React.Component {
                       </Button>
                     }
                   >
+                    <BreakPoint to="medium">
+                      {navigationItems.length === 1 ? (
+                        <AppBarTitle>
+                          <MenuButton onClick={this.handleMenuPanelOpen} />
+                          <AppBarLabel>Permissions</AppBarLabel>
+                        </AppBarTitle>
+                      ) : (
+                        <NavigationBar
+                          items={navigationItems}
+                          onBack={this.goToHome}
+                        />
+                      )}
+                    </BreakPoint>
                     <BreakPoint from="medium">
                       <NavigationBar
                         items={navigationItems}
@@ -303,6 +313,23 @@ class Permissions extends React.Component {
     )
   }
 }
+
+const AppBarTitle = styled.span`
+  display: flex;
+  align-items: center;
+`
+
+const AppBarLabel = styled.span`
+  margin: 0 10px 0 8px;
+  ${font({ size: 'xxlarge' })};
+
+  ${breakpoint(
+    'medium',
+    `
+      margin-left: 24px;
+    `
+  )};
+`
 
 // This element is only used to reset the view scroll using scrollIntoView()
 const ScrollTopElement = styled.div`

--- a/src/apps/Permissions/Permissions.js
+++ b/src/apps/Permissions/Permissions.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { AppBar, AppView, NavigationBar, Button } from '@aragon/ui'
+import { AppBar, AppView, NavigationBar, Button, BreakPoint } from '@aragon/ui'
 import { addressesEqual, shortenAddress, isAddress } from '../../web3-utils'
 import Screen from './Screen'
 import Home from './Home/Home'
@@ -119,6 +119,12 @@ class Permissions extends React.Component {
     }
   }
 
+  handleMenuPanelOpen = () => {
+    this.props.onMessage({
+      data: { from: 'app', name: 'menuPanel', value: true },
+    })
+  }
+
   // Assemble the navigation items
   getNavigationItems(location, resolveEntity) {
     const items = ['Permissions']
@@ -194,6 +200,18 @@ class Permissions extends React.Component {
               <AppView
                 appBar={
                   <AppBar
+                    title={
+                      <BreakPoint to="medium">
+                        {navigationItems.length === 1 && (
+                          <React.Fragment>
+                            <button onClick={this.handleMenuPanelOpen}>
+                              M
+                            </button>
+                            Permissions
+                          </React.Fragment>
+                        )}
+                      </BreakPoint>
+                    }
                     endContent={
                       <Button
                         mode="strong"
@@ -204,10 +222,12 @@ class Permissions extends React.Component {
                       </Button>
                     }
                   >
-                    <NavigationBar
-                      items={navigationItems}
-                      onBack={this.goToHome}
-                    />
+                    <BreakPoint from="medium">
+                      <NavigationBar
+                        items={navigationItems}
+                        onBack={this.goToHome}
+                      />
+                    </BreakPoint>
                   </AppBar>
                 }
               >

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -1,8 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { DropDown, Button, Field, TextInput } from '@aragon/ui'
+import {
+  DropDown,
+  Button,
+  Field,
+  TextInput,
+  font,
+  breakpoint,
+  BreakPoint,
+} from '@aragon/ui'
 import AppLayout from '../../components/AppLayout/AppLayout'
+import MenuButton from '../../components/MenuPanel/MenuButton'
 import { defaultEthNode, ipfsDefaultConf } from '../../environment'
 import {
   getSelectedCurrency,
@@ -74,6 +83,13 @@ class Settings extends React.Component {
     window.localStorage.clear()
     window.location.reload()
   }
+
+  handleMenuPanelOpen = () => {
+    this.props.onMessage({
+      data: { from: 'app', name: 'menuPanel', value: true },
+    })
+  }
+
   render() {
     const {
       account,
@@ -90,7 +106,16 @@ class Settings extends React.Component {
       selectedCurrency,
     } = this.state
     return (
-      <AppLayout title="Settings">
+      <AppLayout
+        title={
+          <AppBarTitle>
+            <BreakPoint to="medium">
+              <MenuButton onClick={this.handleMenuPanelOpen} />
+            </BreakPoint>
+            <AppBarLabel>Settings</AppBarLabel>
+          </AppBarTitle>
+        }
+      >
         <Content>
           <DaoSettings
             apps={apps}
@@ -164,5 +189,23 @@ class Settings extends React.Component {
     )
   }
 }
+
+const AppBarTitle = styled.span`
+  display: flex;
+  align-items: center;
+  margin-left: -30px;
+`
+
+const AppBarLabel = styled.span`
+  margin-left: 8px;
+  ${font({ size: 'xxlarge' })};
+
+  ${breakpoint(
+    'medium',
+    `
+      margin-left: 24px;
+    `
+  )};
+`
 
 export default Settings

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
-import { theme, AppView, Text } from '@aragon/ui'
+import { theme, AppView, Text, BreakPoint } from '@aragon/ui'
 import HomeCard from './HomeCard'
 import { lerp } from '../../math-utils'
 import springs from '../../springs'
@@ -50,6 +50,7 @@ class Home extends React.Component {
     apps: PropTypes.array.isRequired,
     appsLoading: PropTypes.bool.isRequired,
     locator: PropTypes.object.isRequired,
+    onMessage: PropTypes.func.isRequired,
     onOpenApp: PropTypes.func.isRequired,
   }
 
@@ -87,6 +88,11 @@ class Home extends React.Component {
       onOpenApp(app.proxyAddress)
     }
   }
+  handleMenuPanelOpen = () => {
+    this.props.onMessage({
+      data: { from: 'app', name: 'menuPanel', value: true },
+    })
+  }
   render() {
     const { apps, locator } = this.props
     const { showApps } = this.state
@@ -97,7 +103,16 @@ class Home extends React.Component {
     return (
       <Main>
         <AppContent>
-          <AppView title="Home">
+          <AppView
+            title={
+              <React.Fragment>
+                <BreakPoint to="medium">
+                  <button onClick={this.handleMenuPanelOpen}>M</button>
+                </BreakPoint>
+                Home
+              </React.Fragment>
+            }
+          >
             <Spring
               config={springs.lazy}
               to={{ showAppsProgress: Number(showApps) }}

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -2,10 +2,19 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
-import { theme, AppView, Text, BreakPoint } from '@aragon/ui'
+import {
+  theme,
+  AppView,
+  AppBar,
+  Text,
+  font,
+  breakpoint,
+  BreakPoint,
+} from '@aragon/ui'
 import HomeCard from './HomeCard'
 import { lerp } from '../../math-utils'
 import springs from '../../springs'
+import MenuButton from '../MenuPanel/MenuButton'
 
 import logo from './assets/logo-background.svg'
 
@@ -104,13 +113,15 @@ class Home extends React.Component {
       <Main>
         <AppContent>
           <AppView
-            title={
-              <React.Fragment>
-                <BreakPoint to="medium">
-                  <button onClick={this.handleMenuPanelOpen}>M</button>
-                </BreakPoint>
-                Home
-              </React.Fragment>
+            appBar={
+              <AppBar>
+                <AppBarTitle>
+                  <BreakPoint to="medium">
+                    <MenuButton onClick={this.handleMenuPanelOpen} />
+                  </BreakPoint>
+                  <AppBarLabel>Home</AppBarLabel>
+                </AppBarTitle>
+              </AppBar>
             }
           >
             <Spring
@@ -173,6 +184,23 @@ class Home extends React.Component {
     )
   }
 }
+
+const AppBarTitle = styled.span`
+  display: flex;
+  align-items: center;
+`
+
+const AppBarLabel = styled.span`
+  margin-left: 8px;
+  ${font({ size: 'xxlarge' })};
+
+  ${breakpoint(
+    'medium',
+    `
+      margin-left: 24px;
+    `
+  )};
+`
 
 const Main = styled.div`
   display: flex;

--- a/src/components/MenuPanel/MenuButton.js
+++ b/src/components/MenuPanel/MenuButton.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { theme } from '@aragon/ui'
+import IconMenu from '../../icons/IconMenu'
+
+const StyledButton = styled.button`
+  border: none;
+  background: none;
+  margin-left: 24px;
+  height: 32px;
+  width: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+
+  &:focus {
+    border: 2px solid ${theme.accent};
+  }
+  &:active {
+    border: none;
+  }
+`
+
+export default props => (
+  <StyledButton {...props}>
+    <IconMenu />
+  </StyledButton>
+)

--- a/src/contexts/ScreenSize.js
+++ b/src/contexts/ScreenSize.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { BreakPoint } from '@aragon/ui'
+
+const SMALL = Symbol('small')
+const MEDIUM = Symbol('medium')
+const LARGE = Symbol('large')
+
+const { Provider, Consumer } = React.createContext()
+
+const ScreenSizeProvider = ({ children }) => (
+  <React.Fragment>
+    <BreakPoint to="medium">
+      <Provider value={{ screenSize: SMALL }}>{children}</Provider>
+    </BreakPoint>
+    <BreakPoint from="medium" to="large">
+      <Provider value={{ screenSize: MEDIUM }}>{children}</Provider>
+    </BreakPoint>
+    <BreakPoint from="large">
+      <Provider value={{ screenSize: LARGE }}>{children}</Provider>
+    </BreakPoint>
+  </React.Fragment>
+)
+
+ScreenSizeProvider.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.array]).isRequired,
+}
+
+export { SMALL, MEDIUM, LARGE }
+export { ScreenSizeProvider, Consumer as ScreenSizeConsumer }

--- a/src/icons/IconMenu.js
+++ b/src/icons/IconMenu.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Menu = props => (
+  <svg width="18px" height="14px" viewBox="0 0 18 14" {...props}>
+    <g transform="translate(-19, -25)" stroke="currentColor">
+      <g transform="translate(20, 25)">
+        <path d="M0,1 L16,1" />
+        <path d="M0,7 L16,7" />
+        <path d="M0,13 L16,13" />
+      </g>
+    </g>
+  </svg>
+)
+
+export default Menu

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1, user-scalable=no">
     <link rel="shortcut icon" type="image/svg+xml" href="./assets/favicon.svg">
     <link rel="shortcut icon" type="image/png" href="./assets/favicon.png">
     <title>Aragon</title>

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -573,7 +573,7 @@ class Onboarding extends React.PureComponent {
 
 const Main = styled(animated.div)`
   position: fixed;
-  z-index: 2;
+  z-index: 3;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
These changes include a mechanism for apps (both wrapper/local apps and iframe apps) to communicate their intention to open/close the `MenuPanel`.
Iframe apps use `postMessage` while local apps use the same interface but don't actually post any message.

There is still plenty to do but I wanted to get a couple eyes to review the proposed solution.

This [PR](https://github.com/aragon/aragon-apps/pull/606) shows how the _iframed_ apps would interact with this behavior.

<!--- 
![responsive-menu-panel](https://user-images.githubusercontent.com/3072458/49735990-20741e00-fc89-11e8-8d3e-9f18eccdfea8.gif)
--->

![responsive-menu-panel-static-apps-menu-button](https://user-images.githubusercontent.com/3072458/49860262-c8105e00-fdf9-11e8-9638-47f8a5096a64.gif)
