### PR TITLE
Fix infinite rendering loop

### DIFF
--- a/src/components/LocalIdentityModal/LocalIdentityModal.js
+++ b/src/components/LocalIdentityModal/LocalIdentityModal.js
@@ -7,14 +7,26 @@ import EscapeOutside from '../EscapeOutside/EscapeOutside'
 import IdentityBadgeWithNetwork from '../IdentityBadge/IdentityBadgeWithNetwork'
 import keycodes from '../../keycodes'
 
-const LocalIdentityModal = ({ opened, ...props }) => {
-  const { showModal, hideModal } = React.useContext(ModalContext)
-  React.useEffect(() => {
-    opened ? showModal(Modal, props) : hideModal()
-  }, [opened, showModal, hideModal, props])
+const LocalIdentityModal = React.memo(
+  ({ opened, address, label, onCancel, onSave }) => {
+    const { showModal, hideModal } = React.useContext(ModalContext)
 
-  return null
-}
+    const modalProps = React.useMemo(
+      () => ({ address, label, onCancel, onSave }),
+      [address, label, onCancel, onSave]
+    )
+
+    React.useEffect(() => {
+      if (opened) {
+        showModal(Modal, modalProps)
+      } else {
+        hideModal()
+      }
+    }, [opened, modalProps, showModal, hideModal])
+
+    return null
+  }
+)
 
 LocalIdentityModal.propTypes = {
   opened: PropTypes.bool.isRequired,


### PR DESCRIPTION
What was happening:

1. In `LocalIdentityModal`, `props` was recreated on every render (using `...props`).
2. `props` being present in the [`useEffect()` dependencies](https://github.com/aragon/aragon/compare/fix-infinite-rendering?expand=1#diff-4e3064bc49a5abb8223170f44d7b2dd2L14), the effect was running every time the component was re-rendered.
3. This effect was calling [`hideModal()`](https://github.com/aragon/aragon/blob/master/src/components/ModalManager/ModalManager.js#L22) on `ModalProvider`, which updates the state with a new `modalComponentProps` every time it gets called.
4. The state of `ModalProvider` passed to the context provider every time the component is re-rendered…
5. …which was re-rendering LocalIdentityModal. :loop: 

To solve the issue, I destructured `props` and used them to memoize a `modalProps` object.