### PR TITLE
MenuButton: send a message to the current app

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -130,8 +130,14 @@ class Wrapper extends React.PureComponent {
     this.sendDisplayMenuButtonStatus()
   }
   handleAppMessage = ({ data: { name, value } }) => {
-    if (name === 'menuPanel') {
-      this.setState({ menuPanelOpened: Boolean(value) })
+    if (
+      // “menuPanel: Boolean” is deprecated but still supported for a while if
+      // value is `true`.
+      name === 'menuPanel' ||
+      // “requestMenu: true” should now be used.
+      name === 'requestMenu'
+    ) {
+      this.setState({ menuPanelOpened: value === true })
     }
   }
   handleMenuPanelOpen = () => {

--- a/src/components/MenuPanel/SwipeContainer.js
+++ b/src/components/MenuPanel/SwipeContainer.js
@@ -29,14 +29,11 @@ class SwipeContainer extends React.Component {
       onMenuPanelOpen,
       width,
     } = this.props
+
     const oneThirdWindowWidth = width / 3
 
-    if (!enabled) {
-      return <Container>{children(Number(menuPanelOpened))}</Container>
-    }
-
     return (
-      <Gesture passive={{ passive: false }} mouse={false}>
+      <Gesture passive={{ passive: false }} mouse={false} touch={enabled}>
         {({
           delta: [xDelta, yDelta],
           direction: [xDir, yDir],
@@ -45,6 +42,10 @@ class SwipeContainer extends React.Component {
           initial: [xInitial],
           xy: [x],
         }) => {
+          if (!enabled) {
+            return <Container>{children(Number(menuPanelOpened))}</Container>
+          }
+
           if (
             !down &&
             this._previousProgress > 0 &&


### PR DESCRIPTION
Two changes:

- Send `displayMenuButton` (`Boolean`) to the current app.
- Prevent re-mounting the children of Wrapper on resize.
