### PR TITLE
fix: document usage of ethereum providers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,12 +99,12 @@ class App extends React.Component {
       return
     }
     // For providers supporting .enable() (EIP 1102 draft).
-    if ('enable' in provider) {
+    if (typeof provider.enable === 'function') {
       provider.enable()
       return
     }
     // For providers supporting EIP 1102 (final).
-    if ('send' in provider) {
+    if (typeof provider.send === 'function') {
       // Some providers (Metamask) don’t return a promise as defined in EIP
       // 1102, so we can’t rely on it to know the connected accounts.
       provider.send('eth_requestAccounts')

--- a/src/environment.js
+++ b/src/environment.js
@@ -126,7 +126,8 @@ export const defaultEthNode =
 
 export const web3Providers = {
   default: new Web3.providers.WebsocketProvider(defaultEthNode),
-  wallet: getInjectedProvider() || provider(),
+  // Only use eth-provider to connect to frame if no injected provider is detected
+  wallet: getInjectedProvider() || provider(['frame']),
 }
 
 export const defaultGasPriceFn =

--- a/src/web3-utils.js
+++ b/src/web3-utils.js
@@ -149,7 +149,11 @@ export function getInjectedProvider() {
 }
 
 export function isConnected(provider) {
-  return provider.isConnected
+  // EIP-1193 compliant providers may not include `isConnected()`, but most should support it for
+  // the foreseeable future to be backwards compatible with older Web3.js implementations.
+  // The `status` property is also not required by EIP-1193, but is often set on providers for
+  // backwards compatibility as well.
+  return typeof provider.isConnected === 'function'
     ? provider.isConnected()
     : provider.status === 'connected'
 }


### PR DESCRIPTION
Adds a bit of documentation on how Ethereum providers are used, given their many edge cases.

Would be great to document some of the mobile flaws we noticed as well, if we could pinpoint why they were failing.