### PR TITLE
Fix warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "date-fns": "2.0.0-alpha.22",
     "eth-provider": "^0.2.0",
     "file-saver": "^2.0.1",
-    "history": "^4.7.2",
+    "history": "^4.9.0",
     "lodash.memoize": "^4.1.2",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqby": "^4.7.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import createHistory from 'history/createHashHistory'
+import { createHashHistory as createHistory } from 'history'
 import { contractAddresses, web3Providers } from './environment'
 import { parsePath } from './routing'
 import initWrapper, {

--- a/src/components/Activity/TimeTag.js
+++ b/src/components/Activity/TimeTag.js
@@ -36,7 +36,7 @@ function TimeTag({ date, label, ...props }) {
 
 TimeTag.propTypes = {
   date: PropTypes.number.isRequired, // unix timestamp
-  label: PropTypes.string,
+  label: PropTypes.node,
 }
 
 export default TimeTag

--- a/src/components/App/AppLoader.js
+++ b/src/components/App/AppLoader.js
@@ -63,7 +63,7 @@ function useLoadingStatus({
 
     const label = loadingSteps.steps[stepIndex].replace(
       /\{APP\}/,
-      currentAppName || instanceId
+      currentAppName || instanceId || 'App'
     )
     const progress = stepIndex / (loadingSteps.steps.length - 1)
 
@@ -130,7 +130,7 @@ AppLoader.propTypes = {
   children: PropTypes.node,
   currentAppName: PropTypes.string.isRequired,
   daoLoading: PropTypes.bool.isRequired,
-  instanceId: PropTypes.string.isRequired,
+  instanceId: PropTypes.string,
 }
 
 export default AppLoader

--- a/src/components/Preferences/Preferences.js
+++ b/src/components/Preferences/Preferences.js
@@ -125,7 +125,7 @@ const Preferences = React.memo(({ dao, onClose, opened, wrapper }) => {
 })
 
 Preferences.propTypes = {
-  dao: PropTypes.string.isRequired,
+  dao: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   opened: PropTypes.bool,
   wrapper: AragonType,

--- a/src/components/SignerPanel/ConfirmTransaction.js
+++ b/src/components/SignerPanel/ConfirmTransaction.js
@@ -37,7 +37,7 @@ const ConfirmTransaction = ({
 ConfirmTransaction.propTypes = {
   direct: PropTypes.bool.isRequired,
   intent: PropTypes.object.isRequired,
-  dao: PropTypes.string.isRequired,
+  dao: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   onSign: PropTypes.func.isRequired,
   paths: PropTypes.array.isRequired,


### PR DESCRIPTION
[history now recommends using a different import syntax](https://github.com/ReactTraining/history/releases/tag/v4.8.0-beta.0), and a couple of small proptype warnings due to `dao` not being available during onboarding.