### PR TITLE
chore: add ethereum address proptype

### DIFF
--- a/src/apps/Permissions/AppInstanceLabel.js
+++ b/src/apps/Permissions/AppInstanceLabel.js
@@ -4,11 +4,12 @@ import styled from 'styled-components'
 import { Badge } from '@aragon/ui'
 import { shortenAddress } from '../../web3-utils'
 import AppIcon from './AppIcon'
+import { EthereumAddress } from '../../prop-types'
 
 class AppInstanceLabel extends React.PureComponent {
   static propTypes = {
     app: PropTypes.object.isRequired,
-    proxyAddress: PropTypes.string.isRequired,
+    proxyAddress: EthereumAddress.isRequired,
     showIcon: PropTypes.bool,
   }
 

--- a/src/apps/Permissions/AppPermissions.js
+++ b/src/apps/Permissions/AppPermissions.js
@@ -15,10 +15,11 @@ import AppInstanceLabel from './AppInstanceLabel'
 import IdentityBadge from '../../components/IdentityBadge'
 import EntityPermissions from './EntityPermissions'
 import AppRoles from './AppRoles'
+import { EthereumAddress } from '../../prop-types'
 
 class AppPermissions extends React.PureComponent {
   static propTypes = {
-    address: PropTypes.string.isRequired,
+    address: EthereumAddress.isRequired,
     app: PropTypes.object, // may not be available if still loading
     loading: PropTypes.bool.isRequired,
     onManageRole: PropTypes.func.isRequired,
@@ -85,7 +86,7 @@ class Row extends React.Component {
   static propTypes = {
     entity: PropTypes.object.isRequired,
     onRevoke: PropTypes.func.isRequired,
-    proxyAddress: PropTypes.string.isRequired,
+    proxyAddress: EthereumAddress.isRequired,
     role: PropTypes.object.isRequired,
   }
 

--- a/src/apps/Permissions/EntityPermissions.js
+++ b/src/apps/Permissions/EntityPermissions.js
@@ -12,10 +12,11 @@ import Section from './Section'
 import EmptyBlock from './EmptyBlock'
 import AppInstanceLabel from './AppInstanceLabel'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
+import { EthereumAddress } from '../../prop-types'
 
 class EntityPermissions extends React.PureComponent {
   static propTypes = {
-    address: PropTypes.string.isRequired,
+    address: EthereumAddress.isRequired,
     loadPermissionsLabel: PropTypes.string,
     loading: PropTypes.bool.isRequired,
     noPermissionsLabel: PropTypes.string,
@@ -112,9 +113,9 @@ class Row extends React.Component {
 Row.propTypes = {
   action: PropTypes.string.isRequired,
   app: PropTypes.object.isRequired,
-  entityAddress: PropTypes.string.isRequired,
+  entityAddress: EthereumAddress.isRequired,
   onRevoke: PropTypes.func.isRequired,
-  proxyAddress: PropTypes.string.isRequired,
+  proxyAddress: EthereumAddress.isRequired,
   roleBytes: PropTypes.string.isRequired,
 }
 

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -4,13 +4,14 @@ import { DropDown, Field, TextInput } from '@aragon/ui'
 import { getAnyEntity } from '../../permissions'
 import { getEmptyAddress } from '../../web3-utils'
 import AppInstanceLabel from './AppInstanceLabel'
+import { EthereumAddress } from '../../prop-types'
 
 class EntitySelector extends React.Component {
   static propTypes = {
     activeIndex: PropTypes.number.isRequired,
     apps: PropTypes.array.isRequired,
     label: PropTypes.string.isRequired,
-    labelCustomAddress: PropTypes.string.isRequired,
+    labelCustomAddress: EthereumAddress.isRequired,
     onChange: PropTypes.func.isRequired,
   }
 

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -4,14 +4,13 @@ import { DropDown, Field, TextInput } from '@aragon/ui'
 import { getAnyEntity } from '../../permissions'
 import { getEmptyAddress } from '../../web3-utils'
 import AppInstanceLabel from './AppInstanceLabel'
-import { EthereumAddress } from '../../prop-types'
 
 class EntitySelector extends React.Component {
   static propTypes = {
     activeIndex: PropTypes.number.isRequired,
     apps: PropTypes.array.isRequired,
     label: PropTypes.string.isRequired,
-    labelCustomAddress: EthereumAddress.isRequired,
+    labelCustomAddress: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
   }
 

--- a/src/apps/Permissions/NavigationItem.js
+++ b/src/apps/Permissions/NavigationItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Badge } from '@aragon/ui'
 import IdentityBadge from '../../components/IdentityBadge'
+import { EthereumAddress } from '../../prop-types'
 
 const NavigationItem = ({ title, badge, address, entity }) => {
   const isEntity = !badge && address
@@ -20,7 +21,7 @@ const NavigationItem = ({ title, badge, address, entity }) => {
 }
 
 NavigationItem.propTypes = {
-  address: PropTypes.string,
+  address: EthereumAddress,
   badge: PropTypes.object,
   entity: PropTypes.object,
   title: PropTypes.string.isRequired,

--- a/src/components/Identicon.js
+++ b/src/components/Identicon.js
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Blockies from 'react-blockies'
+import { EthereumAddress } from '../prop-types'
 
 const PX_RATIO = typeof devicePixelRatio === 'undefined' ? 2 : devicePixelRatio
 const BLOCKIES_SQUARES = 8
 
 class Identicon extends React.Component {
   static propTypes = {
-    address: PropTypes.string.isRequired,
+    address: EthereumAddress.isRequired,
     scale: PropTypes.number,
   }
   static defaultProps = {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { isAddress } from './web3-utils'
 
 const validatorCreator = nonRequiredFunction => {
   const validator = nonRequiredFunction
@@ -25,7 +26,7 @@ const ethereumAddressValidator = (props, propName, componentName) => {
     return null
   }
 
-  if (!/^0x[a-fA-F0-9]{4}$/.test(value)) {
+  if (!isAddress(value)) {
     const valueType = typeof value
     let nonAddress = null
 

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -44,16 +44,16 @@ export const EthereumAddress = validatorCreator(ethereumAddressValidator)
 
 export const FavoriteDaoType = PropTypes.shape({
   name: PropTypes.string,
-  address: PropTypes.string,
+  address: EthereumAddress,
   favorited: PropTypes.bool,
 })
 
 export const DaoItemType = PropTypes.shape({
   name: PropTypes.string,
-  address: PropTypes.string,
+  address: EthereumAddress,
 })
 
 export const DaoAddressType = PropTypes.shape({
-  address: PropTypes.string,
+  address: EthereumAddress,
   domain: PropTypes.string,
 })

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -1,5 +1,47 @@
 import PropTypes from 'prop-types'
 
+const validatorCreator = nonRequiredFunction => {
+  const validator = nonRequiredFunction
+
+  validator.isRequired = (props, propName, componentName) => {
+    const value = props[propName]
+
+    if (value === null || value === undefined || value === '') {
+      return new Error(
+        `Property ${propName} is required on ${componentName}, but ${value} was given.`
+      )
+    }
+
+    return nonRequiredFunction(props, propName, componentName)
+  }
+
+  return validator
+}
+
+const ethereumAddressValidator = (props, propName, componentName) => {
+  const value = props[propName]
+
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  if (!/^0x[a-fA-F0-9]{4}$/.test(value)) {
+    const valueType = typeof value
+    let nonAddress = null
+
+    if (valueType !== 'object') {
+      nonAddress = value.toString()
+    }
+
+    return new Error(
+      `Invalid prop ${propName} supplied to ${componentName}. The provided value is not a valid ethereum address.${nonAddress &&
+        ` You provided "${nonAddress}"`}`
+    )
+  }
+}
+
+export const EthereumAddress = validatorCreator(ethereumAddressValidator)
+
 export const FavoriteDaoType = PropTypes.shape({
   name: PropTypes.string,
   address: PropTypes.string,


### PR DESCRIPTION
### Description

This PR adds and applies a custom proptype for testing for an ethereum address. Both an optional and `isRequired` version.

### Linked Issue
Fixes #464 

### How
Wanted to minimize impact on repo, so decided to add in the already existing `prop-types.js` file. Let me know if you would prefer me to extract the new logic into self-contained file. I would then like to create a folder to group the new file and `prop-types.js` file together.

### PS
First PR to Aragon, yay! :tada: 
