### PR TITLE
feat: restart app worker when upgraded

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,15 +28,22 @@ import {
   DAO_CREATION_STATUS_ERROR,
 } from './symbols'
 
+const INITIAL_DAO_STATE = {
+  apps: [],
+  appIdentifiers: {},
+  appsStatus: APPS_STATUS_LOADING,
+  daoAddress: { address: '', domain: '' },
+  permissions: {},
+  permissionsLoading: true,
+}
+
 class App extends React.Component {
   state = {
+    ...INITIAL_DAO_STATE,
     account: '',
-    apps: [],
-    appsStatus: APPS_STATUS_LOADING,
     balance: getUnknownBalance(),
     buildData: null, // data returned by aragon.js when a DAO is created
     connected: false,
-    daoAddress: { address: '', domain: '' },
     // daoCreationStatus is one of:
     //  - DAO_CREATION_STATUS_NONE
     //  - DAO_CREATION_STATUS_SUCCESS
@@ -45,8 +52,6 @@ class App extends React.Component {
     fatalError: null,
     identityIntent: null,
     locator: {},
-    permissions: {},
-    permissionsLoading: true,
     prevLocator: null,
     selectorNetworks: [
       ['main', 'Ethereum Mainnet', 'https://mainnet.aragon.org/'],
@@ -193,18 +198,19 @@ class App extends React.Component {
 
   updateDao(dao = null) {
     // Cancel the subscriptions / unload the wrapper
-    if (dao === null && this.state.wrapper) {
+    if (this.state.wrapper) {
       this.state.wrapper.cancel()
       this.setState({ wrapper: null })
-      return
     }
 
     // Reset the DAO state
     this.setState({
-      appsStatus: APPS_STATUS_LOADING,
-      apps: [],
-      daoAddress: { address: '', domain: '' },
+      ...INITIAL_DAO_STATE,
     })
+
+    if (dao === null) {
+      return
+    }
 
     log('Init DAO', dao)
     initWrapper(dao, contractAddresses.ensRegistry, {

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -114,11 +114,16 @@ class Wrapper extends React.PureComponent {
       wrapper,
       locator: { instanceId },
     } = this.props
-    if (
-      !wrapper ||
-      !apps.find(app => addressesEqual(app.proxyAddress, instanceId))
-    ) {
-      console.error('The app cannot be connected to aragon.js')
+    if (!wrapper) {
+      console.error(
+        `Attempted to connect app (${instanceId}) before aragonAPI was ready`
+      )
+      return
+    }
+    if (!apps.find(app => addressesEqual(app.proxyAddress, instanceId))) {
+      console.error(
+        `The requested app (${instanceId}) could not be found in the installed apps`
+      )
       return
     }
 

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -236,7 +236,7 @@ const subscribe = (
     apps,
     permissions,
     forwarders,
-    identifiers,
+    appIdentifiers,
     identityIntents,
     transactions,
   } = wrapper
@@ -257,7 +257,7 @@ const subscribe = (
     connectedApp: null,
     connectedWorkers: workerSubscriptionPool,
     forwarders: forwarders.subscribe(onForwarders),
-    identifiers: identifiers.subscribe(onAppIdentifiers),
+    appIdentifiers: appIdentifiers.subscribe(onAppIdentifiers),
     identityIntents: identityIntents.subscribe(onIdentityIntent),
     transactions: transactions.subscribe(onTransaction),
     workers: apps.subscribe(apps => {

--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -35,6 +35,20 @@ export class WorkerSubscriptionPool {
   hasWorker = proxyAddress => {
     return this.workers.has(proxyAddress)
   }
+  removeWorker = async (proxyAddress, clearCache) => {
+    if (this.hasWorker(proxyAddress)) {
+      const { connection, worker } = this.workers.get(proxyAddress)
+      this.workers.delete(proxyAddress)
+
+      worker.terminate()
+
+      if (clearCache) {
+        await connection.shutdownAndClearCache()
+      } else {
+        connection.shutdown()
+      }
+    }
+  }
   unsubscribe = () => {
     this.workers.forEach(({ connection, worker }) => {
       // TODO: ask worker to nicely terminate itself first

--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -29,17 +29,17 @@ const fetchUrl = async url => {
 
 export class WorkerSubscriptionPool {
   workers = new Map()
-  addWorker = ({ app, subscription, worker }) => {
-    this.workers.set(app.proxyAddress, { app, subscription, worker })
+  addWorker = ({ app, connection, worker }) => {
+    this.workers.set(app.proxyAddress, { app, connection, worker })
   }
   hasWorker = proxyAddress => {
     return this.workers.has(proxyAddress)
   }
   unsubscribe = () => {
-    this.workers.forEach(({ subscription, worker }) => {
+    this.workers.forEach(({ connection, worker }) => {
       // TODO: ask worker to nicely terminate itself first
       worker.terminate()
-      subscription.unsubscribe()
+      connection.shutdown()
     })
   }
 }


### PR DESCRIPTION
Coupled with https://github.com/aragon/aragon.js/pull/267, this allows the client to restart an upgraded app's worker in-place.

We reset the cache on the upgrade as well, as there may be incompatibilities in the reduced state between different worker versions (as well as paired with their frontends). Note that app frontends are handled mostly transparently as we re-load their URL into the iframe upon navigation.