### PR TITLE
457 block explorer url

### DIFF
--- a/src/components/Etherscan/EtherscanLink.js
+++ b/src/components/Etherscan/EtherscanLink.js
@@ -1,15 +1,18 @@
 import PropTypes from 'prop-types'
 import { network } from '../../environment'
+import { blockExplorerUrl } from '@aragon/ui'
 
-const { etherscanBaseUrl } = network
+const  networkType  = network.type
 
 // Render props component that injects an appropriate Etherscan url if possible
-const EtherscanLink = ({ address, children }) =>
-  children(
-    typeof etherscanBaseUrl === 'string'
-      ? `${etherscanBaseUrl}/address/${address}`
+const EtherscanLink = ({ address, children }) =>{
+  const etherscanUrl = blockExplorerUrl('address', address, { networkType })
+  return children(
+    typeof etherscanUrl === 'string'
+      ? etherscanUrl
       : null
   )
+}
 EtherscanLink.propTypes = {
   children: PropTypes.func.isRequired,
 }

--- a/src/components/Etherscan/EtherscanLink.js
+++ b/src/components/Etherscan/EtherscanLink.js
@@ -7,7 +7,7 @@ const EtherscanLink = ({ address, children }) => {
   const etherscanUrl = blockExplorerUrl('address', address, {
     networkType: network.type,
   })
-  return children(typeof etherscanUrl === 'string' ? etherscanUrl : null)
+  return children(etherscanUrl)
 }
 EtherscanLink.propTypes = {
   children: PropTypes.func.isRequired,

--- a/src/components/Etherscan/EtherscanLink.js
+++ b/src/components/Etherscan/EtherscanLink.js
@@ -2,16 +2,12 @@ import PropTypes from 'prop-types'
 import { network } from '../../environment'
 import { blockExplorerUrl } from '@aragon/ui'
 
-const  networkType  = network.type
+const networkType = network.type
 
 // Render props component that injects an appropriate Etherscan url if possible
-const EtherscanLink = ({ address, children }) =>{
+const EtherscanLink = ({ address, children }) => {
   const etherscanUrl = blockExplorerUrl('address', address, { networkType })
-  return children(
-    typeof etherscanUrl === 'string'
-      ? etherscanUrl
-      : null
-  )
+  return children(typeof etherscanUrl === 'string' ? etherscanUrl : null)
 }
 EtherscanLink.propTypes = {
   children: PropTypes.func.isRequired,

--- a/src/components/Etherscan/EtherscanLink.js
+++ b/src/components/Etherscan/EtherscanLink.js
@@ -2,11 +2,9 @@ import PropTypes from 'prop-types'
 import { network } from '../../environment'
 import { blockExplorerUrl } from '@aragon/ui'
 
-const networkType = network.type
-
 // Render props component that injects an appropriate Etherscan url if possible
 const EtherscanLink = ({ address, children }) => {
-  const etherscanUrl = blockExplorerUrl('address', address, { networkType })
+  const etherscanUrl = blockExplorerUrl('address', address, { networkType: network.type })
   return children(typeof etherscanUrl === 'string' ? etherscanUrl : null)
 }
 EtherscanLink.propTypes = {

--- a/src/components/Etherscan/EtherscanLink.js
+++ b/src/components/Etherscan/EtherscanLink.js
@@ -4,7 +4,9 @@ import { blockExplorerUrl } from '@aragon/ui'
 
 // Render props component that injects an appropriate Etherscan url if possible
 const EtherscanLink = ({ address, children }) => {
-  const etherscanUrl = blockExplorerUrl('address', address, { networkType: network.type })
+  const etherscanUrl = blockExplorerUrl('address', address, {
+    networkType: network.type,
+  })
   return children(typeof etherscanUrl === 'string' ? etherscanUrl : null)
 }
 EtherscanLink.propTypes = {

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -1,5 +1,4 @@
 import { getEnsRegistryAddress } from './local-settings'
-import { makeEtherscanBaseUrl } from './utils'
 
 const localEnsRegistryAddress = getEnsRegistryAddress()
 
@@ -14,7 +13,6 @@ export const networkConfigs = {
     },
     settings: {
       chainId: 1,
-      etherscanBaseUrl: makeEtherscanBaseUrl('main'),
       name: 'Mainnet',
       type: 'main', // as returned by web3.eth.net.getNetworkType()
     },
@@ -29,7 +27,6 @@ export const networkConfigs = {
     },
     settings: {
       chainId: 4,
-      etherscanBaseUrl: makeEtherscanBaseUrl('rinkeby'),
       name: 'Rinkeby testnet',
       type: 'rinkeby', // as returned by web3.eth.net.getNetworkType()
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,18 +20,6 @@ export function appIconUrl(app) {
     : null
 }
 
-export function makeEtherscanBaseUrl(network) {
-  // Don't make etherscan urls if the network isn't one that etherscan supports
-  if (
-    network === 'main' ||
-    network === 'kovan' ||
-    network === 'rinkeby' ||
-    network === 'ropsten'
-  ) {
-    return `https://${network === 'main' ? '' : `${network}.`}etherscan.io`
-  }
-}
-
 export function noop() {}
 
 export function removeStartingSlash(str) {


### PR DESCRIPTION
Fix for issue #457 about start using blockExplorerUrl from aragon/ui instead of makeEtherscanBaseUrl