### PR TITLE
LocalIdentityModal: update required props

### DIFF
--- a/src/components/LocalIdentityModal/LocalIdentityModal.js
+++ b/src/components/LocalIdentityModal/LocalIdentityModal.js
@@ -111,8 +111,8 @@ const Modal = ({ address, label, onCancel, onSave }) => {
 Modal.propTypes = {
   address: EthereumAddressType,
   label: PropTypes.string,
-  onCancel: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func,
+  onSave: PropTypes.func,
 }
 
 const Error = styled.div`


### PR DESCRIPTION
Turns out these aren't safe as required props, since closing the modal resets all the props.