### PR TITLE
HelpScout suggestions: use appIds instead of app names

### DIFF
--- a/src/components/HelpScoutBeacon/suggestions.js
+++ b/src/components/HelpScoutBeacon/suggestions.js
@@ -43,21 +43,21 @@ const suggestions = [
     ],
   ],
   [
-    'finance',
+    '0xbf8491150dafc5dcaee5b861414dca922de09ccffa344964ae167212e8c673ae',
     [
       '5cce39b32c7d3a177d6e5b8b', // finance
       aboutAragon,
     ],
   ],
   [
-    'token manager',
+    '0x6b20a3010614eeebf2138ccec99f028a61c811b3b1a3343b6ff635985c75c91f',
     [
       '5cce38892c7d3a177d6e5b84', // token manager
       aboutAragon,
     ],
   ],
   [
-    'voting',
+    '0x9fa3927f639745e587912d4b0fea7ef9013bf93fb907d29faeab57417ba6e1d4',
     [
       '5cce393a2c7d3a177d6e5b87', // voting
       aboutAragon,

--- a/src/components/HelpScoutBeacon/useBeaconSuggestions.js
+++ b/src/components/HelpScoutBeacon/useBeaconSuggestions.js
@@ -21,7 +21,7 @@ function useBeaconSuggestions({
     }
     const app = apps.find(({ proxyAddress }) => proxyAddress === instanceId)
     if (app) {
-      return app.name.toLowerCase()
+      return app.appId
     }
     return null
   }, [path, instanceId, apps])


### PR DESCRIPTION
Migrates the suggestions to use appIds instead, as they're less likely to change (basically impossible ATM).

Fixes #816.