### PR TITLE
fix: always leave Kernel as first app

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -30,6 +30,14 @@ export const sortAppsPair = (app1, app2) => {
   const index1 = name1 ? appsOrder.indexOf(name1) : -1
   const index2 = name2 ? appsOrder.indexOf(name2) : -1
 
+  // Keep kernel first
+  if (app1.name === 'Kernel') {
+    return -1
+  }
+  if (app2.name === 'Kernel') {
+    return 1
+  }
+
   // Internal apps first
   if (app1.isAragonOsInternalApp !== app2.isAragonOsInternalApp) {
     return app1.isAragonOsInternalApp ? -1 : 1


### PR DESCRIPTION
Was previously moving the Kernel to be below the ACL and EVMScriptRegistry (due to later alphabeticalized checks).