### PR TITLE
Update identity badges to compact mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Aragon Institution MTU <contact@aragon.one>",
   "dependencies": {
     "@aragon/templates-tokens": "^1.2.1",
-    "@aragon/ui": "^0.37.0",
+    "@aragon/ui": "^0.38.0",
     "@aragon/wrapper": "^5.0.0-rc.5",
     "@babel/polyfill": "^7.0.0",
     "bn.js": "4.11.6",

--- a/src/components/Activity/ActivityItem.js
+++ b/src/components/Activity/ActivityItem.js
@@ -5,12 +5,13 @@ import {
   IconClose,
   IconError,
   SafeLink,
+  IdentityBadge,
   blockExplorerUrl,
   theme,
 } from '@aragon/ui'
 import { network } from '../../environment'
 import { cssgu } from '../../utils'
-import { shortenAddress, transformAddresses } from '../../web3-utils'
+import { transformAddresses } from '../../web3-utils'
 import AppIcon from '../AppIcon/AppIcon'
 import IconSuccess from '../../icons/IconSuccess'
 import IconPending from '../../icons/IconPending'
@@ -108,7 +109,7 @@ const ItemContent = React.memo(
       {transformAddresses(text, (part, isAddress, index) =>
         isAddress ? (
           <span title={part} key={index}>
-            {shortenAddress(part)}
+            <IdentityBadge entity={part} compact />
           </span>
         ) : (
           <span key={index}>{part}</span>

--- a/src/components/Preferences/EmptyLocalIdentities.js
+++ b/src/components/Preferences/EmptyLocalIdentities.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { EthIdenticon, IdentityBadge, breakpoint } from '@aragon/ui'
+import { IdentityBadge, breakpoint } from '@aragon/ui'
 import { getEmptyAddress } from '../../web3-utils'
 import Import from './Import'
 
@@ -15,21 +15,15 @@ const EmptyLocalIdentities = ({ onImport }) => (
           display: inline-flex;
           margin-right: 2px;
           vertical-align: text-bottom;
+          position: relative;
+          top: 3px;
         `}
       >
-        <EthIdenticon
-          address={getEmptyAddress()}
-          css={`
-            position: relative;
-            z-index: 1;
-            height: 22px;
-            overflow: hidden;
-            border-top-left-radius: 3px;
-            border-bottom-left-radius: 3px;
-            left: 2px;
-          `}
+        <IdentityBadge
+          entity={getEmptyAddress()}
+          customLabel="Address badge"
+          compact
         />
-        <IdentityBadge entity="Address badge" />
       </span>
       anywhere in the app, or importing a .json file with labels by clicking
       "Import" below.

--- a/src/components/Preferences/EmptyLocalIdentities.js
+++ b/src/components/Preferences/EmptyLocalIdentities.js
@@ -23,6 +23,7 @@ const EmptyLocalIdentities = ({ onImport }) => (
           entity={getEmptyAddress()}
           customLabel="Address badge"
           compact
+          badgeOnly
         />
       </span>
       anywhere in the app, or importing a .json file with labels by clicking

--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -61,11 +61,14 @@ class ActionPathsContent extends React.Component {
                         display: inline-flex;
                         vertical-align: middle;
                         margin-right: 4px;
+                        position: relative;
+                        top: -1px;
                       `}
                     >
                       <LocalIdentityBadge
                         entity={type === 'any-account' ? 'Any account' : value}
                         fontSize="small"
+                        compact
                       />
                     </span>
                   )


### PR DESCRIPTION
Update identity badges to compact mode when is displayed with inline text.

~Requires the master branch of @aragon/ui.~

1- Activity panel:

![image](https://user-images.githubusercontent.com/10419340/57307102-57285600-70ba-11e9-84a6-c8cb1dd2ecb2.png)

2- ActionPathsContent

![image](https://user-images.githubusercontent.com/10419340/57307178-758e5180-70ba-11e9-9eb4-bfcf7e3246b6.png)

3- EmptyLocalIdentities

![image](https://user-images.githubusercontent.com/10419340/57307231-95be1080-70ba-11e9-92d8-616dad8e35ad.png)
