### PR TITLE
Organization switcher: open or create another org

### DIFF
--- a/src/components/MenuPanel/OrganizationSwitcher/FavoriteRow.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/FavoriteRow.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { theme } from '@aragon/ui'
 import OrganizationItem from './OrganizationItem'
 import { FavoriteDaoType } from '../../../prop-types'
-import FocusVisible from '../../FocusVisible'
+import ItemButton from './ItemButton'
 
 class FavoriteRow extends React.Component {
   static propTypes = {
@@ -23,79 +21,33 @@ class FavoriteRow extends React.Component {
   render() {
     const { dao } = this.props
     return (
-      <Main>
-        <FocusVisible>
-          {({ focusVisible, onFocus }) => (
-            <React.Fragment>
-              <OrganizationButton
-                onClick={this.handleOpenClick}
-                focusVisible={focusVisible}
-                onFocus={onFocus}
-              >
-                <OrganizationItem dao={dao} />
-              </OrganizationButton>
-              <FavoriteButton
-                onClick={this.handleFavoriteClick}
-                focusVisible={focusVisible}
-                onFocus={onFocus}
-              >
-                {dao.favorited ? '★' : '☆'}
-              </FavoriteButton>
-            </React.Fragment>
-          )}
-        </FocusVisible>
-      </Main>
+      <div
+        css={`
+          display: flex;
+          align-items: center;
+        `}
+      >
+        <ItemButton
+          css={`
+            display: flex;
+            flex-grow: 1;
+          `}
+          onClick={this.handleOpenClick}
+        >
+          <OrganizationItem dao={dao} />
+        </ItemButton>
+        <ItemButton
+          css={`
+            padding: 0 10px;
+            color: hsl(50, 90%, 50%);
+          `}
+          onClick={this.handleFavoriteClick}
+        >
+          {dao.favorited ? '★' : '☆'}
+        </ItemButton>
+      </div>
     )
   }
 }
-
-const Main = styled.div`
-  display: flex;
-  align-items: center;
-`
-
-const OrganizationButton = styled.button.attrs({ type: 'button' })`
-  flex-grow: 1;
-  border: 0;
-  background: none;
-  cursor: pointer;
-  padding: 0;
-  &:active {
-    background: rgba(220, 234, 239, 0.3);
-  }
-  &:focus {
-    outline: ${p => (p.focusVisible ? `2px solid ${theme.accent}` : '0')};
-  }
-  &:active {
-    outline: 0;
-    background: rgba(220, 234, 239, 0.3);
-  }
-  &::-moz-focus-inner {
-    border: 0;
-  }
-`
-
-const FavoriteButton = styled.button.attrs({ type: 'button' })`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  height: 44px;
-  padding: 0 10px;
-  white-space: nowrap;
-  cursor: pointer;
-  border: 0;
-  color: hsl(50, 90%, 50%);
-  background: transparent;
-  &:active {
-    background: rgba(220, 234, 239, 0.3);
-  }
-  &:focus {
-    outline: ${p => (p.focusVisible ? `2px solid ${theme.accent}` : '0')};
-  }
-  &::-moz-focus-inner {
-    border: 0;
-  }
-`
 
 export default FavoriteRow

--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -9,7 +9,7 @@ class Favorites extends React.Component {
   static propTypes = {
     favoriteDaos: PropTypes.arrayOf(FavoriteDaoType),
     currentDao: DaoItemType,
-    onDone: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
   }
 
   state = { localDaos: [] }
@@ -19,9 +19,9 @@ class Favorites extends React.Component {
   }
 
   componentWillUnmount() {
-    const { onDone } = this.props
+    const { onUpdate } = this.props
     const { localDaos } = this.state
-    onDone(
+    onUpdate(
       localDaos
         .filter(dao => dao.favorited)
         .map(dao => ({

--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { FavoriteDaoType, DaoItemType } from '../../../prop-types'
 import FavoriteRow from './FavoriteRow'
+import ItemButton from './ItemButton'
 
 class Favorites extends React.Component {
   static propTypes = {
@@ -63,6 +64,11 @@ class Favorites extends React.Component {
     }
   }
 
+  handleGoHome = () => {
+    window.location.hash = ''
+    this.props.onDone()
+  }
+
   handleDaoOpened = dao => {
     window.location.hash = `/${dao.name || dao.address}`
     this.props.onDone()
@@ -86,6 +92,16 @@ class Favorites extends React.Component {
     )
     return (
       <section aria-label="Organizations">
+        <ItemButton
+          onClick={this.handleGoHome}
+          css={`
+            width: 100%;
+            padding: 0 20px;
+          `}
+        >
+          Open organization…
+        </ItemButton>
+
         <SectionTitle>Current</SectionTitle>
         <FavoriteRow
           dao={currentDao}

--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { IconPlus, theme } from '@aragon/ui'
 import { FavoriteDaoType, DaoItemType } from '../../../prop-types'
 import FavoriteRow from './FavoriteRow'
 import ItemButton from './ItemButton'
@@ -97,7 +98,18 @@ class Favorites extends React.Component {
             padding: 0 20px;
           `}
         >
-          Open organization…
+          <span
+            css={`
+              display: flex;
+              align-items: center;
+              width: 24px;
+              margin-right: 13px;
+              color: ${theme.accent};
+            `}
+          >
+            <IconPlus />
+          </span>
+          <span>Open organization…</span>
         </ItemButton>
 
         <SectionTitle>Current</SectionTitle>

--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -96,6 +96,8 @@ class Favorites extends React.Component {
           css={`
             width: 100%;
             padding: 0 20px;
+            margin-bottom: 15px;
+            border-bottom: 1px solid ${theme.contentBorder};
           `}
         >
           <span

--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -66,12 +66,10 @@ class Favorites extends React.Component {
 
   handleGoHome = () => {
     window.location.hash = ''
-    this.props.onDone()
   }
 
   handleDaoOpened = dao => {
     window.location.hash = `/${dao.name || dao.address}`
-    this.props.onDone()
   }
 
   handleFavoriteUpdate = ({ address }, favorited) => {

--- a/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ButtonBase } from '@aragon/ui'
+import { ButtonBase, theme } from '@aragon/ui'
 
 const ItemButton = props => (
   <ButtonBase
@@ -7,6 +7,11 @@ const ItemButton = props => (
       display: flex;
       align-items: center;
       height: 44px;
+      color: ${theme.textPrimary};
+      border-radius: 0;
+      &:active {
+        background: rgba(220, 234, 239, 0.3);
+      }
     `}
     {...props}
   />

--- a/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
@@ -1,36 +1,15 @@
 import React from 'react'
-import { theme } from '@aragon/ui'
-import FocusVisible from '../../FocusVisible'
+import { ButtonBase } from '@aragon/ui'
 
 const ItemButton = props => (
-  <FocusVisible>
-    {({ focusVisible, onFocus }) => (
-      <button
-        onFocus={onFocus}
-        css={`
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          height: 44px;
-          padding: 0;
-          white-space: nowrap;
-          cursor: pointer;
-          border: 0;
-          background: transparent;
-          &:active {
-            background: rgba(220, 234, 239, 0.3);
-          }
-          &:focus {
-            outline: ${focusVisible ? `2px solid ${theme.accent}` : '0'};
-          }
-          &::-moz-focus-inner {
-            border: 0;
-          }
-        `}
-        {...props}
-      />
-    )}
-  </FocusVisible>
+  <ButtonBase
+    css={`
+      display: flex;
+      align-items: center;
+      height: 44px;
+    `}
+    {...props}
+  />
 )
 
 export default ItemButton

--- a/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/ItemButton.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { theme } from '@aragon/ui'
+import FocusVisible from '../../FocusVisible'
+
+const ItemButton = props => (
+  <FocusVisible>
+    {({ focusVisible, onFocus }) => (
+      <button
+        onFocus={onFocus}
+        css={`
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          height: 44px;
+          padding: 0;
+          white-space: nowrap;
+          cursor: pointer;
+          border: 0;
+          background: transparent;
+          &:active {
+            background: rgba(220, 234, 239, 0.3);
+          }
+          &:focus {
+            outline: ${focusVisible ? `2px solid ${theme.accent}` : '0'};
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+        `}
+        {...props}
+      />
+    )}
+  </FocusVisible>
+)
+
+export default ItemButton

--- a/src/components/MenuPanel/OrganizationSwitcher/OrganizationItem.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/OrganizationItem.js
@@ -43,6 +43,7 @@ class OrganizationItem extends React.Component {
 }
 
 const Organization = styled.div`
+  flex-grow: 1;
   display: flex;
   align-items: center;
   padding: 10px 20px;

--- a/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
@@ -52,7 +52,7 @@ class OrganizationSwitcher extends React.PureComponent {
               <Favorites
                 favoriteDaos={favoriteDaos}
                 currentDao={currentDao}
-                onDone={this.handleFavoritesUpdate}
+                onUpdate={this.handleFavoritesUpdate}
               />
             </Popup>
           </Main>

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -135,7 +135,7 @@ const Main = styled(Card)`
   width: auto;
   height: auto;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
-  padding: 10px 0;
+  padding: 0 0 10px;
   &:focus {
     outline: 0;
   }


### PR DESCRIPTION
Fixes #568

### Preview

<p align=center> <img width="1000" alt="" src="https://user-images.githubusercontent.com/36158/55641084-59527880-57cd-11e9-9e59-fdc24a93f875.png"><br>Normal state

<p align=center> <img width="1000" alt="" src="https://user-images.githubusercontent.com/36158/55641086-59eb0f00-57cd-11e9-9178-27fb8742f368.png"><br>Focused state

### Changes

- Add an item to open or create another organization by redirecting to the home screen.
- Move the common focus logic and styling in `ItemButton`.

### Notes

- The correct label should be something like “Create or open another organization”, but “Open organization…” was chosen to keep it shorter.
- The “…” were used to make it clearer that it is a clickable item, but maybe an icon could do a better job at it? Edit: done, thanks @dizzypaty!