### PR TITLE
 HelpScoutBeacon: move towards an onLoad handler and lift ready state to Beacon itself

### DIFF
--- a/src/components/HelpScoutBeacon/BeaconHeadScripts.js
+++ b/src/components/HelpScoutBeacon/BeaconHeadScripts.js
@@ -1,14 +1,29 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
-import { GU } from '../../utils'
+import { noop, GU } from '../../utils'
 
 const BEACON_EMBED =
   '!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});'
 const HELPSCOUT_ID = "'163e0284-762b-4e2d-b3b3-70a73a7e6c9f'"
 const BEACON_INIT = "window.Beacon('init'," + HELPSCOUT_ID + ')'
 
-const BeaconHeadScripts = ({ optedIn }) => {
+const BeaconHeadScripts = React.memo(({ optedIn, onReady }) => {
+  useEffect(() => {
+    let timeout = null
+    if (optedIn) {
+      ;(function isBeaconReady() {
+        if (window.Beacon) {
+          onReady()
+          return
+        }
+        timeout = setTimeout(isBeaconReady, 100)
+      })()
+
+      return () => clearTimeout(timeout)
+    }
+  }, [optedIn, onReady])
+
   if (!optedIn) {
     return null
   }
@@ -46,14 +61,16 @@ const BeaconHeadScripts = ({ optedIn }) => {
       </style>
     </Helmet>
   )
-}
+})
 
 BeaconHeadScripts.propTypes = {
   optedIn: PropTypes.bool,
+  onReady: PropTypes.func,
 }
 
 BeaconHeadScripts.defaultProps = {
   optedIn: false,
+  onReady: noop,
 }
 
 export default BeaconHeadScripts


### PR DESCRIPTION
Attempt at making the logic a bit more natural, despite some cumbersome behaviour with how HelpScout's Beacon works (that probably influenced the original design).

Fixes the issue with the `window.Beacon('on')` handlers not being attached properly when `window.Beacon` isn't in the `useEffect()`'s dependency list. The old way of doing this was prone to race conditions, as `window.Beacon` isn't a value inside React, and is fully dependent on the component being re-rendered afterwards to properly attach (rather than triggering the update itself).

Some notes:

- `window.Beacon('on', 'open')` looks like the most fullproof way to actually detect when the modal can be opened; `window.Beacon` (and the script itself) being loaded are not enough