### PR TITLE
[Experiment] [DO NOT MERGE] Improve load performance of App WebWorkers

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rimraf": "^2.6.2"
   },
   "scripts": {
-    "ui-assets": "copy-aragon-ui-assets -n aragon-ui ./build",
+    "ui-assets": "copy-aragon-ui-assets -n aragon-ui ./build && cp ./src/worker.js ./build",
     "start": "node scripts/start",
     "start:local": "node scripts/launch-local",
     "start:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main npm start",

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -31,14 +31,18 @@ dataUriWorker.onmessage = function(event) {
   urlMappings[event.data.id](url)
 }
 const urlMappings = {}
+let prevPromise = Promise.resolve()
 function getDataUriForBlob(blob, url) {
   const ret = new Promise(resolve => {
     urlMappings[url] = resolve
   })
-  dataUriWorker.postMessage({
-    blob,
-    id: url,
+  prevPromise.then(() => {
+    dataUriWorker.postMessage({
+      blob,
+      id: url,
+    })
   })
+  prevPromise = ret
   return ret
 }
 

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -27,7 +27,8 @@ import { NoConnection, DAONotFound } from './errors'
 
 const dataUriWorker = new Worker('./worker.js', { name: 'data-uri-worker' })
 dataUriWorker.onmessage = function(event) {
-  urlMappings[event.data.id](event.data.url)
+  const url = new TextDecoder('utf-8').decode(event.data.url)
+  urlMappings[event.data.id](url)
 }
 const urlMappings = {}
 function getDataUriForBlob(blob, url) {

--- a/src/worker-utils.js
+++ b/src/worker-utils.js
@@ -1,17 +1,12 @@
 /**
- * Fetch the given script and create a local URL for it
+ * Fetch the given script and return it as a blob
  *
  * @param {string} scriptUrl Real world location of the script
- * @returns {Promise<string>} Local url for the script
+ * @returns {Promise<Blob>} Blob representing the script
  */
-export async function getDataUrlForScript(scriptUrl) {
+export async function getBlobForScript(scriptUrl) {
   // In the future, we might support IPFS protocols in addition to http
-  const blob = await fetchScriptUrlAsBlob(scriptUrl)
-  return readAsDataUrl(blob)
-}
-
-const fetchScriptUrlAsBlob = async url => {
-  const res = await fetch(url, {
+  const res = await fetch(scriptUrl, {
     method: 'GET',
     mode: 'cors',
   })
@@ -23,15 +18,6 @@ const fetchScriptUrlAsBlob = async url => {
   }
 
   return res.blob()
-}
-
-const readAsDataUrl = file => {
-  const reader = new FileReader()
-  return new Promise((resolve, reject) => {
-    reader.addEventListener('loadend', () => resolve(reader.result))
-    reader.addEventListener('error', reject)
-    reader.readAsDataURL(file)
-  })
 }
 
 export class WorkerSubscriptionPool {

--- a/src/worker.js
+++ b/src/worker.js
@@ -3,7 +3,9 @@ console.log('started data url worker')
 const readAsDataUrl = file => {
   const reader = new FileReader()
   return new Promise((resolve, reject) => {
-    reader.addEventListener('loadend', () => resolve(reader.result))
+    reader.addEventListener('loadend', () => {
+      resolve(new TextEncoder().encode(reader.result))
+    })
     reader.addEventListener('error', reject)
     reader.readAsDataURL(file)
   })

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,23 @@
+console.log('started data url worker')
+
+const readAsDataUrl = file => {
+  const reader = new FileReader()
+  return new Promise((resolve, reject) => {
+    reader.addEventListener('loadend', () => resolve(reader.result))
+    reader.addEventListener('error', reject)
+    reader.readAsDataURL(file)
+  })
+}
+
+self.onmessage = function(event) {
+  readAsDataUrl(event.data.blob)
+    .then(dataUrl => {
+      self.postMessage({
+        id: event.data.id,
+        url: dataUrl,
+      })
+    })
+    .catch(err => {
+      console.error('could not get data uri', event)
+    })
+}


### PR DESCRIPTION
Quick and dirty code to try a couple things out:

- deb66f0: Move the dataURI transform into a webworker
- 8f56f3f: Rather than pass a giant (~2-4mb) string back, use an ArrayBuffer
- 0048d40: Transform the dataURIs one at a time
- 0cfb581: Start the workers one at a time, and delay them by 1s

Of all of them, it looks like the last one "improves" the experience the most, by hiding some of the jank to after the loader's finished animating. All the other tricks made very little difference in the jank :(.

----------

No matter the attempt, these giant spikes stay :(. Also not sure why the profiler reports them as part of "network". This what the app currently looks like on load (without these changes):

<img width="1440" alt="Screen Shot 2019-05-28 at 3 00 49 PM" src="https://user-images.githubusercontent.com/4166642/58480056-cfce7f80-8159-11e9-9749-6f08aaccd8f8.png">

The big "data:uri" network blobs seem to be causing some trouble; for reference, the scripts have already been downloaded from network previously. Before, when we were passing blobURIs into the WebWorkers, this would take ~30ms (vs. up to 300ms for Finance's script).

Initializing the WebWorker itself doesn't appear to cause much of a problem, it usually finishes within 100ms.