### PR TITLE
Apps: orphan app WebWorkers' origins

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -22,7 +22,7 @@ import {
   getMainAccount,
   isValidEnsName,
 } from './web3-utils'
-import { getBlobUrl, WorkerSubscriptionPool } from './worker-utils'
+import { getDataUrlForScript, WorkerSubscriptionPool } from './worker-utils'
 import { NoConnection, DAONotFound } from './errors'
 
 const POLL_DELAY_ACCOUNT = 2000
@@ -247,6 +247,7 @@ const subscribe = (
         )
         .forEach(async app => {
           const { name, proxyAddress, script, updated } = app
+          const workerName = `${name}(${proxyAddress})`
           const baseUrl = appBaseUrl(app, ipfsConf.gateway)
 
           // If the app URL is empty, the script can’t be retrieved
@@ -264,11 +265,14 @@ const subscribe = (
           let workerUrl = ''
           try {
             // WebWorkers can only load scripts from the local origin, so we
-            // have to fetch the script as text and make a blob out of it
-            workerUrl = await getBlobUrl(scriptUrl)
+            // have to fetch the script (from an IPFS gateway) and process it locally
+            // Note that we **HAVE** to use a data url, to ensure the Worker is
+            // created with an opaque origin
+            // (see https://html.spec.whatwg.org/multipage/workers.html#dom-worker)
+            workerUrl = await getDataUrlForScript(scriptUrl)
           } catch (e) {
             console.error(
-              `Failed to load ${name}(${proxyAddress})'s script (${script}): `,
+              `Failed to load ${workerName}'s script (${script}): `,
               e
             )
             return
@@ -284,14 +288,10 @@ const subscribe = (
           // If another execution context already loaded this app's worker
           // before we got to it here, let's short circuit
           if (!workerSubscriptionPool.hasWorker(proxyAddress)) {
-            const worker = new Worker(workerUrl)
+            const worker = new Worker(workerUrl, { name: workerName })
             worker.addEventListener(
               'error',
-              err =>
-                console.error(
-                  `Error from worker for ${name}(${proxyAddress}):`,
-                  err
-                ),
+              err => console.error(`Error from worker for ${workerName}:`, err),
               false
             )
 
@@ -302,9 +302,6 @@ const subscribe = (
               connection: connectApp(provider),
             })
           }
-
-          // Clean up the url we created to spawn the worker
-          URL.revokeObjectURL(workerUrl)
         })
     }),
   }

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -265,10 +265,16 @@ const subscribe = (
           let workerUrl = ''
           try {
             // WebWorkers can only load scripts from the local origin, so we
-            // have to fetch the script (from an IPFS gateway) and process it locally
+            // have to fetch the script (from an IPFS gateway) and process it locally.
+            //
             // Note that we **HAVE** to use a data url, to ensure the Worker is
-            // created with an opaque origin
-            // (see https://html.spec.whatwg.org/multipage/workers.html#dom-worker)
+            // created with an opaque ("orphaned") origin, see
+            // https://html.spec.whatwg.org/multipage/workers.html#dom-worker.
+            //
+            // The opaque origin is a necessary part of creating the WebWorker sandbox;
+            // even though the script never has access to the DOM or local storage, it can
+            // still access global features like IndexedDB if it is not enclosed in an
+            // opaque origin.
             workerUrl = await getDataUrlForScript(scriptUrl)
           } catch (e) {
             console.error(

--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -4,15 +4,13 @@
  * @param {string} scriptUrl Real world location of the script
  * @returns {Promise<string>} Local url for the script
  */
-export async function getBlobUrl(scriptUrl) {
+export async function getDataUrlForScript(scriptUrl) {
   // In the future, we might support IPFS protocols in addition to http
-  const text = await fetchUrl(scriptUrl)
-  const blob = new Blob([text], { type: 'application/javascript' })
-
-  return URL.createObjectURL(blob)
+  const blob = await fetchScriptUrlAsBlob(scriptUrl)
+  return readAsDataUrl(blob)
 }
 
-const fetchUrl = async url => {
+const fetchScriptUrlAsBlob = async url => {
   const res = await fetch(url, {
     method: 'GET',
     mode: 'cors',
@@ -24,7 +22,16 @@ const fetchUrl = async url => {
     throw res
   }
 
-  return res.text()
+  return res.blob()
+}
+
+const readAsDataUrl = file => {
+  const reader = new FileReader()
+  return new Promise((resolve, reject) => {
+    reader.addEventListener('loadend', () => resolve(reader.result))
+    reader.addEventListener('error', reject)
+    reader.readAsDataURL(file)
+  })
 }
 
 export class WorkerSubscriptionPool {


### PR DESCRIPTION
Orphans app WebWorkers to an [opaque origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque). Trying to access `indexedDB` now results in an error:

<img src="https://user-images.githubusercontent.com/4166642/58083477-59f67100-7bb9-11e9-9cf8-0c50f31caa32.png" height="100">

This wasn't a huge issue before, as WebWorkers have no access to `localStorage` or the DOM, but after we introduced `localForage` and `indexedDB` access, these WebWorkers all of a sudden were able to Do Bad Things<sup>TM</sup> (like write to an app's cache at will and influence another app's frontend).

----------

Also gives the WebWorkers some names, for ease of debugging:

<img width="315" alt="Screen Shot 2019-05-21 at 10 57 03 AM" src="https://user-images.githubusercontent.com/4166642/58083612-9c1fb280-7bb9-11e9-9936-f6ab120d2c8e.png">
