### PR TITLE
Environment: clarify name override for Token Manager

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -69,8 +69,8 @@ export const sortAppsPair = (app1, app2) => {
 }
 
 // Use appOverrides to override specific keys in an app instance, e.g. the start_url or script location
-// Needed to change app name on sidebar
 const appOverrides = {
+  // Needed to change app name on sidebar for old versions whose aragonPM repo content cannot be changed anymore
   [appIds['TokenManager']]: { name: 'Tokens' },
 }
 


### PR DESCRIPTION
Small adjustment to #801's comment on the name override, to clarify why it's needed.