### PR TITLE
Identity Provider: provide response to aragonAPI when user cancels identity modification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -280,6 +280,9 @@ class App extends React.Component {
   }
 
   handleIdentityCancel = () => {
+    const { identityIntent } = this.state
+
+    identityIntent.reject(new Error('Identity modification cancelled'))
     this.setState({ identityIntent: null })
   }
 
@@ -287,9 +290,8 @@ class App extends React.Component {
     const { identityIntent } = this.state
     this.state.wrapper
       .modifyAddressIdentity(address, { name: label })
-      .then(() =>
-        this.setState({ identityIntent: null }, identityIntent.resolve)
-      )
+      .then(identityIntent.resolve)
+      .then(() => this.setState({ identityIntent: null }))
       .catch(identityIntent.reject)
   }
 


### PR DESCRIPTION
Coupled with https://github.com/aragon/aragon.js/pull/277, apps will now receive errors on `requestAddressIdentityModification()`.