### PR TITLE
Fix the width of MenuPanel

### DIFF
--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -260,8 +260,7 @@ const Wrap = styled(animated.div)`
   width: 90vw;
   height: 100vh;
   min-width: 300px;
-  flex-shrink: 0;
-  flex-grow: 0;
+  flex: none;
 
   ${breakpoint(
     'medium',
@@ -277,9 +276,8 @@ const Main = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
+  flex: none;
   flex-direction: column;
-  flex-grow: 0;
-  flex-shrink: 0;
   ${unselectable};
 `
 

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -260,6 +260,8 @@ const Wrap = styled(animated.div)`
   width: 90vw;
   height: 100vh;
   min-width: 300px;
+  flex-shrink: 0;
+  flex-grow: 0;
 
   ${breakpoint(
     'medium',


### PR DESCRIPTION
Now that `MenuPanel` is wrapped, we need to ensure that the wrapper doesn’t grow / shrink too, so that the width is always the same.