### PR TITLE
App center polish

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -296,12 +296,14 @@ class Wrapper extends React.PureComponent {
           web3={web3}
         />
 
-        <UpgradeOrganizationPanel
-          dao={locator.dao}
-          opened={orgUpgradePanelOpened}
-          onClose={this.hideOrgUpgradePanel}
-          repos={repos}
-        />
+        {canUpgradeOrg && (
+          <UpgradeOrganizationPanel
+            dao={locator.dao}
+            opened={orgUpgradePanelOpened}
+            onClose={this.hideOrgUpgradePanel}
+            repos={repos}
+          />
+        )}
       </Main>
     )
   }

--- a/src/apps/AppCenter/InstalledApps/AppContent.js
+++ b/src/apps/AppCenter/InstalledApps/AppContent.js
@@ -117,7 +117,7 @@ const AppContent = React.memo(({ repo, repoVersions, onRequestUpgrade }) => {
             >
               <DetailsGroup compact={compact}>
                 <Heading2>Description</Heading2>
-                <div>{description}</div>
+                <div>{description || 'No description.'}</div>
                 <Heading2>Source code</Heading2>
                 <div>
                   {sourceUrl ? (

--- a/src/apps/AppCenter/InstalledApps/AppContent.js
+++ b/src/apps/AppCenter/InstalledApps/AppContent.js
@@ -24,7 +24,7 @@ const AppContent = React.memo(({ repo, repoVersions, onRequestUpgrade }) => {
       content: {
         author,
         icons,
-        description = '',
+        description = 'No description.',
         screenshots = [],
         source_url: sourceUrl,
       },
@@ -117,7 +117,7 @@ const AppContent = React.memo(({ repo, repoVersions, onRequestUpgrade }) => {
             >
               <DetailsGroup compact={compact}>
                 <Heading2>Description</Heading2>
-                <div>{description || 'No description.'}</div>
+                <div>{description}</div>
                 <Heading2>Source code</Heading2>
                 <div>
                   {sourceUrl ? (

--- a/src/components/Upgrade/UpgradeOrganizationPanel.js
+++ b/src/components/Upgrade/UpgradeOrganizationPanel.js
@@ -14,7 +14,7 @@ import { ReposListType } from '../../prop-types'
 import { TextLabel } from '../../components/TextStyles'
 import AppIcon from '../../components/AppIcon/AppIcon'
 import { network } from '../../environment'
-import { KNOWN_ICONS } from '../../repo-utils'
+import { KNOWN_ICONS, isKnownRepo } from '../../repo-utils'
 import { getAppPath } from '../../routing'
 import { repoBaseUrl } from '../../url-utils'
 import { GU } from '../../utils'
@@ -45,13 +45,15 @@ const UpgradeOrganizationPanel = React.memo(
   ({ repos = [], opened, onClose, dao }) => {
     const [currentVersions, newVersions] = useMemo(
       () =>
-        repos.reduce(
-          (results, repo) => [
-            [...results[0], getAppVersionData(repo.currentVersion)],
-            [...results[1], getAppVersionData(repo.latestVersion)],
-          ],
-          [[], []]
-        ),
+        repos
+          .filter(repo => isKnownRepo(repo.appId))
+          .reduce(
+            (results, repo) => [
+              [...results[0], getAppVersionData(repo.currentVersion)],
+              [...results[1], getAppVersionData(repo.latestVersion)],
+            ],
+            [[], []]
+          ),
       [repos]
     )
 


### PR DESCRIPTION
Super small items:

- Avoid rendering the `UpgradeOrganizationPanel` when not necessary
- Filter the list of repos included in the `UpgradeOrganizationPanel` to only include known ones
- Default an app's description in the App Center to "No description." to avoid a dangling header