### PR TITLE
Permissions: hide Any Account from role management selectors

### DIFF
--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -153,11 +153,12 @@ class AssignPermissionPanel extends React.PureComponent {
           </Field>
 
           <EntitySelector
+            includeAnyEntity
             label="Grant permission to"
             labelCustomAddress="Grant permission to"
+            activeIndex={assignEntityIndex}
             apps={this.getNamedApps()}
             onChange={this.handleEntityChange}
-            activeIndex={assignEntityIndex}
           />
 
           {selectedApp && (

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -10,6 +10,7 @@ class EntitySelector extends React.Component {
   static propTypes = {
     activeIndex: PropTypes.number.isRequired,
     apps: PropTypes.arrayOf(AppType).isRequired,
+    includeAnyEntity: PropTypes.bool,
     label: PropTypes.string.isRequired,
     labelCustomAddress: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -52,7 +53,7 @@ class EntitySelector extends React.Component {
       return this.state.customAddress
     }
 
-    if (index === items.length - 2) {
+    if (this.props.includeAnyEntity && index === items.length - 2) {
       return getAnyEntity()
     }
 
@@ -60,12 +61,19 @@ class EntitySelector extends React.Component {
     return (app && app.proxyAddress) || getEmptyAddress()
   }
   getItems() {
-    return [
+    const { includeAnyEntity } = this.props
+
+    const items = [
       'Select an entity',
       ...this.getAppsItems(),
-      'Any account',
       'Custom address…',
     ]
+    if (includeAnyEntity) {
+      // Add immediately before last item
+      items.splice(-1, 0, 'Any account')
+    }
+
+    return items
   }
   render() {
     const { customAddress } = this.state

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -310,27 +310,28 @@ class ManageRolePanel extends React.PureComponent {
             <EntitySelector
               label="New manager"
               labelCustomAddress="Address for new manager"
+              activeIndex={assignManagerIndex}
               apps={this.getNamedApps()}
               onChange={this.handleRoleManagerChange}
-              activeIndex={assignManagerIndex}
             />
           )}
 
           {action === CREATE_PERMISSION && (
             <React.Fragment>
               <EntitySelector
+                includeAnyEntity
                 label="Grant permission to"
                 labelCustomAddress="Grant permission to"
+                activeIndex={assignEntityIndex}
                 apps={this.getNamedApps()}
                 onChange={this.handleEntityChange}
-                activeIndex={assignEntityIndex}
               />
               <EntitySelector
                 label="Manager"
                 labelCustomAddress="Address for manager"
+                activeIndex={assignManagerIndex}
                 apps={this.getNamedApps()}
                 onChange={this.handleRoleManagerChange}
-                activeIndex={assignManagerIndex}
               />
             </React.Fragment>
           )}


### PR DESCRIPTION
Fixes https://github.com/aragon/aragonOS/issues/484.

`Any account` doesn't apply to managers; trying to set a role manager to "0xff...ff" only results in it being unchangeable.

Default `EntitySelector` with this change:

<img width="422" alt="screen shot 2019-02-23 at 11 13 30 pm" src="https://user-images.githubusercontent.com/4166642/53292423-a3a20c00-37c2-11e9-9dda-13eda9c999bd.png">

