### PR TITLE
WalletWeb3: always pass down resolved instance rather than use environment's

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -333,6 +333,7 @@ class App extends React.Component {
           onResetDaoBuilder={this.handleResetDaoBuilder}
           onRequestEnable={this.handleRequestEnable}
           selectorNetworks={selectorNetworks}
+          walletWeb3={walletWeb3}
         />
       </ModalProvider>
     )

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -52,8 +52,8 @@ class Wrapper extends React.Component {
   static defaultProps = {
     onRequestEnable: noop,
     transactionBag: null,
-    walletWeb3: null,
     walletProviderId: '',
+    walletWeb3: null,
     wrapper: null,
   }
   state = {
@@ -113,17 +113,17 @@ class Wrapper extends React.Component {
     const {
       account,
       apps,
-      walletWeb3,
+      appsStatus,
+      banner,
+      connected,
+      locator: { instanceId, params },
+      onRequestAppsReload,
+      onRequestEnable,
+      transactionBag,
       walletNetwork,
       walletProviderId,
+      walletWeb3,
       wrapper,
-      appsStatus,
-      locator: { instanceId, params },
-      connected,
-      banner,
-      onRequestAppsReload,
-      transactionBag,
-      onRequestEnable,
     } = this.props
 
     return (
@@ -157,15 +157,16 @@ class Wrapper extends React.Component {
   }
   renderApp(instanceId, params) {
     const {
-      locator,
+      account,
       apps,
       appsStatus,
-      permissionsLoading,
-      account,
-      walletNetwork,
-      wrapper,
       connected,
       daoAddress,
+      locator,
+      permissionsLoading,
+      walletNetwork,
+      walletWeb3,
+      wrapper,
     } = this.props
 
     const appsLoading = appsStatus === APPS_STATUS_LOADING
@@ -206,6 +207,7 @@ class Wrapper extends React.Component {
           daoAddress={daoAddress}
           onOpenApp={this.openApp}
           walletNetwork={walletNetwork}
+          walletWeb3={walletWeb3}
         />
       )
     }

--- a/src/apps/Settings/DaoSettings.js
+++ b/src/apps/Settings/DaoSettings.js
@@ -2,10 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Button, Field, Text, IdentityBadge } from '@aragon/ui'
-import { appIds, network, web3Providers } from '../../environment'
+import { appIds, network } from '../../environment'
 import { sanitizeNetworkType } from '../../network-config'
-import { noop } from '../../utils'
-import { getWeb3, toChecksumAddress } from '../../web3-utils'
+import { toChecksumAddress } from '../../web3-utils'
 import airdrop, { testTokensEnabled } from '../../testnet/airdrop'
 import Option from './Option'
 import Note from './Note'
@@ -21,19 +20,13 @@ class DaoSettings extends React.Component {
     daoAddress: PropTypes.string.isRequired,
     onOpenApp: PropTypes.func.isRequired,
     walletNetwork: PropTypes.string.isRequired,
-  }
-
-  static defaultProps = {
-    account: '',
-    apps: [],
-    daoAddress: '',
-    onOpenApp: noop,
+    walletWeb3: PropTypes.object,
   }
   handleDepositTestTokens = () => {
-    const { account, apps } = this.props
+    const { account, apps, walletWeb3 } = this.props
     const finance = apps.find(app => app.appId === appIds.Finance)
     if (finance && finance.proxyAddress) {
-      airdrop(getWeb3(web3Providers.wallet), finance.proxyAddress, account)
+      airdrop(walletWeb3, finance.proxyAddress, account)
     }
   }
   handleOpenFinance = () => {

--- a/src/apps/Settings/Settings.js
+++ b/src/apps/Settings/Settings.js
@@ -10,7 +10,6 @@ import {
   setIpfsGateway,
   setSelectedCurrency,
 } from '../../local-settings'
-import { noop } from '../../utils'
 import DaoSettings from './DaoSettings'
 import Option from './Option'
 import Note from './Note'
@@ -38,13 +37,7 @@ class Settings extends React.Component {
     daoAddress: PropTypes.string.isRequired,
     onOpenApp: PropTypes.func.isRequired,
     walletNetwork: PropTypes.string.isRequired,
-  }
-
-  static defaultProps = {
-    account: '',
-    apps: [],
-    daoAddress: '',
-    onOpenApp: noop,
+    walletWeb3: PropTypes.object,
   }
   state = {
     defaultEthNode,
@@ -74,7 +67,14 @@ class Settings extends React.Component {
     window.location.reload()
   }
   render() {
-    const { account, apps, daoAddress, onOpenApp, walletNetwork } = this.props
+    const {
+      account,
+      apps,
+      daoAddress,
+      onOpenApp,
+      walletNetwork,
+      walletWeb3,
+    } = this.props
     const {
       defaultEthNode,
       ipfsGateway,
@@ -90,6 +90,7 @@ class Settings extends React.Component {
             daoAddress={daoAddress}
             onOpenApp={onOpenApp}
             walletNetwork={walletNetwork}
+            walletWeb3={walletWeb3}
           />
           {currencies.length > 1 && selectedCurrency && (
             <Option

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -66,20 +66,21 @@ class Onboarding extends React.PureComponent {
     selectorNetworks: PropTypes.array.isRequired,
     visible: PropTypes.bool.isRequired,
     walletNetwork: PropTypes.string.isRequired,
+    walletWeb3: PropTypes.object,
   }
 
   static defaultProps = {
     account: '',
     balance: getUnknownBalance(),
-    walletNetwork: '',
-    visible: true,
+    banner: null,
     daoCreationStatus: DAO_CREATION_STATUS_NONE,
     onComplete: noop,
     onBuildDao: noop,
     onOpenOrganization: noop,
     onResetDaoBuilder: noop,
     onRequestEnable: noop,
-    banner: null,
+    visible: true,
+    walletNetwork: '',
     walletProviderId: '',
   }
   state = {
@@ -464,13 +465,14 @@ class Onboarding extends React.PureComponent {
 
     const {
       account,
-      walletNetwork,
-      walletProviderId,
       balance,
       daoCreationStatus,
       onComplete,
       selectorNetworks,
       onRequestEnable,
+      walletNetwork,
+      walletProviderId,
+      walletWeb3,
     } = this.props
 
     // No need to move the screens farther than one step
@@ -497,7 +499,6 @@ class Onboarding extends React.PureComponent {
         <Start
           hasAccount={Boolean(account)}
           balance={balance}
-          walletNetwork={walletNetwork}
           onCreate={this.handleStartCreate}
           onRest={this.handleStartRest}
           domain={domainToOpen}
@@ -507,7 +508,9 @@ class Onboarding extends React.PureComponent {
           onOpenOrganizationAddress={this.handleOpenOrganizationAddress}
           selectorNetworks={selectorNetworks}
           onRequestEnable={onRequestEnable}
+          walletNetwork={walletNetwork}
           walletProviderId={walletProviderId}
+          walletWeb3={walletWeb3}
           {...sharedProps}
         />
       )

--- a/src/onboarding/Start.js
+++ b/src/onboarding/Start.js
@@ -13,7 +13,7 @@ import {
   IconAttention,
 } from '@aragon/ui'
 import { animated } from 'react-spring'
-import { network, web3Providers, getDemoDao } from '../environment'
+import { network, getDemoDao } from '../environment'
 import { sanitizeNetworkType } from '../network-config'
 import { noop } from '../utils'
 import providerString from '../provider-strings'
@@ -38,7 +38,6 @@ const demoDao = getDemoDao()
 
 class Start extends React.Component {
   static defaultProps = {
-    hasAccount: false,
     walletNetwork: '',
     walletProviderId: '',
     balance: getUnknownBalance(),
@@ -70,6 +69,7 @@ class Start extends React.Component {
       selectorNetworks,
       onRequestEnable,
       screenTransitionStyles,
+      walletWeb3,
     } = this.props
 
     return (
@@ -77,7 +77,7 @@ class Start extends React.Component {
         <Content style={screenTransitionStyles}>
           <StartContent
             onCreate={onCreate}
-            hasWallet={!!web3Providers.wallet}
+            hasWallet={Boolean(walletWeb3)}
             hasAccount={hasAccount}
             walletNetwork={walletNetwork}
             walletProviderId={walletProviderId}


### PR DESCRIPTION
Builds on #469 

Always uses the passed down `walletWeb3` instance.

Also removes some unnecessary default props.