### PR TITLE
Fix import file button

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-blockies": "^1.3.0",
     "react-container-dimensions": "^1.3.3",
     "react-dom": "^16.8.4",
-    "react-dropzone": "^10.0.0",
+    "react-dropzone": "^10.1.3",
     "react-onclickout": "^2.0.8",
     "react-spring": "^7.2.10",
     "react-with-gesture": "^4.0.4",

--- a/src/components/Preferences/Import.js
+++ b/src/components/Preferences/Import.js
@@ -46,7 +46,7 @@ const fileImport = cb => files => {
 
 const Import = ({ onImport }) => {
   const handleImport = e => fileImport(onImport)(e.currentTarget.files)
-  const { getRootProps } = useDropzone({
+  const { getRootProps, getInputProps } = useDropzone({
     onDrop: fileImport(onImport),
   })
 
@@ -60,6 +60,7 @@ const Import = ({ onImport }) => {
       {...getRootProps()}
     >
       <input
+        {...getInputProps()}
         type="file"
         onChange={handleImport}
         css={`

--- a/src/components/Preferences/Import.js
+++ b/src/components/Preferences/Import.js
@@ -45,9 +45,9 @@ const fileImport = cb => files => {
 }
 
 const Import = ({ onImport }) => {
-  const handleImport = e => fileImport(onImport)(e.currentTarget.files)
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: fileImport(onImport),
+    multiple: false,
   })
 
   return (
@@ -61,8 +61,6 @@ const Import = ({ onImport }) => {
     >
       <input
         {...getInputProps()}
-        type="file"
-        onChange={handleImport}
         css={`
           position: absolute;
           z-index: 1;


### PR DESCRIPTION
## What
- Bug fix for non working button

## Why
- Because we were not using `getInputProps` on the input (as suggested in react-dropzone docs), `react-dropzone` didn't properly attach the callback or set the ref. 


