### PR TITLE
Add github workflow for linting/building

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,21 @@
+workflow "Lint and build" {
+  on = "push"
+  resolves = ["install", "lint", "build"]
+}
+
+action "install" {
+  uses = "actions/npm@master"
+  args = "install"
+}
+
+action "lint" {
+  needs = "install"
+  uses = "actions/npm@master"
+  args = "run lint"
+}
+
+action "build" {
+  needs = "install"
+  uses = "actions/npm@master"
+  args = "run build"
+}


### PR DESCRIPTION
## What

- Replicate the travis configuration in Github

## Why
- We now wait quite a while for travis builds, Github might prove to be faster
- Github Actions are nicely integrated
- We see the failed step, e.g. lint inside the PR without having to navigate away into the Travis cosmos
- https://twitter.com/alicegoldfuss/status/1098604563664420865
- https://news.ycombinator.com/item?id=19218036