### PR TITLE
Ensure the local identity is resolved when the entity changes

### DIFF
--- a/src/components/IdentityBadge/LocalIdentityBadge.js
+++ b/src/components/IdentityBadge/LocalIdentityBadge.js
@@ -56,7 +56,7 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
     return () => {
       subscription.unsubscribe()
     }
-  }, [entity])
+  }, [entity, identityEvents$])
 
   return (
     <IdentityBadgeWithNetwork

--- a/src/components/IdentityBadge/LocalIdentityBadge.js
+++ b/src/components/IdentityBadge/LocalIdentityBadge.js
@@ -56,7 +56,7 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
     return () => {
       subscription.unsubscribe()
     }
-  }, [])
+  }, [entity])
 
   return (
     <IdentityBadgeWithNetwork


### PR DESCRIPTION
## What 
- Ensure the effect runs when the entity changes

## Why
- When changing accounts the custom identity label wouldn't update