### PR TITLE
Transactions activity panel

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -186,7 +186,9 @@ class Wrapper extends React.Component {
               open={notificationOpen}
               notifications={notifications}
               onClearAll={this.handleNotificationsCleared}
+              onBlur={this.handleNotificationClicked}
             />
+
             {this.renderApp(locator.instanceId, locator.params)}
           </AppScreen>
         </Container>

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -73,7 +73,20 @@ class Wrapper extends React.Component {
     appInstance: {},
     menuPanelOpened: this.props.screenSize !== SMALL,
     notificationOpen: false,
-    notifications: [],
+    notifications: [
+      {
+        id: '1',
+        type: '',
+        title: 'Vote #9 passed',
+        content: 'A 100 ANT payment to 0xabcd... was executed',
+      },
+      {
+        id: '2',
+        type: 'transaction',
+        title: 'Vote #11 created',
+        content: 'Mint 100 ORG to 0x1234...',
+      },
+    ],
     queuedNotifications: [],
   }
   openApp = (instanceId, params) => {
@@ -137,6 +150,15 @@ class Wrapper extends React.Component {
     }
   }
 
+  handleNotificationClosed = item =>
+    console.log(item) ||
+    this.setState(state => ({
+      ...state,
+      notifications: state.notifications.filter(
+        notification => notification.id !== item.id
+      ),
+    }))
+
   isAppInstalled(instanceId) {
     const { apps } = this.props
     return (
@@ -187,6 +209,7 @@ class Wrapper extends React.Component {
               notifications={notifications}
               onClearAll={this.handleNotificationsCleared}
               onBlur={this.handleNotificationClicked}
+              onNotificationClosed={this.handleNotificationClosed}
             />
 
             {this.renderApp(locator.instanceId, locator.params)}
@@ -201,7 +224,14 @@ class Wrapper extends React.Component {
           walletNetwork={walletNetwork}
           walletProviderId={walletProviderId}
           walletWeb3={walletWeb3}
-          onTransactionSuccess={({ data, name, description, identifier }) =>
+          onTransactionSuccess={({
+            data,
+            name,
+            description,
+            identifier,
+            ...rest
+          }) =>
+            console.log(rest) ||
             this.setState(state => ({
               queuedNotifications: [
                 {

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -81,6 +81,7 @@ class MenuPanel extends React.PureComponent {
       daoAddress,
       onNotificationClicked,
       notifications,
+      notificationOpen,
     } = this.props
     const appGroups = this.getAppGroups(apps)
 
@@ -105,6 +106,7 @@ class MenuPanel extends React.PureComponent {
             <NotificationAlert
               notifications={notifications}
               onClick={onNotificationClicked}
+              notificationOpen={notificationOpen}
             />
           </Header>
           <Content>

--- a/src/components/Notifications/NotificationAlert.js
+++ b/src/components/Notifications/NotificationAlert.js
@@ -11,7 +11,10 @@ export default class NotificationAlert extends React.PureComponent {
     { opened, previousNotifications }
   ) {
     return {
-      opened: !notificationOpen && notifications !== previousNotifications ? false : opened,
+      opened:
+        !notificationOpen && notifications !== previousNotifications
+          ? false
+          : opened,
       previousNotifications: notifications,
     }
   }
@@ -20,7 +23,7 @@ export default class NotificationAlert extends React.PureComponent {
     this.setState({ opened: true })
     this.props.onClick()
   }
-  
+
   render() {
     const show = !this.state.opened && this.props.notifications > 0
     return (

--- a/src/components/Notifications/NotificationAlert.js
+++ b/src/components/Notifications/NotificationAlert.js
@@ -22,8 +22,7 @@ export default class NotificationAlert extends React.PureComponent {
   }
 
   render() {
-    const { notifications, onClick } = this.props
-    const show = !this.state.opened && notifications > 0
+    const show = !this.state.opened && this.props.notifications > 0
     return (
       <div className="actions">
         <IconButton
@@ -55,7 +54,7 @@ export default class NotificationAlert extends React.PureComponent {
                     .interpolate(s => `scale(${s})`),
                 }}
               >
-                {show && notifications}
+                {show && this.props.notifications}
               </Badge>
             )}
           </Spring>

--- a/src/components/Notifications/NotificationAlert.js
+++ b/src/components/Notifications/NotificationAlert.js
@@ -4,32 +4,15 @@ import { Spring, animated } from 'react-spring'
 import { theme, springs, IconNotifications } from '@aragon/ui'
 
 export default class NotificationAlert extends React.PureComponent {
-  state = { opened: false, previousNotifications: 0 }
-
-  static getDerivedStateFromProps(
-    { notifications },
-    { opened, previousNotifications }
-  ) {
-    return {
-      opened: notifications !== previousNotifications ? false : opened,
-      previousNotifications: notifications,
-    }
-  }
-
-  handleClick = () => {
-    this.setState({ opened: true })
-    this.props.onClick()
-  }
-
   render() {
-    const show = !this.state.opened && this.props.notifications > 0
+    const show = this.props.notifications > 0
     return (
-      <div className="actions" style={{ display: 'none' }}>
+      <div className="actions">
         <IconButton
           style={{ height: 22 }}
           role="button"
-          tabindex={0}
-          onClick={this.handleClick}
+          tabIndex="0"
+          onClick={this.props.onClick}
         >
           <IconNotifications />
           <Spring
@@ -66,6 +49,7 @@ export default class NotificationAlert extends React.PureComponent {
 
 const IconButton = styled.span`
   cursor: pointer;
+  outline: 0;
 `
 
 const Badge = styled(animated.div)`

--- a/src/components/Notifications/NotificationAlert.js
+++ b/src/components/Notifications/NotificationAlert.js
@@ -4,15 +4,32 @@ import { Spring, animated } from 'react-spring'
 import { theme, springs, IconNotifications } from '@aragon/ui'
 
 export default class NotificationAlert extends React.PureComponent {
+  state = { opened: false, previousNotifications: 0 }
+
+  static getDerivedStateFromProps(
+    { notificationOpen, notifications },
+    { opened, previousNotifications }
+  ) {
+    return {
+      opened: !notificationOpen && notifications !== previousNotifications ? false : opened,
+      previousNotifications: notifications,
+    }
+  }
+
+  handleClick = () => {
+    this.setState({ opened: true })
+    this.props.onClick()
+  }
+  
   render() {
-    const show = this.props.notifications > 0
+    const show = !this.state.opened && this.props.notifications > 0
     return (
       <div className="actions">
         <IconButton
           style={{ height: 22 }}
           role="button"
           tabIndex="0"
-          onClick={this.props.onClick}
+          onClick={this.handleClick}
         >
           <IconNotifications />
           <Spring
@@ -57,7 +74,7 @@ const Badge = styled(animated.div)`
   font-weight: 600;
   white-space: nowrap;
   color: ${theme.badgeNotificationForeground};
-  background: ${theme.badgeNotificationBackground};
+  background: ${theme.accent};
   overflow: hidden;
   padding-top: 2px;
   letter-spacing: -0.5px;

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -48,7 +48,9 @@ export default class NotificationBar extends React.Component {
                   <Text>Activity</Text>
                 </h1>
                 {count ? (
-                  <Badge.Notification style={{ background: theme.accent }}>{count}</Badge.Notification>
+                  <Badge.Notification style={{ background: theme.accent }}>
+                    {count}
+                  </Badge.Notification>
                 ) : null}
               </div>
               <a href="#" onClick={onClearAll}>

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
-import { Badge } from '@aragon/ui'
+import { theme, Badge } from '@aragon/ui'
 import { NotificationHub, Notification } from './NotificationHub'
 import springs from '../../springs'
 
@@ -24,7 +24,7 @@ export default class NotificationBar extends React.Component {
   }
 
   render() {
-    const { open, notifications, onClearAll } = this.props
+    const { open, notifications, onClearAll, onNotificationClosed } = this.props
     const count = notifications.length
     return (
       <Spring
@@ -44,16 +44,22 @@ export default class NotificationBar extends React.Component {
           >
             <NotificationHeader>
               <div style={{ display: 'flex', alignItems: 'center' }}>
-                <h1 style={{ marginRight: 10 }}><Text>Activity</Text></h1>
+                <h1 style={{ marginRight: 10 }}>
+                  <Text>Activity</Text>
+                </h1>
                 {count ? (
-                  <Badge.Notification>{count}</Badge.Notification>
+                  <Badge.Notification style={{ background: theme.accent }}>{count}</Badge.Notification>
                 ) : null}
               </div>
               <a href="#" onClick={onClearAll}>
                 <Text>Clear All</Text>
               </a>
             </NotificationHeader>
-            <NotificationHub items={notifications} keys={item => item.id}>
+            <NotificationHub
+              items={notifications}
+              keys={item => item.id}
+              onNotificationClosed={onNotificationClosed}
+            >
               {NotificationImpl}
             </NotificationHub>
           </NotificationFrame>
@@ -69,10 +75,7 @@ function NotificationImpl(item, ready) {
   switch (item.type) {
     case 'transaction':
       return (
-        <Notification.Transaction
-          ready={ready}
-          title={item.title}
-        >
+        <Notification.Transaction ready={ready} title={item.title}>
           {payload}
         </Notification.Transaction>
       )

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -44,13 +44,13 @@ export default class NotificationBar extends React.Component {
           >
             <NotificationHeader>
               <div style={{ display: 'flex', alignItems: 'center' }}>
-                <h1 style={{ marginRight: 10 }}>Activity</h1>
+                <h1 style={{ marginRight: 10 }}><Text>Activity</Text></h1>
                 {count ? (
                   <Badge.Notification>{count}</Badge.Notification>
                 ) : null}
               </div>
               <a href="#" onClick={onClearAll}>
-                Clear All
+                <Text>Clear All</Text>
               </a>
             </NotificationHeader>
             <NotificationHub items={notifications} keys={item => item.id}>
@@ -72,7 +72,6 @@ function NotificationImpl(item, ready) {
         <Notification.Transaction
           ready={ready}
           title={item.title}
-          time="10 min ago"
         >
           {payload}
         </Notification.Transaction>
@@ -123,4 +122,8 @@ const NotificationHeader = styled('div')`
     color: #b3b3b3;
     text-align: right;
   }
+`
+
+const Text = styled('span')`
+  vertical-align: sub;
 `

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -17,8 +17,8 @@ export default function NotificationBar({ open, notifications, onClearAll }) {
       {props => (
         <NotificationFrame
           tabIndex={0}
-          /*ref={r => r && open && r.focus()}
-          onBlur={e => notificationOpen && this.handleNotificationPanelClose()}*/
+          /* ref={r => r && open && r.focus()}
+          onBlur={e => notificationOpen && this.handleNotificationPanelClose()} */
           style={{
             transform: props.x.interpolate(x => `translate3d(${x}px,0,0)`),
           }}
@@ -26,9 +26,7 @@ export default function NotificationBar({ open, notifications, onClearAll }) {
           <NotificationHeader>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <h1 style={{ marginRight: 10 }}>Activity</h1>
-              {count ? (
-                <Badge.Notification>{count}</Badge.Notification>
-              ) : null}
+              {count ? <Badge.Notification>{count}</Badge.Notification> : null}
             </div>
             <a href="#" onClick={onClearAll}>
               Clear All

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -15,20 +15,16 @@ export default class NotificationBar extends React.Component {
     setTimeout(() => {
       if (!currentTarget.contains(document.activeElement)) {
         if (this.handler) clearTimeout(this.handler)
-        this.handler = setTimeout(() => this.props.open && this.props.onBlur(), 200)
+        this.handler = setTimeout(
+          () => this.props.open && this.props.onBlur(),
+          200
+        )
       }
     }, 0)
   }
 
   render() {
-    const {
-      open,
-      notifications,
-      onClearAll,
-      onFocus,
-      focusVisible,
-      onBlur,
-    } = this.props
+    const { open, notifications, onClearAll } = this.props
     const count = notifications.length
     return (
       <Spring

--- a/src/components/Notifications/NotificationHub.js
+++ b/src/components/Notifications/NotificationHub.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Spring, Transition, animated } from 'react-spring'
 import styled from 'styled-components'
+import { theme, IconClose } from '@aragon/ui'
 import TimeTag from './TimeTag'
 
 const spring = { tension: 1900, friction: 200, precision: 0.0001, clamp: true }
@@ -8,7 +9,7 @@ const spring = { tension: 1900, friction: 200, precision: 0.0001, clamp: true }
 class NotificationHub extends React.Component {
   state = { ready: {} }
   render() {
-    const { items, keys, children } = this.props
+    const { items, keys, children, onNotificationClosed } = this.props
     return (
       <div>
         <Transition
@@ -29,6 +30,12 @@ class NotificationHub extends React.Component {
         >
           {(item, state) => props => (
             <InnerContainer style={props}>
+              <CloseButton
+                role="button"
+                onClick={() => onNotificationClosed(item)}
+              >
+                <IconClose />
+              </CloseButton>
               {children(item, this.state.ready[keys(item)])}
             </InnerContainer>
           )}
@@ -47,7 +54,7 @@ class Notification extends React.Component {
           <span>{title}</span>
         </h1>
         <h2>
-          <TimeTag />
+          <TimeTag style={{ marginRight: 10 }} />
         </h2>
         <div>{children}</div>
       </Frame>
@@ -81,13 +88,16 @@ Notification.Transaction = class extends React.Component {
                 >
                   {props => (
                     <ProgressBar
-                      style={{ width: props.p.interpolate(p => `${p * 100}%`) }}
+                      style={{
+                        background: theme.accent,
+                        width: props.p.interpolate(p => `${p * 100}%`),
+                      }}
                     />
                   )}
                 </Spring>
               </ProgressTrack>
               <span>Estimated:</span>
-              <span>1 min 40 sec</span>
+              <span>- min -- sec</span>
             </Progress>
           )}
         </Spring>
@@ -191,6 +201,15 @@ const Progress = styled(animated.div)`
     grid-area: time;
     text-align: right;
   }
+`
+
+const CloseButton = styled('div')`
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  transform: scale(0.9);
+  cursor: pointer;
+  z-index: 1;
 `
 
 const ProgressTrack = styled('div')`

--- a/src/components/Notifications/NotificationHub.js
+++ b/src/components/Notifications/NotificationHub.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Spring, Transition, animated } from 'react-spring'
 import styled from 'styled-components'
+import TimeTag from './TimeTag'
 
 const spring = { tension: 1900, friction: 200, precision: 0.0001, clamp: true }
 
@@ -39,14 +40,14 @@ class NotificationHub extends React.Component {
 
 class Notification extends React.Component {
   render() {
-    const { children, title, time } = this.props
+    const { children, title } = this.props
     return (
       <Frame>
         <h1>
           <span>{title}</span>
         </h1>
         <h2>
-          <span>{time}</span>
+          <TimeTag />
         </h2>
         <div>{children}</div>
       </Frame>

--- a/src/components/Notifications/NotificationHub.js
+++ b/src/components/Notifications/NotificationHub.js
@@ -77,11 +77,11 @@ Notification.Transaction = class extends React.Component {
         <Spring
           native
           delay={400}
-          from={{ opacity: 1 /*, height: 'auto'*/ }}
+          from={{ opacity: 1 /*, height: 'auto' */ }}
           to={{
             opacity: this.state.showPayload
               ? 1
-              : 0.5 /*, height: this.state.showPayload ? 'auto' : 0*/,
+              : 0.5 /*, height: this.state.showPayload ? 'auto' : 0 */,
           }}
         >
           {props => (

--- a/src/components/Notifications/NotificationHub.js
+++ b/src/components/Notifications/NotificationHub.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import { Spring, Transition, animated, config } from 'react-spring'
+import { Spring, Transition, animated } from 'react-spring'
 import styled from 'styled-components'
-import springs from '../../springs'
-import { IconCross } from '@aragon/ui'
 
 const spring = { tension: 1900, friction: 200, precision: 0.0001, clamp: true }
 
@@ -39,10 +37,6 @@ class NotificationHub extends React.Component {
   }
 }
 
-/** TODO
- * 1. Timetags are still a mock up
- * 2. Notifications still need an X button to close on interaction
- */
 class Notification extends React.Component {
   render() {
     const { children, title, time } = this.props
@@ -60,12 +54,6 @@ class Notification extends React.Component {
   }
 }
 
-/** TODO
- * 1. Progress bar needs to work with callbacks
- * 2. Successfull notifications should collapse progress (for this react-spring "auto" in arrays needs to be fixed)
- * 3. Error status needs to be shown
- * 4. Estimated time needs to be functional
- */
 Notification.Transaction = class extends React.Component {
   state = { showPayload: true }
   isDone = props => props.p === 1 && this.setState({ showPayload: false })
@@ -77,12 +65,8 @@ Notification.Transaction = class extends React.Component {
         <Spring
           native
           delay={400}
-          from={{ opacity: 1 /*, height: 'auto' */ }}
-          to={{
-            opacity: this.state.showPayload
-              ? 1
-              : 0.5 /*, height: this.state.showPayload ? 'auto' : 0 */,
-          }}
+          from={{ opacity: 1 }}
+          to={{ opacity: this.state.showPayload ? 1 : 0.5 }}
         >
           {props => (
             <Progress style={props}>

--- a/src/components/Notifications/TimeTag.js
+++ b/src/components/Notifications/TimeTag.js
@@ -11,6 +11,10 @@ export default class TimeTag extends React.Component {
   }
   render() {
     const time = differenceInMinutes(new Date(), this.state.time)
-    return <span style={this.props.style} ref={this.viewRef}>{time}m ago</span>
+    return (
+      <span style={this.props.style} ref={this.viewRef}>
+        {time}m ago
+      </span>
+    )
   }
 }

--- a/src/components/Notifications/TimeTag.js
+++ b/src/components/Notifications/TimeTag.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { differenceInMinutes } from 'date-fns'
+
+export default class TimeTag extends React.Component {
+  state = { time: new Date() }
+  componentDidMount() {
+    this.interval = setInterval(() => this.forceUpdate(), 1000)
+  }
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
+  render() {
+    const time = differenceInMinutes(new Date(), this.state.time)
+    return <span ref={this.viewRef}>{time}m ago</span>
+  }
+}

--- a/src/components/Notifications/TimeTag.js
+++ b/src/components/Notifications/TimeTag.js
@@ -11,6 +11,6 @@ export default class TimeTag extends React.Component {
   }
   render() {
     const time = differenceInMinutes(new Date(), this.state.time)
-    return <span ref={this.viewRef}>{time}m ago</span>
+    return <span style={this.props.style} ref={this.viewRef}>{time}m ago</span>
   }
 }


### PR DESCRIPTION
Closes #117.

Note: see the first part of this PR in https://github.com/aragon/aragon/pull/495 (merged too early).

## Chores 

- [x] using it in Aragons wrapper
- [x] barebone functionality: styles, adding, removing, peeking, animations, clear-all, alert bell
- [x] Click outside should close the panel
- [x] Ongoing notification should be flagged faulty on exceptions
- [ ] Notifications still need an X button to close on interaction
- [ ] Progress bar needs to work with callbacks which could fudge/estimate progress
- [x] Successfull notifications should collapse progress (react-spring has a bug that prevents it atm)
- [x] Error status needs to be shown
- [ ] Estimated time & timetags need to be functional
- [ ] Making it public in aragon-ui/lorikeet

![a](https://user-images.githubusercontent.com/2223602/48973550-f512f180-f041-11e8-9b23-5d0aa5012640.jpg)

