### PR TITLE
Add build:local script

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "start:staging": "cross-env REACT_APP_ENS_REGISTRY_ADDRESS=0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939 npm start",
     "start:ropsten": "cross-env REACT_APP_ETH_NETWORK_TYPE=ropsten npm start",
     "build": "node scripts/build",
+    "build:local": "node scripts/build-local",
     "build:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main ARAGON_DEMO_DAO=0x8A83D4bCE45b4C4F751f76cf565953D1E4A3BF0a npm run build",
     "build:mainnet-infura": "cross-env REACT_APP_DEFAULT_ETH_NODE=wss://mainnet.infura.io/_ws npm run build:mainnet",
     "build:rinkeby": "cross-env ARAGON_DEMO_DAO=0xB578FbBFB8f3268FB1445bf3C0dF42343Da90748 npm run build",

--- a/scripts/build-local
+++ b/scripts/build-local
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const version = require('../package.json').version
+const execute = require('child_process').execSync
+const {
+  DEFAULT_LOCAL_ENS_ADDRESS,
+  DEFAULT_LOCAL_IPFS_GATEWAY,
+} = require('./config/local')
+
+execute('rimraf build/', { stdio: 'inherit' })
+execute('npm run ui-assets', { stdio: 'inherit' })
+
+process.env.REACT_APP_PACKAGE_VERSION = version
+process.env.REACT_APP_ETH_NETWORK_TYPE = 'local'
+process.env.REACT_APP_ENS_REGISTRY_ADDRESS = DEFAULT_LOCAL_ENS_ADDRESS
+process.env.REACT_APP_IPFS_GATEWAY = DEFAULT_LOCAL_IPFS_GATEWAY
+process.env.REACT_APP_ASSET_BRIDGE = 'ipfs'
+
+execute(
+  `parcel build src/index.html --out-dir ./build --public-url ./ --no-cache`,
+  { stdio: 'inherit' }
+)

--- a/scripts/config/local.js
+++ b/scripts/config/local.js
@@ -1,0 +1,4 @@
+module.exports = {
+  DEFAULT_LOCAL_ENS_ADDRESS: '0x5f6F7E8cc7346a11ca2dEf8f827b7a0b612c56a1',
+  DEFAULT_LOCAL_IPFS_GATEWAY: 'http://localhost:8080/ipfs',
+}

--- a/scripts/launch-local
+++ b/scripts/launch-local
@@ -2,9 +2,10 @@
 
 const ps = require('ps-node')
 const execute = require('child_process').execSync
-
-const DEFAULT_LOCAL_ENS_ADDRESS = '0x5f6F7E8cc7346a11ca2dEf8f827b7a0b612c56a1'
-const DEFAULT_LOCAL_IPFS_GATEWAY = 'http://localhost:8080/ipfs'
+const {
+  DEFAULT_LOCAL_ENS_ADDRESS,
+  DEFAULT_LOCAL_IPFS_GATEWAY,
+} = require('./config/local')
 
 // Determine if quiet mode enabled
 const quietMode = process.argv.includes('-q') || process.argv.includes('-Q')


### PR DESCRIPTION
Needed to publish a locally-connected version of the Aragon client to local aragen aragonPM instances.

@0xGabi this will make that published version of the client connect to the localhost RPC **and** localhost IPFS daemon by default (it's similar to what happens on `start:local`). I think this is a valid assumption for the CLI, but not super sure about Aragon desktop.