### PR TITLE
Added probot bots

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,16 @@
+# Configuration for https://probot.github.io/apps/auto-assign
+
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - sohkai
+  - bpierre
+  - aquigorka
+
+skipKeywords:
+  - wip
+  - draft
+
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -7,4 +7,6 @@ newPRWelcomeComment: >
   Thanks for opening this pull request! Someone will review it soon 🔍
 
 firstPRMergeComment: >
-  Congrats on merging your first pull request! Aragon is proud of you 🦅 ![Eagle gif](https://media.giphy.com/media/SLD8eKFPuUDuw/200w_d.gif)
+  Congrats on merging your first pull request! Aragon is proud of you 🦅
+
+  ![Eagle gif](https://media.giphy.com/media/SLD8eKFPuUDuw/200w_d.gif)

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,10 @@
+# Configuration for https://probot.github.io/apps/welcome
+
+newIssueWelcomeComment: >
+  Thanks for opening your first issue in the Aragon client repo! Someone will circle back soon ⚡
+
+newPRWelcomeComment: >
+  Thanks for opening this pull request! Someone will review it soon 🔍
+
+firstPRMergeComment: >
+  Congrats on merging your first pull request! Aragon is proud of you 🦅 ![Eagle gif](https://media.giphy.com/media/SLD8eKFPuUDuw/200w_d.gif)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# Configuration for https://probot.github.io/apps/release-drafter
+
+template: |
+  ## What’s changed in the Aragon client
+
+  $CHANGES

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for https://probot.github.io/apps/stale
+
+daysUntilStale: 60
+daysUntilClose: 7
+
+staleLabel: abandoned
+
+issues:
+  daysUntilStale: 180
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for contributing to Aragon! 🦅
+
+pulls:
+  daysUntilStale: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for contributing to Aragon! 🦅


### PR DESCRIPTION
- Adds https://probot.github.io/apps/welcome to welcome people who open issues and PRs and congratulates them on their first PR getting merged
- Adds https://probot.github.io/apps/stale to remind people with issues opened for 6 months, and PRs opened for a month without activity. Closes if there's no reply for a week
- Adds https://probot.github.io/apps/release-drafter to automatically draft release notes by using commit history
- Adds https://probot.github.io/apps/auto-assign to auto-assign @sohkai @bpierre and @AquiGorka as reviewers for PRs
