### PR TITLE
fix: clean proptype validation and properly pass ethereum.enable() to Wrapper

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -342,10 +342,9 @@ class App extends React.Component {
               daoCreationStatus={daoCreationStatus}
               onComplete={this.handleCompleteOnboarding}
               onOpenOrganization={this.handleOpenOrganization}
-              onResetDaoBuilder={this.handleResetDaoBuilder}
               onRequestEnable={this.handleRequestEnable}
+              onResetDaoBuilder={this.handleResetDaoBuilder}
               selectorNetworks={selectorNetworks}
-              walletWeb3={walletWeb3}
             />
           </ScreenSizeProvider>
         </FavoriteDaosProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -321,6 +321,7 @@ class App extends React.Component {
                 historyPush={this.historyPush}
                 locator={locator}
                 onRequestAppsReload={this.handleRequestAppsReload}
+                onRequestEnable={this.handleRequestEnable}
                 permissionsLoading={permissionsLoading}
                 transactionBag={transactionBag}
                 walletNetwork={walletNetwork}

--- a/src/App.js
+++ b/src/App.js
@@ -311,21 +311,21 @@ class App extends React.Component {
               permissions={permissions}
             >
               <Wrapper
+                account={account}
+                apps={apps}
+                appsStatus={appsStatus}
                 banner={showDeprecatedBanner && <DeprecatedBanner dao={dao} />}
+                connected={connected}
+                daoAddress={daoAddress}
                 historyBack={this.historyBack}
                 historyPush={this.historyPush}
                 locator={locator}
-                wrapper={wrapper}
-                apps={apps}
-                appsStatus={appsStatus}
+                onRequestAppsReload={this.handleRequestAppsReload}
                 permissionsLoading={permissionsLoading}
-                account={account}
+                transactionBag={transactionBag}
                 walletNetwork={walletNetwork}
                 walletWeb3={walletWeb3}
-                daoAddress={daoAddress}
-                transactionBag={transactionBag}
-                connected={connected}
-                onRequestAppsReload={this.handleRequestAppsReload}
+                wrapper={wrapper}
               />
             </PermissionsProvider>
 

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -14,7 +14,6 @@ import { DaoAddressType } from './prop-types'
 import { getAppPath } from './routing'
 import { staticApps } from './static-apps'
 import { addressesEqual } from './web3-utils'
-import { noop } from './utils'
 import {
   APPS_STATUS_ERROR,
   APPS_STATUS_READY,
@@ -24,7 +23,7 @@ import NotificationBar from './components/Notifications/NotificationBar'
 
 class Wrapper extends React.Component {
   static propTypes = {
-    account: PropTypes.string.isRequired,
+    account: PropTypes.string,
     apps: PropTypes.array.isRequired,
     appsStatus: PropTypes.oneOf([
       APPS_STATUS_ERROR,
@@ -36,38 +35,31 @@ class Wrapper extends React.Component {
       PropTypes.shape({
         type: PropTypes.oneOf([DeprecatedBanner]),
       }),
-    ]).isRequired,
-    connected: PropTypes.bool.isRequired,
+    ]),
+    connected: PropTypes.bool,
     daoAddress: DaoAddressType.isRequired,
     historyBack: PropTypes.func.isRequired,
     historyPush: PropTypes.func.isRequired,
     locator: PropTypes.object.isRequired,
     onRequestAppsReload: PropTypes.func.isRequired,
+    onRequestEnable: PropTypes.func.isRequired,
     permissionsLoading: PropTypes.bool.isRequired,
     screenSize: PropTypes.symbol.isRequired,
     transactionBag: PropTypes.object,
-    walletNetwork: PropTypes.string.isRequired,
-    walletWeb3: PropTypes.object,
+    walletNetwork: PropTypes.string,
     walletProviderId: PropTypes.string,
+    walletWeb3: PropTypes.object,
     wrapper: PropTypes.object,
-    onRequestEnable: PropTypes.func,
   }
 
   static defaultProps = {
     account: '',
-    apps: [],
-    banner: null,
+    banner: false,
     connected: false,
-    daoAddress: '',
-    historyBack: noop,
-    historyPush: noop,
-    locator: {},
-    onRequestEnable: noop,
     transactionBag: null,
     walletNetwork: '',
     walletProviderId: '',
     walletWeb3: null,
-    wrapper: null,
   }
   state = {
     appInstance: {},

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -47,14 +47,14 @@ const initialState = {
 
 class Onboarding extends React.PureComponent {
   static propTypes = {
-    account: PropTypes.string.isRequired,
+    account: PropTypes.string,
     balance: PropTypes.object,
     banner: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({
         type: PropTypes.oneOf([DeprecatedBanner]),
       }),
-    ]).isRequired,
+    ]),
     daoCreationStatus: PropTypes.oneOf([
       DAO_CREATION_STATUS_NONE,
       DAO_CREATION_STATUS_SUCCESS,
@@ -64,24 +64,18 @@ class Onboarding extends React.PureComponent {
     onComplete: PropTypes.func.isRequired,
     onOpenOrganization: PropTypes.func.isRequired,
     onResetDaoBuilder: PropTypes.func.isRequired,
+    onRequestEnable: PropTypes.func.isRequired,
     selectorNetworks: PropTypes.array.isRequired,
     visible: PropTypes.bool.isRequired,
-    walletProviderId: PropTypes.string.isRequired,
-    walletNetwork: PropTypes.string.isRequired,
-    walletWeb3: PropTypes.object,
+    walletNetwork: PropTypes.string,
+    walletProviderId: PropTypes.string,
   }
 
   static defaultProps = {
     account: '',
     balance: getUnknownBalance(),
-    banner: null,
-    daoCreationStatus: DAO_CREATION_STATUS_NONE,
+    banner: false,
     onComplete: noop,
-    onBuildDao: noop,
-    onOpenOrganization: noop,
-    onResetDaoBuilder: noop,
-    onRequestEnable: noop,
-    visible: true,
     walletNetwork: '',
     walletProviderId: '',
   }
@@ -474,7 +468,6 @@ class Onboarding extends React.PureComponent {
       onRequestEnable,
       walletNetwork,
       walletProviderId,
-      walletWeb3,
     } = this.props
 
     // No need to move the screens farther than one step
@@ -512,7 +505,6 @@ class Onboarding extends React.PureComponent {
           onRequestEnable={onRequestEnable}
           walletNetwork={walletNetwork}
           walletProviderId={walletProviderId}
-          walletWeb3={walletWeb3}
           {...sharedProps}
         />
       )


### PR DESCRIPTION
Turns out the signer panel's `enable()` wasn't doing anything before... 🤷‍♂️.

Builds on #581 for convenience (less merge conflicts later).

Commits:

- 1757c9a: adds missing proptypes, removes defaults when proptype is declared as required
- 13a801d: alphabetically order props to `Wrapper` to make it easier to spot missing props like this in the future
- 10c8d87: add `onRequestEnable()` to `Wrapper`