### PR TITLE
fix: center Preferences' close button

### DIFF
--- a/src/components/Preferences/Preferences.js
+++ b/src/components/Preferences/Preferences.js
@@ -77,9 +77,7 @@ const Preferences = ({ dao, onClose, smallView, wrapper }) => {
       appBar={
         <StyledAppBar>
           <Title>Preferences</Title>
-          <StyledButton label="Close" onClick={onClose}>
-            <IconClose />
-          </StyledButton>
+          <CloseButton onClick={onClose} />
         </StyledAppBar>
       }
     >
@@ -202,10 +200,21 @@ const StyledAppBar = styled(AppBar)`
   )}
 `
 
-const StyledButton = styled(ButtonIcon)`
+const CloseButton = styled(ButtonIcon).attrs({
+  children: <IconClose />,
+  label: 'Close',
+})`
   width: auto;
   height: 100%;
   padding: 0 16px;
+
+  ${breakpoint(
+    'medium',
+    `
+      /* half screen width minus half max container width */
+      margin-right: calc(100vw / 2 - ${BREAKPOINTS.medium / 2}px);
+    `
+  )}
 `
 
 export default props => (


### PR DESCRIPTION
Horizontally centers the close button to be the same margin as the title.

Before:

<img width="1288" alt="Screen Shot 2019-04-15 at 11 44 50 PM" src="https://user-images.githubusercontent.com/4166642/56167687-1ec0bb00-5fd9-11e9-9017-a20019f8c8ea.png">

After:

<img width="1022" alt="Screen Shot 2019-04-15 at 11 44 32 PM" src="https://user-images.githubusercontent.com/4166642/56167691-22544200-5fd9-11e9-8b1c-749f0aa25a1f.png">
