### PR TITLE
Mainnet: remove artifical event delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "start:ropsten": "cross-env REACT_APP_ETH_NETWORK_TYPE=ropsten npm start",
     "build": "node scripts/build",
     "build:local": "node scripts/build-local",
-    "build:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main REACT_APP_ETH_SUBSCRIPTION_EVENT_DELAY=5000 ARAGON_DEMO_DAO=0x8A83D4bCE45b4C4F751f76cf565953D1E4A3BF0a npm run build",
+    "build:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main ARAGON_DEMO_DAO=0x8A83D4bCE45b4C4F751f76cf565953D1E4A3BF0a npm run build",
     "build:rinkeby": "cross-env ARAGON_DEMO_DAO=0xB578FbBFB8f3268FB1445bf3C0dF42343Da90748 npm run build",
     "build:staging": "cross-env REACT_APP_ENS_REGISTRY_ADDRESS=0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939 npm run build",
     "build:ropsten": "cross-env REACT_APP_ETH_NETWORK_TYPE=ropsten npm run build",


### PR DESCRIPTION
Removes the specific delay we applied to work with Infura's inconsistent events.