### PR TITLE
App Center: correctly use repo's latest version for baseUrl

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -291,7 +291,6 @@ class Wrapper extends React.PureComponent {
         />
 
         <UpgradeOrganizationPanel
-          apps={apps}
           dao={locator.dao}
           opened={orgUpgradePanelOpened}
           onClose={this.hideOrgUpgradePanel}

--- a/src/apps/AppCenter/AppCenter.js
+++ b/src/apps/AppCenter/AppCenter.js
@@ -13,6 +13,7 @@ import {
   DaoAddressType,
   RepoType,
 } from '../../prop-types'
+import { repoBaseUrl } from '../../url-utils'
 import { log } from '../../utils'
 
 const SCREENS = [
@@ -95,7 +96,7 @@ class AppCenter extends React.Component {
       )
       return {
         ...repo,
-        baseUrl: appGroup.app.baseUrl,
+        baseUrl: repoBaseUrl(repo),
         name: appGroup.name,
         instances: appGroup.instances,
         repoName: appGroup.repoName,

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -9,13 +9,13 @@ import Aragon, {
 import {
   appOverrides,
   sortAppsPair,
-  appLocator,
   ipfsDefaultConf,
   web3Providers,
   contractAddresses,
   defaultGasPriceFn,
 } from './environment'
-import { noop, removeStartingSlash, appendTrailingSlash } from './utils'
+import { appBaseUrl } from './url-utils'
+import { noop, removeStartingSlash } from './utils'
 import {
   getWeb3,
   getUnknownBalance,
@@ -28,37 +28,6 @@ import { NoConnection, DAONotFound } from './errors'
 const POLL_DELAY_ACCOUNT = 2000
 const POLL_DELAY_NETWORK = 2000
 const POLL_DELAY_CONNECTIVITY = 2000
-
-/*
- * Supported locations:
- *   ipfs:{IPFS_HASH}
- *   http:{HOST}
- *   http:{HOST}:{PORT}
- *   http:{HOST}:{PORT}/{PATH}
- *   http:http(s)://{HOST}
- *   http:http(s)://{HOST}:{PORT}
- *   http:http(s)://{HOST}:{PORT}/{PATH}
- */
-const appBaseUrl = (app, gateway = ipfsDefaultConf.gateway) => {
-  // Support overriding app URLs, see network-config.js
-  if (appLocator[app.appId]) {
-    return appLocator[app.appId]
-  }
-  if (!app.content) {
-    return ''
-  }
-
-  const { provider, location } = app.content
-  if (provider === 'ipfs') {
-    return `${gateway}/${location}/`
-  }
-  if (provider === 'http') {
-    return /^https?:\/\//.test(location)
-      ? appendTrailingSlash(location)
-      : `http://${location}/`
-  }
-  return ''
-}
 
 const applyAppOverrides = apps =>
   apps.map(app => ({ ...app, ...(appOverrides[app.appId] || {}) }))

--- a/src/components/Upgrade/UpgradeOrganizationPanel.js
+++ b/src/components/Upgrade/UpgradeOrganizationPanel.js
@@ -10,25 +10,22 @@ import {
   SidePanelSplit,
   blockExplorerUrl,
 } from '@aragon/ui'
-import { AppsListType, ReposListType } from '../../prop-types'
+import { ReposListType } from '../../prop-types'
 import { TextLabel } from '../../components/TextStyles'
 import AppIcon from '../../components/AppIcon/AppIcon'
 import { network } from '../../environment'
 import { KNOWN_ICONS } from '../../repo-utils'
 import { getAppPath } from '../../routing'
+import { repoBaseUrl } from '../../url-utils'
 import { GU } from '../../utils'
 
 const VERSION = '0.7 Bella'
 
-function getBaseUrlFromAppId(appId, apps) {
-  const app = apps.find(app => app.appId === appId)
-  return (app && app.baseUrl) || null
-}
-
-function getAppVersionData({ content, version }, apps) {
+function getAppVersionData(repo) {
+  const { content, version } = repo
   return {
     appId: content.appId,
-    baseUrl: getBaseUrlFromAppId(content.appId, apps),
+    baseUrl: repoBaseUrl(repo),
     contractAddress: content.contractAddress,
     icons: content.icons,
     knownIcon: KNOWN_ICONS.has(content.appId)
@@ -40,19 +37,19 @@ function getAppVersionData({ content, version }, apps) {
 }
 
 const UpgradeOrganizationPanel = React.memo(
-  ({ apps = [], repos = [], opened, onClose, dao }) => {
+  ({ repos = [], opened, onClose, dao }) => {
     const sourceUrl = 'https://github.com/aragon/aragon-apps'
 
     const [currentVersions, newVersions] = useMemo(
       () =>
         repos.reduce(
           (results, repo) => [
-            [...results[0], getAppVersionData(repo.currentVersion, apps)],
-            [...results[1], getAppVersionData(repo.latestVersion, apps)],
+            [...results[0], getAppVersionData(repo.currentVersion)],
+            [...results[1], getAppVersionData(repo.latestVersion)],
           ],
           [[], []]
         ),
-      [repos, apps]
+      [repos]
     )
 
     return (
@@ -136,7 +133,6 @@ const UpgradeOrganizationPanel = React.memo(
 UpgradeOrganizationPanel.propTypes = {
   opened: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  apps: AppsListType,
   repos: ReposListType,
   dao: PropTypes.string.isRequired,
 }

--- a/src/url-utils.js
+++ b/src/url-utils.js
@@ -1,6 +1,16 @@
 import { appLocator, ipfsDefaultConf } from './environment'
 import { appendTrailingSlash } from './utils'
 
+/*
+ * Supported locations:
+ *   ipfs:{IPFS_HASH}
+ *   http:{HOST}
+ *   http:{HOST}:{PORT}
+ *   http:{HOST}:{PORT}/{PATH}
+ *   http:http(s)://{HOST}
+ *   http:http(s)://{HOST}:{PORT}
+ *   http:http(s)://{HOST}:{PORT}/{PATH}
+ */
 function contentBaseUrl(content, gateway) {
   if (!content) {
     return ''
@@ -18,16 +28,6 @@ function contentBaseUrl(content, gateway) {
   return ''
 }
 
-/*
- * Supported locations:
- *   ipfs:{IPFS_HASH}
- *   http:{HOST}
- *   http:{HOST}:{PORT}
- *   http:{HOST}:{PORT}/{PATH}
- *   http:http(s)://{HOST}
- *   http:http(s)://{HOST}:{PORT}
- *   http:http(s)://{HOST}:{PORT}/{PATH}
- */
 export function appBaseUrl(app, gateway = ipfsDefaultConf.gateway) {
   // Support overriding app URLs, see network-config.js
   if (appLocator[app.appId]) {

--- a/src/url-utils.js
+++ b/src/url-utils.js
@@ -1,0 +1,54 @@
+import { appLocator, ipfsDefaultConf } from './environment'
+import { appendTrailingSlash } from './utils'
+
+function contentBaseUrl(content, gateway) {
+  if (!content) {
+    return ''
+  }
+
+  const { provider, location } = content
+  if (provider === 'ipfs') {
+    return `${gateway}/${location}/`
+  }
+  if (provider === 'http') {
+    return /^https?:\/\//.test(location)
+      ? appendTrailingSlash(location)
+      : `http://${location}/`
+  }
+  return ''
+}
+
+/*
+ * Supported locations:
+ *   ipfs:{IPFS_HASH}
+ *   http:{HOST}
+ *   http:{HOST}:{PORT}
+ *   http:{HOST}:{PORT}/{PATH}
+ *   http:http(s)://{HOST}
+ *   http:http(s)://{HOST}:{PORT}
+ *   http:http(s)://{HOST}:{PORT}/{PATH}
+ */
+export function appBaseUrl(app, gateway = ipfsDefaultConf.gateway) {
+  // Support overriding app URLs, see network-config.js
+  if (appLocator[app.appId]) {
+    return appLocator[app.appId]
+  }
+
+  return contentBaseUrl(app.content, gateway)
+}
+
+export function repoBaseUrl(repo, gateway = ipfsDefaultConf.gateway) {
+  const { appId, latestVersion = {} } = repo
+
+  // Support overriding app URLs, see network-config.js
+  if (appLocator[appId]) {
+    return appLocator[appId]
+  }
+
+  return contentBaseUrl(
+    // The latest version's content is the artifact.json and manifest.json, so we need to
+    // look up content again for the actual content location
+    latestVersion.content && latestVersion.content.content,
+    gateway
+  )
+}


### PR DESCRIPTION
Oops, we should always be using the repo's latest version to get its base url, not the currently installed version (the one we get from apps) 🙈 