### PR TITLE
Menu panel tweaks

### DIFF
--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -4,16 +4,7 @@ import styled from 'styled-components'
 import { Keyframes, Spring, animated } from 'react-spring'
 import throttle from 'lodash.throttle'
 import color from 'onecolor'
-import {
-  ButtonBase,
-  Button,
-  IconSettings,
-  Viewport,
-  breakpoint,
-  springs,
-  theme,
-  unselectable,
-} from '@aragon/ui'
+import { ButtonBase, Viewport, springs, theme, unselectable } from '@aragon/ui'
 import memoize from 'lodash.memoize'
 import { AppType, AppsStatusType, DaoAddressType } from '../../prop-types'
 import { staticApps } from '../../static-apps'
@@ -259,17 +250,10 @@ class MenuPanel extends React.PureComponent {
               `}
             />
           )}
-          <MenuPanelFooter connected={connected} />
-          <PreferencesWrap>
-            <StyledPreferencesButton
-              size="small"
-              mode="outline"
-              label="Preferences"
-              onClick={onOpenPreferences}
-            >
-              <IconSettings /> Preferences
-            </StyledPreferencesButton>
-          </PreferencesWrap>
+          <MenuPanelFooter
+            connected={connected}
+            onOpenPreferences={onOpenPreferences}
+          />
         </In>
       </Main>
     )
@@ -464,30 +448,6 @@ const SystemAppsToggleArrow = props => (
     </span>
   </animated.span>
 )
-
-const PreferencesWrap = styled.div`
-  text-align: left;
-
-  ${breakpoint(
-    'medium',
-    `
-      text-align: center;
-    `
-  )}
-`
-
-const StyledPreferencesButton = styled(Button)`
-  display: inline-flex;
-  margin: 0 16px 16px 16px;
-  align-items: center;
-
-  ${breakpoint(
-    'medium',
-    `
-      margin: 0 0 16px 0;
-    `
-  )}
-`
 
 const Overlay = styled(animated.div)`
   position: absolute;

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -195,45 +195,37 @@ class MenuPanel extends React.PureComponent {
               >
                 {({ openProgress, showBorder }) => (
                   <div>
-                    <animated.div
-                      style={{
-                        transform: showBorder.interpolate(
-                          v => `translate3d(0, ${-v * 0}px, 0)`
-                        ),
-                      }}
-                    >
-                      <SystemAppsToggle onClick={this.handleToggleSystemApps}>
-                        <animated.div
+                    <SystemAppsToggle onClick={this.handleToggleSystemApps}>
+                      <animated.div
+                        style={{
+                          position: 'absolute',
+                          height: '1px',
+                          left: '0',
+                          right: '0',
+                          bottom: '0',
+                          boxShadow: '0 1px 1px rgba(0, 0, 0, 0.1)',
+                          opacity: showBorder,
+                        }}
+                      />
+                      <h1
+                        css={`
+                          display: flex;
+                          justify-content: flex-start;
+                          align-items: flex-end;
+                        `}
+                      >
+                        <span>System</span>
+                        <SystemAppsToggleArrow
                           style={{
-                            position: 'absolute',
-                            height: '1px',
-                            left: '0',
-                            right: '0',
-                            bottom: '0',
-                            boxShadow: '0 1px 1px rgba(0, 0, 0, 0.1)',
-                            opacity: showBorder.interpolate(v => v),
+                            marginLeft: '5px',
+                            transform: openProgress.interpolate(
+                              v => `rotate(${(1 - v) * 180}deg)`
+                            ),
+                            transformOrigin: '50% calc(50% - 0.5px)',
                           }}
                         />
-                        <h1
-                          css={`
-                            display: flex;
-                            justify-content: flex-start;
-                            align-items: flex-end;
-                          `}
-                        >
-                          <span>System</span>
-                          <SystemAppsToggleArrow
-                            style={{
-                              marginLeft: '5px',
-                              transform: openProgress.interpolate(
-                                v => `rotate(${(1 - v) * 180}deg)`
-                              ),
-                              transformOrigin: '50% calc(50% - 0.5px)',
-                            }}
-                          />
-                        </h1>
-                      </SystemAppsToggle>
-                    </animated.div>
+                      </h1>
+                    </SystemAppsToggle>
                     <div css="overflow: hidden">
                       <animated.div
                         style={{

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Keyframes, Spring, animated } from 'react-spring'
+import { Spring, animated } from 'react-spring'
 import throttle from 'lodash.throttle'
 import color from 'onecolor'
 import { ButtonBase, Viewport, springs, theme, unselectable } from '@aragon/ui'

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -169,6 +169,7 @@ class MenuPanel extends React.PureComponent {
                 )}
               </div>
               <Spring
+                config={springs.smooth}
                 from={{ openProgress: 0 }}
                 to={{ openProgress: Number(systemAppsOpened) }}
                 immediate={!animate}

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -57,6 +57,7 @@ const prepareAppGroups = apps =>
   }, [])
 
 // Interpolate the elevation of a toggle from which a drawer slides down.
+// In / out example: [0, 0.25, 0.5, 0.75, 1] => [0, 0.5, 1, 0.5, 0]
 const interpolateToggleElevation = (value, fn = v => v) =>
   value.interpolate(v => fn(1 - Math.abs(v * 2 - 1)))
 

--- a/src/components/MenuPanel/MenuPanelFooter.js
+++ b/src/components/MenuPanel/MenuPanelFooter.js
@@ -1,20 +1,38 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Text, theme } from '@aragon/ui'
+import { Button, IconSettings, Text, theme } from '@aragon/ui'
 
-const MenuPanelFooter = ({ connected }) => (
-  <div css="margin: 15px 20px;">
+const MenuPanelFooter = ({ connected, onOpenPreferences }) => (
+  <div css="margin: 15px 20px">
     <ConnectionBullet connected={connected} />
     <Text size="xsmall">
       {connected ? 'Connected to the network' : 'Not connected'}
     </Text>
+    <PreferencesButton onClick={onOpenPreferences} />
   </div>
 )
 
 MenuPanelFooter.propTypes = {
   connected: PropTypes.bool,
+  onOpenPreferences: PropTypes.func.isRequired,
 }
+
+const PreferencesButton = ({ onClick }) => (
+  <div css="margin-top: 12px">
+    <Button size="small" mode="outline" label="Preferences" onClick={onClick}>
+      <span
+        css={`
+          display: flex;
+          align-items: center;
+        `}
+      >
+        <IconSettings css="margin: 0 6px 0 -3px" />
+        <span>Preferences</span>
+      </span>
+    </Button>
+  </div>
+)
 
 const ConnectionBullet = styled.span`
   width: 8px;

--- a/src/components/MenuPanel/MenuPanelFooter.js
+++ b/src/components/MenuPanel/MenuPanelFooter.js
@@ -12,7 +12,6 @@ const MenuPanelFooter = ({ connected, onOpenPreferences }) => (
     <PreferencesButton onClick={onOpenPreferences} />
   </div>
 )
-
 MenuPanelFooter.propTypes = {
   connected: PropTypes.bool,
   onOpenPreferences: PropTypes.func.isRequired,
@@ -33,6 +32,9 @@ const PreferencesButton = ({ onClick }) => (
     </Button>
   </div>
 )
+PreferencesButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+}
 
 const ConnectionBullet = styled.span`
   width: 8px;


### PR DESCRIPTION
Borders: consistent colors + use of 1px border vs. height (browser engines round these differently).

Preferences button: the button is now always left aligned + fix inner spacing.

System apps toggle:

- The arrow is now next to the label, vertically aligned, points in the direction of the action (opposite), and is animated.
- The toggle button has an active state.
- Transition + cosmetic tweaks.

~Note about the toggle transition: the plan is to improve it later, after having moved to the latest version of react-spring. I think it could work better visually, and I’d also like it to feel more snappy, but in the react-spring version we are using, keyframe transitions seem to wait for the current step to finish before cancelling the transition. I want to check if it gets fixed after an upgrade before trying an alternative approach.~
**Edit:** [moved back to a single step transition](https://github.com/aragon/aragon/pull/684/commits/488f9dcc3ec4a5033208d536963ee407ecc93818).