### PR TITLE
Removes all the react/prop-types warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/onboarding/**/*.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-src/onboarding/**/*.js

--- a/src/apps/Apps/Apps.js
+++ b/src/apps/Apps/Apps.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {
   Card,
@@ -21,6 +22,9 @@ import payrollIcon from './icons/payroll.svg'
 import espressoIcon from './icons/espresso.svg'
 
 class Apps extends React.Component {
+  static propTypes = {
+    onMessage: PropTypes.func,
+  }
   handleMenuPanelOpen = () => {
     this.props.onMessage({
       data: { from: 'app', name: 'menuPanel', value: true },

--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, Table, TableRow, Text } from '@aragon/ui'
+import { AppType, EthereumAddressType } from '../../prop-types'
 import { TableHeader, TableCell, FirstTableCell, LastTableCell } from './Table'
 import IdentityBadge from '../../components/IdentityBadge'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
-import { AppType } from '../../prop-types'
 import Section from './Section'
 import EmptyBlock from './EmptyBlock'
 import AppInstanceLabel from './AppInstanceLabel'
@@ -75,7 +75,10 @@ class RoleRow extends React.Component {
   static propTypes = {
     onManage: PropTypes.func.isRequired,
     role: PropTypes.shape({ bytes: PropTypes.string }).isRequired,
-    manager: PropTypes.shape({ type: PropTypes.string }).isRequired,
+    manager: PropTypes.shape({
+      type: PropTypes.string,
+      address: EthereumAddressType,
+    }).isRequired,
   }
   handleManageClick = () => {
     this.props.onManage(this.props.role.bytes)

--- a/src/apps/Permissions/AppRoles.js
+++ b/src/apps/Permissions/AppRoles.js
@@ -72,6 +72,11 @@ class AppRoles extends React.PureComponent {
 }
 
 class RoleRow extends React.Component {
+  static propTypes = {
+    onManage: PropTypes.func.isRequired,
+    role: PropTypes.shape({ bytes: PropTypes.string }).isRequired,
+    manager: PropTypes.shape({ type: PropTypes.string }).isRequired,
+  }
   handleManageClick = () => {
     this.props.onManage(this.props.role.bytes)
   }

--- a/src/components/AppLayout/AppLayout.js
+++ b/src/components/AppLayout/AppLayout.js
@@ -1,20 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { AppBar } from '@aragon/ui'
 
 class AppLayout extends React.Component {
+  static propTypes = {
+    title: PropTypes.node,
+    endContent: PropTypes.node,
+    children: PropTypes.node,
+  }
   static defaultProps = {
     title: '',
   }
   render() {
-    const { title, endContent, children, padding, maxWidth } = this.props
+    const { title, endContent, children } = this.props
     return (
       <Main>
         <StyledAppBar title={title} endContent={endContent} />
         <ScrollWrapper>
-          <Content maxWidth={maxWidth} padding={padding}>
-            {children}
-          </Content>
+          <Content>{children}</Content>
         </ScrollWrapper>
       </Main>
     )

--- a/src/components/DeprecatedBanner/DeprecatedBanner.js
+++ b/src/components/DeprecatedBanner/DeprecatedBanner.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { theme, Text, SafeLink, Button } from '@aragon/ui'
 import Banner from '../Banner/Banner'
@@ -22,6 +23,12 @@ const DeprecatedBanner = props => (
 )
 
 class DeprecatedDao extends React.Component {
+  static propTypes = {
+    dao: PropTypes.object.isRequired,
+    lightMode: PropTypes.bool,
+    showModal: PropTypes.bool,
+    children: PropTypes.node,
+  }
   static defaultProps = {
     lightMode: false,
   }
@@ -86,6 +93,10 @@ const DeprecatedBody = ({ dao }) => (
   </React.Fragment>
 )
 
+DeprecatedBody.propTypes = {
+  dao: PropTypes.object.isRequired,
+}
+
 const DeprecatedModal = ({ onHide, dao }) => (
   <Modal
     title={DEPRECATION_TITLE}
@@ -98,6 +109,11 @@ const DeprecatedModal = ({ onHide, dao }) => (
     }
   />
 )
+
+DeprecatedModal.propTypes = {
+  onHide: PropTypes.func.isRequired,
+  dao: PropTypes.object.isRequired,
+}
 
 const TopParagraph = styled(Text.Paragraph)`
   margin-bottom: 20px;

--- a/src/components/DeprecatedBanner/DeprecatedBanner.js
+++ b/src/components/DeprecatedBanner/DeprecatedBanner.js
@@ -24,7 +24,7 @@ const DeprecatedBanner = props => (
 
 class DeprecatedDao extends React.Component {
   static propTypes = {
-    dao: PropTypes.object.isRequired,
+    dao: PropTypes.string.isRequired,
     lightMode: PropTypes.bool,
     showModal: PropTypes.bool,
     children: PropTypes.node,
@@ -94,7 +94,7 @@ const DeprecatedBody = ({ dao }) => (
 )
 
 DeprecatedBody.propTypes = {
-  dao: PropTypes.object.isRequired,
+  dao: PropTypes.string.isRequired,
 }
 
 const DeprecatedModal = ({ onHide, dao }) => (
@@ -112,7 +112,7 @@ const DeprecatedModal = ({ onHide, dao }) => (
 
 DeprecatedModal.propTypes = {
   onHide: PropTypes.func.isRequired,
-  dao: PropTypes.object.isRequired,
+  dao: PropTypes.string.isRequired,
 }
 
 const TopParagraph = styled(Text.Paragraph)`

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -206,6 +206,12 @@ const AnimatedMenuPanel = ({
   )
 }
 
+AnimatedMenuPanel.propTypes = {
+  opened: PropTypes.bool,
+  autoClosing: PropTypes.bool,
+  onCloseMenuPanel: PropTypes.func.isRequired,
+}
+
 const Overlay = styled.div`
   position: absolute;
   z-index: 2;

--- a/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
@@ -97,7 +97,7 @@ const LoaderLabel = styled.span`
   font-size: 15px;
 `
 
-export default props =>
+const OrganizationSwitcherWithFavorites = props =>
   props.currentDao.address ? (
     <FavoriteDaosConsumer>
       {({ favoriteDaos, updateFavoriteDaos }) => (
@@ -114,3 +114,9 @@ export default props =>
       <LoaderLabel>Loading…</LoaderLabel>
     </Loader>
   )
+
+OrganizationSwitcherWithFavorites.propTypes = {
+  currentDao: DaoItemType.isRequired,
+}
+
+export default OrganizationSwitcherWithFavorites

--- a/src/components/ModalManager/Modal.js
+++ b/src/components/ModalManager/Modal.js
@@ -1,10 +1,11 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import EscapeOutside from '../EscapeOutside/EscapeOutside'
 import { Button, breakpoint, font } from '@aragon/ui'
 import { noop } from '../../utils'
 
-const Modal = ({ title, body, moreText, onHide, More, blocking }) => (
+const Modal = ({ title, body, onHide, More, blocking }) => (
   <Main>
     <WrapModal role="alertdialog" onEscapeOutside={blocking ? noop : onHide}>
       <Header>{title}</Header>
@@ -18,6 +19,14 @@ const Modal = ({ title, body, moreText, onHide, More, blocking }) => (
     </WrapModal>
   </Main>
 )
+
+Modal.propTypes = {
+  title: PropTypes.node.isRequired,
+  body: PropTypes.node.isRequired,
+  onHide: PropTypes.func.isRequired,
+  More: PropTypes.node,
+  blocking: PropTypes.bool,
+}
 
 const Main = styled.div`
   display: grid;

--- a/src/components/ModalManager/ModalManager.js
+++ b/src/components/ModalManager/ModalManager.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Transition, animated } from 'react-spring'
 import springs from '../../springs'
@@ -37,6 +38,10 @@ class ModalProvider extends React.Component {
   }
 }
 
+ModalProvider.propTypes = {
+  children: PropTypes.node,
+}
+
 const ModalConsumer = ModalContext.Consumer
 
 const ModalView = () => (
@@ -52,6 +57,7 @@ const ModalView = () => (
       >
         {ModalComponent =>
           ModalComponent &&
+          /* eslint-disable react/prop-types */
           (({ opacity, enterProgress, blocking }) => (
             <Wrap style={{ pointerEvents: blocking ? 'auto' : 'none' }}>
               <Overlay style={{ opacity: opacity.interpolate(v => v * 0.5) }} />
@@ -70,6 +76,7 @@ const ModalView = () => (
               </AnimatedWrap>
             </Wrap>
           ))
+        /* eslint-enable react/prop-types */
         }
       </Transition>
     )}

--- a/src/components/Notifications/NotificationAlert.js
+++ b/src/components/Notifications/NotificationAlert.js
@@ -1,11 +1,14 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
 import { theme, springs, IconNotifications } from '@aragon/ui'
 
 export default class NotificationAlert extends React.PureComponent {
-  state = { opened: false, previousNotifications: 0 }
-
+  static propTypes = {
+    notifications: PropTypes.number.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }
   static getDerivedStateFromProps(
     { notifications },
     { opened, previousNotifications }
@@ -15,6 +18,8 @@ export default class NotificationAlert extends React.PureComponent {
       previousNotifications: notifications,
     }
   }
+
+  state = { opened: false, previousNotifications: 0 }
 
   handleClick = () => {
     this.setState({ opened: true })

--- a/src/components/Notifications/NotificationBar.js
+++ b/src/components/Notifications/NotificationBar.js
@@ -1,11 +1,12 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
 import { Badge } from '@aragon/ui'
 import { NotificationHub, Notification } from './NotificationHub'
 import springs from '../../springs'
 
-export default function NotificationBar({ open, notifications, onClearAll }) {
+const NotificationBar = ({ open, notifications, onClearAll }) => {
   const count = notifications.length
   return (
     <Spring
@@ -14,11 +15,11 @@ export default function NotificationBar({ open, notifications, onClearAll }) {
       to={{ x: open ? 0 : -300 }}
       config={springs.lazy}
     >
-      {props => (
+      {({ x }) => (
         <NotificationFrame
           tabIndex={0}
           style={{
-            transform: props.x.interpolate(x => `translate3d(${x}px,0,0)`),
+            transform: x.interpolate(x => `translate3d(${x}px,0,0)`),
           }}
         >
           <NotificationHeader>
@@ -39,7 +40,13 @@ export default function NotificationBar({ open, notifications, onClearAll }) {
   )
 }
 
-function NotificationImpl(item, ready) {
+NotificationBar.propTypes = {
+  open: PropTypes.bool,
+  notifications: PropTypes.arrayOf(PropTypes.object),
+  onClearAll: PropTypes.func.isRequired,
+}
+
+const NotificationImpl = (item, ready) => {
   let payload =
     typeof item.content === 'string' ? <p>{item.content}</p> : item.content
   switch (item.type) {
@@ -100,3 +107,5 @@ const NotificationHeader = styled('div')`
     text-align: right;
   }
 `
+
+export default NotificationBar

--- a/src/components/Notifications/NotificationHub.js
+++ b/src/components/Notifications/NotificationHub.js
@@ -1,10 +1,17 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Spring, Transition, animated } from 'react-spring'
 import styled from 'styled-components'
 
 const spring = { tension: 1900, friction: 200, precision: 0.0001, clamp: true }
 
 class NotificationHub extends React.Component {
+  static propTypes = {
+    items: PropTypes.arrayOf(PropTypes.object).isRequired,
+    keys: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
+  }
+
   state = { ready: {} }
   render() {
     const { items, keys, children } = this.props
@@ -42,6 +49,11 @@ class NotificationHub extends React.Component {
  * 2. Notifications still need an X button to close on interaction
  */
 class Notification extends React.Component {
+  static propTypes = {
+    title: PropTypes.string,
+    children: PropTypes.node,
+    time: PropTypes.string,
+  }
   render() {
     const { children, title, time } = this.props
     return (
@@ -65,6 +77,10 @@ class Notification extends React.Component {
  * 4. Estimated time needs to be functional
  */
 Notification.Transaction = class extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    ready: PropTypes.bool,
+  }
   state = { showPayload: true }
   isDone = props => props.p === 1 && this.setState({ showPayload: false })
   render() {

--- a/src/components/SignerPanel/SigningStatus.js
+++ b/src/components/SignerPanel/SigningStatus.js
@@ -1,10 +1,16 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Info, theme } from '@aragon/ui'
 import providerString from '../../provider-strings'
 import SignerButton from './SignerButton'
 
-import { STATUS_SIGNING, STATUS_SIGNED, STATUS_ERROR } from './signer-statuses'
+import {
+  STATUS_ERROR,
+  STATUS_SIGNED,
+  STATUS_SIGNING,
+  SignerStatusType,
+} from './signer-statuses'
 
 import imgPending from '../../assets/transaction-pending.svg'
 import imgSuccess from '../../assets/transaction-success.svg'
@@ -15,6 +21,12 @@ const cleanErrorMessage = msg =>
   msg.replace(/^Returned error: /, '').replace(/^Error: /, '')
 
 class SigningStatus extends React.Component {
+  static propTypes = {
+    status: SignerStatusType.isRequired,
+    signError: PropTypes.instanceOf(Error),
+    walletProviderId: PropTypes.string,
+    onClose: PropTypes.func.isRequired,
+  }
   getLabel() {
     const { status } = this.props
     if (status === STATUS_SIGNING) return 'Waiting for signature…'
@@ -99,6 +111,10 @@ const StatusImage = ({ status }) => (
     <StatusImageImg visible={status === STATUS_SIGNED} src={imgSuccess} />
   </StatusImageMain>
 )
+StatusImage.propTypes = {
+  status: SignerStatusType.isRequired,
+}
+
 const StatusImageMain = styled.div`
   position: relative;
   width: 150px;

--- a/src/components/SignerPanel/signer-statuses.js
+++ b/src/components/SignerPanel/signer-statuses.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 // The user need to confirm the transaction
 export const STATUS_CONFIRMING = Symbol('STATUS_CONFIRMING')
 
@@ -9,3 +11,11 @@ export const STATUS_SIGNED = Symbol('STATUS_SIGNED')
 
 // An error happened while signing the transaction
 export const STATUS_ERROR = Symbol('STATUS_ERROR')
+
+// Corresponding proptype
+export const SignerStatusType = PropTypes.oneOf([
+  STATUS_CONFIRMING,
+  STATUS_SIGNING,
+  STATUS_SIGNED,
+  STATUS_ERROR,
+])

--- a/src/icons/IconKernel.js
+++ b/src/icons/IconKernel.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const IconKernel = ({ size = 28, ...props }) => (
   <svg width={size} height={size} viewBox="0 0 28 28" {...props}>
@@ -29,5 +30,9 @@ const IconKernel = ({ size = 28, ...props }) => (
     </g>
   </svg>
 )
+
+IconKernel.propTypes = {
+  size: PropTypes.number,
+}
 
 export default IconKernel

--- a/src/onboarding/Domain.js
+++ b/src/onboarding/Domain.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { theme, Text, TextInput, IconCheck, IconCross } from '@aragon/ui'

--- a/src/onboarding/Launch.js
+++ b/src/onboarding/Launch.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { theme, Text, Button } from '@aragon/ui'

--- a/src/onboarding/PrevNext.js
+++ b/src/onboarding/PrevNext.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'

--- a/src/onboarding/Sign.js
+++ b/src/onboarding/Sign.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { theme, Text, Button } from '@aragon/ui'

--- a/src/onboarding/Start.js
+++ b/src/onboarding/Start.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import BN from 'bn.js'

--- a/src/onboarding/StepsBar.js
+++ b/src/onboarding/StepsBar.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { Spring } from 'react-spring'

--- a/src/onboarding/Template.js
+++ b/src/onboarding/Template.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { theme, Text } from '@aragon/ui'

--- a/src/onboarding/TemplateCard.js
+++ b/src/onboarding/TemplateCard.js
@@ -1,9 +1,18 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { theme, font, IconCheck } from '@aragon/ui'
 import { noop } from '../utils'
+import { TemplateType } from './templates'
 
 class TemplateCard extends React.Component {
+  static propTypes = {
+    template: TemplateType,
+    active: PropTypes.bool,
+    onSelect: PropTypes.func,
+    label: PropTypes.string,
+    icon: PropTypes.string.isRequired,
+  }
   static defaultProps = {
     template: null,
     active: false,

--- a/src/onboarding/templates.js
+++ b/src/onboarding/templates.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types'
+
 import democracy from './templates/democracy'
 import multisig from './templates/multisig'
 
@@ -8,5 +10,7 @@ const Templates = new Map()
 Templates.set(Democracy, democracy)
 Templates.set(Multisig, multisig)
 
+const TemplateType = PropTypes.oneOf([Multisig, Democracy])
+
 export default Templates
-export { Multisig, Democracy }
+export { TemplateType, Multisig, Democracy }

--- a/src/onboarding/templates/democracy/ConfigureTokenName.js
+++ b/src/onboarding/templates/democracy/ConfigureTokenName.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { Field, TextInput, Text, theme } from '@aragon/ui'

--- a/src/onboarding/templates/democracy/ConfigureVotingDefaults.js
+++ b/src/onboarding/templates/democracy/ConfigureVotingDefaults.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { Field, TextInput, Text, theme } from '@aragon/ui'

--- a/src/onboarding/templates/multisig/ConfigureMultisigAddresses.js
+++ b/src/onboarding/templates/multisig/ConfigureMultisigAddresses.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { Button, TextInput, Text, DropDown, theme } from '@aragon/ui'

--- a/src/onboarding/templates/multisig/ConfigureMultisigToken.js
+++ b/src/onboarding/templates/multisig/ConfigureMultisigToken.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react'
 import styled from 'styled-components'
 import { Field, TextInput, Text, theme } from '@aragon/ui'


### PR DESCRIPTION
Fixes #390.

Removes all the proptypes warnings:

- Ignore the `react/prop-types` rule in most of the files in `src/onboarding`. We can add them later by searching for `eslint` in the codebase, but a cleanup / refactoring of this part is needed, so it might not be worth doing it until then.
- Add prop types for everything else.

<p align=right><img width=30 src=https://user-images.githubusercontent.com/36158/53132982-d7d2be00-3571-11e9-94e0-8434d41f11c8.png></p>