### PR TITLE
fix: avoid assigning a registry tag if app is not on a registry

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -77,7 +77,7 @@ const prepareAppsForFrontend = (apps, daoAddress, gateway) => {
     if (app.status) {
       tags.push(app.status)
     }
-    if (apmRegistry !== 'aragonpm.eth') {
+    if (apmRegistry && apmRegistry !== 'aragonpm.eth') {
       tags.push(`${apmRegistry} registry`)
     }
     if (!hasWebApp(app)) {


### PR DESCRIPTION
Some internal apps, like the Kernel, ACL, and EVM Scripts Registry, aren't published onto a registry yet. This avoids erroneously setting their registry tag to `' registry'`.