### PR TITLE
Custom labels integration refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import DeprecatedBanner from './components/DeprecatedBanner/DeprecatedBanner'
 import { IdentityProvider } from './components/IdentityManager/IdentityManager'
 import { CustomLabelModalProvider } from './components/CustomLabelModal/CustomLabelModalManager'
 import CustomLabelModal from './components/CustomLabelModal/CustomLabelModal'
+import { EventEmitterProvider } from './components/EventEmitterManager/EventEmitterManager'
 import {
   APPS_STATUS_ERROR,
   APPS_STATUS_READY,
@@ -358,70 +359,72 @@ class App extends React.Component {
       identityIntent || {}
 
     return (
-      <IdentityProvider onResolve={this.handleIdentityResolve}>
-        <ModalProvider>
-          <CustomLabelModalProvider
-            onShowCustomLabelModal={this.handleOpenCustomLabelModal}
-          >
-            <CustomLabelModal
-              address={identityAddress}
-              label={identityLabel}
-              opened={identityIntent !== null}
-              onCancel={this.handleIdentityCancel}
-              onSave={this.handleIdentitySave}
-            />
-            <FavoriteDaosProvider>
-              <PermissionsProvider
-                wrapper={wrapper}
-                apps={apps}
-                permissions={permissions}
-              >
-                <Wrapper
-                  account={account}
-                  apps={apps}
-                  appsStatus={appsStatus}
-                  banner={
-                    showDeprecatedBanner && <DeprecatedBanner dao={dao} />
-                  }
-                  connected={connected}
-                  daoAddress={daoAddress}
-                  historyBack={this.historyBack}
-                  historyPush={this.historyPush}
-                  identityIntent={identityIntent}
-                  locator={locator}
-                  onRequestAppsReload={this.handleRequestAppsReload}
-                  onRequestEnable={this.handleRequestEnable}
-                  permissionsLoading={permissionsLoading}
-                  transactionBag={transactionBag}
-                  walletNetwork={walletNetwork}
-                  walletWeb3={walletWeb3}
-                  wrapper={wrapper}
-                />
-              </PermissionsProvider>
-
-              <Onboarding
-                banner={
-                  showDeprecatedBanner && (
-                    <DeprecatedBanner dao={dao} lightMode />
-                  )
-                }
-                visible={mode === 'home' || mode === 'setup'}
-                account={account}
-                balance={balance}
-                walletNetwork={walletNetwork}
-                walletProviderId={walletProviderId}
-                onBuildDao={this.handleBuildDao}
-                daoCreationStatus={daoCreationStatus}
-                onComplete={this.handleCompleteOnboarding}
-                onOpenOrganization={this.handleOpenOrganization}
-                onRequestEnable={this.handleRequestEnable}
-                onResetDaoBuilder={this.handleResetDaoBuilder}
-                selectorNetworks={selectorNetworks}
+      <EventEmitterProvider>
+        <IdentityProvider onResolve={this.handleIdentityResolve}>
+          <ModalProvider>
+            <CustomLabelModalProvider
+              onShowCustomLabelModal={this.handleOpenCustomLabelModal}
+            >
+              <CustomLabelModal
+                address={identityAddress}
+                label={identityLabel}
+                opened={identityIntent !== null}
+                onCancel={this.handleIdentityCancel}
+                onSave={this.handleIdentitySave}
               />
-            </FavoriteDaosProvider>
-          </CustomLabelModalProvider>
-        </ModalProvider>
-      </IdentityProvider>
+              <FavoriteDaosProvider>
+                <PermissionsProvider
+                  wrapper={wrapper}
+                  apps={apps}
+                  permissions={permissions}
+                >
+                  <Wrapper
+                    account={account}
+                    apps={apps}
+                    appsStatus={appsStatus}
+                    banner={
+                      showDeprecatedBanner && <DeprecatedBanner dao={dao} />
+                    }
+                    connected={connected}
+                    daoAddress={daoAddress}
+                    historyBack={this.historyBack}
+                    historyPush={this.historyPush}
+                    identityIntent={identityIntent}
+                    locator={locator}
+                    onRequestAppsReload={this.handleRequestAppsReload}
+                    onRequestEnable={this.handleRequestEnable}
+                    permissionsLoading={permissionsLoading}
+                    transactionBag={transactionBag}
+                    walletNetwork={walletNetwork}
+                    walletWeb3={walletWeb3}
+                    wrapper={wrapper}
+                  />
+                </PermissionsProvider>
+
+                <Onboarding
+                  banner={
+                    showDeprecatedBanner && (
+                      <DeprecatedBanner dao={dao} lightMode />
+                    )
+                  }
+                  visible={mode === 'home' || mode === 'setup'}
+                  account={account}
+                  balance={balance}
+                  walletNetwork={walletNetwork}
+                  walletProviderId={walletProviderId}
+                  onBuildDao={this.handleBuildDao}
+                  daoCreationStatus={daoCreationStatus}
+                  onComplete={this.handleCompleteOnboarding}
+                  onOpenOrganization={this.handleOpenOrganization}
+                  onRequestEnable={this.handleRequestEnable}
+                  onResetDaoBuilder={this.handleResetDaoBuilder}
+                  selectorNetworks={selectorNetworks}
+                />
+              </FavoriteDaosProvider>
+            </CustomLabelModalProvider>
+          </ModalProvider>
+        </IdentityProvider>
+      </EventEmitterProvider>
     )
   }
 }

--- a/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
+++ b/src/components/CustomLabelIdentityBadge/CustomLabelIdentityBadge.js
@@ -2,12 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Badge, IdentityBadge, font } from '@aragon/ui'
-import { CustomLabelModalContext } from '../../components/CustomLabelModal/CustomLabelModalManager'
-import { IdentityContext } from '../../components/IdentityManager/IdentityManager'
+import { CustomLabelModalContext } from '../CustomLabelModal/CustomLabelModalManager'
+import { IdentityContext } from '../IdentityManager/IdentityManager'
+import { EventEmitterContext } from '../EventEmitterManager/EventEmitterManager'
 
 const CustomLabelIdentityBadge = ({ address, ...props }) => {
   const { resolve } = React.useContext(IdentityContext)
   const { showCustomLabelModal } = React.useContext(CustomLabelModalContext)
+  const { eventEmitter } = React.useContext(EventEmitterContext)
   const [label, setLabel] = React.useState()
   const handleResolve = async () => {
     try {
@@ -24,8 +26,15 @@ const CustomLabelIdentityBadge = ({ address, ...props }) => {
         /* user cancelled modify intent */
       })
   }
+  const handleEvent = addr => {
+    if (addr === address) {
+      handleResolve()
+    }
+  }
   React.useEffect(() => {
     handleResolve()
+    eventEmitter.on('modifyLocalIdentity', handleEvent)
+    return () => eventEmitter.off('modifyLocalIdentity', handleEvent)
   }, [])
 
   return (

--- a/src/components/EventEmitterManager/EventEmitterManager.js
+++ b/src/components/EventEmitterManager/EventEmitterManager.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import EventEmitter from 'events'
+
+const eventEmitter = new EventEmitter()
+
+const EventEmitterContext = React.createContext({})
+
+const EventEmitterProvider = ({ children }) => {
+  return (
+    <EventEmitterContext.Provider value={{ eventEmitter }}>
+      {children}
+    </EventEmitterContext.Provider>
+  )
+}
+
+EventEmitterProvider.propTypes = { children: PropTypes.node.isRequired }
+
+const EventEmitterConsumer = EventEmitterContext.Consumer
+
+export { EventEmitterProvider, EventEmitterConsumer, EventEmitterContext }

--- a/src/components/Preferences/CustomLabels.js
+++ b/src/components/Preferences/CustomLabels.js
@@ -13,6 +13,7 @@ import {
   theme,
 } from '@aragon/ui'
 import { CustomLabelModalContext } from '../CustomLabelModal/CustomLabelModalManager'
+import { EventEmitterContext } from '../EventEmitterManager/EventEmitterManager'
 import EmptyCustomLabels from './EmptyCustomLabels'
 import Import from './Import'
 
@@ -53,10 +54,14 @@ const Labels = ({ clearAll, identities, onImport, onModifyHook }) => {
   if (!identities.length) {
     return <EmptyCustomLabels onImport={onImport} />
   }
+  const { eventEmitter } = React.useContext(EventEmitterContext)
   const updateLabel = (fn, address) => async () => {
     try {
       await fn(address)
+      // preferences get all
       onModifyHook()
+      // for iframe apps
+      eventEmitter.emit('modifyLocalIdentity', address)
     } catch (e) {
       /* nothing was updated */
     }

--- a/src/components/Preferences/Preferences.js
+++ b/src/components/Preferences/Preferences.js
@@ -16,10 +16,12 @@ import {
 } from '@aragon/ui'
 import CustomLabels from './CustomLabels'
 import { AragonType } from '../../prop-types'
+import { EventEmitterContext } from '../EventEmitterManager/EventEmitterManager'
 
 const TABS = ['Network', 'Manage labels']
 
 const Preferences = ({ onClose, smallView, wrapper }) => {
+  const { eventEmitter } = React.useContext(EventEmitterContext)
   const [selectedTab, setSelectedTab] = React.useState(1)
   const [localIdentities, setLocalIdentities] = React.useState({})
   const handleGetAll = async () => {
@@ -34,6 +36,7 @@ const Preferences = ({ onClose, smallView, wrapper }) => {
     }
     wrapper.clearLocalIdentities()
     setLocalIdentities({})
+    eventEmitter.emit('clearLocalIdentities')
   }
   const handleModify = (address, data) => {
     if (!wrapper) {
@@ -50,6 +53,7 @@ const Preferences = ({ onClose, smallView, wrapper }) => {
       await wrapper.modifyAddressIdentity(address, { name })
     })
     setLocalIdentities(await wrapper.getLocalIdentities())
+    eventEmitter.emit('importLocalIdentities')
   }
   React.useEffect(() => {
     handleGetAll()


### PR DESCRIPTION
These changes make it possible to:

- Subscribe to `clear`, `import` and `modify` events from `Preferences`
- Iframe apps reload when any of such events happens
- `CustomLabelIdentityBadge` in native apps re-resolves itself if the address was modified.

https://www.useloom.com/share/46d0f5e7f80541b3bf02fe970b128d05