### PR TITLE
fix(MenuPanel): avoid clickable margin above system apps toggle

### DIFF
--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -144,10 +144,9 @@ class MenuPanel extends React.PureComponent {
                     : this.renderAppGroup(app, false)
                 )}
               </div>
-              <StyledButton onClick={this.handleToggleSystemApps}>
+              <SystemAppsToggle onClick={this.handleToggleSystemApps}>
                 <h1
                   style={{
-                    marginTop: '24px',
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'flex-end',
@@ -166,7 +165,7 @@ class MenuPanel extends React.PureComponent {
                     <IconArrow />
                   </span>
                 </h1>
-              </StyledButton>
+              </SystemAppsToggle>
               <Transition
                 items={systemAppsOpened}
                 config={springs.swift}
@@ -344,15 +343,15 @@ AnimatedMenuPanel.propTypes = {
   onCloseMenuPanel: PropTypes.func.isRequired,
 }
 
-const StyledButton = styled(ButtonBase)`
+const SystemAppsToggle = styled(ButtonBase)`
   padding: 0;
   margin: 0;
+  margin-top: 20px;
   background: none;
   border: none;
   cursor: pointer;
   width: 100%;
   text-align: left;
-  margin-top: 5px;
   outline: none;
 `
 


### PR DESCRIPTION
Seems odd to have the extra margin above the actual button (easily mistakable for the app itself):

<img width="259" alt="Screen Shot 2019-03-29 at 2 00 27 PM" src="https://user-images.githubusercontent.com/4166642/55234270-16236300-522b-11e9-9855-c81acc948422.png">
