### PR TITLE
chore: upgrade @aragon/wrapper to v4.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aragon/templates-tokens": "^1.1.1",
     "@aragon/ui": "^0.32.0",
-    "@aragon/wrapper": "^3.0.0-beta.5",
+    "@aragon/wrapper": "^4.0.0-beta.1",
     "@babel/polyfill": "^7.0.0",
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -1,5 +1,4 @@
 import BN from 'bn.js'
-import throttle from 'lodash.throttle'
 import resolvePathname from 'resolve-pathname'
 import Aragon, {
   providers,
@@ -240,7 +239,7 @@ const subscribe = (
         )
       )
     }),
-    permissions: permissions.subscribe(throttle(onPermissions, 100)),
+    permissions: permissions.subscribe(onPermissions),
     connectedApp: null,
     connectedWorkers: workerSubscriptionPool,
     forwarders: forwarders.subscribe(onForwarders),


### PR DESCRIPTION
This upgrade should be completely transparent to aragon/aragon, since it doesn't really make use of any rxjs operators.