### PR TITLE
ENS: replace @aragon/wrapper's ens utilities with ethereum-ens

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",
     "eth-provider": "^0.2.0",
+    "ethereum-ens": "^0.7.7",
     "file-saver": "^2.0.1",
     "history": "^4.9.0",
     "lodash.memoize": "^4.1.2",

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -1,19 +1,13 @@
 import BN from 'bn.js'
 import resolvePathname from 'resolve-pathname'
-import Aragon, {
-  providers,
-  setupTemplates,
-  isNameUsed,
-  ensResolve,
-} from '@aragon/wrapper'
+import Aragon, { providers, setupTemplates } from '@aragon/wrapper'
 import {
   appOverrides,
-  sortAppsPair,
-  ipfsDefaultConf,
-  web3Providers,
-  contractAddresses,
   defaultGasPriceFn,
+  ipfsDefaultConf,
+  sortAppsPair,
 } from './environment'
+import { resolveEnsDomain } from './ens-utils'
 import { NoConnection, DAONotFound } from './errors'
 import { appBaseUrl } from './url-utils'
 import { noop, removeStartingSlash } from './utils'
@@ -291,17 +285,6 @@ const subscribe = (
   return subscriptions
 }
 
-const resolveEnsDomain = async (domain, opts) => {
-  try {
-    return await ensResolve(domain, opts)
-  } catch (err) {
-    if (err.message === 'ENS name not defined.') {
-      return ''
-    }
-    throw err
-  }
-}
-
 const initWrapper = async (
   dao,
   ensRegistryAddress,
@@ -464,9 +447,7 @@ const templateParamFilters = {
 
     if (neededSignatures < 1 || neededSignatures > signers.length) {
       throw new Error(
-        `neededSignatures must be between 1 and the total number of signers (${
-          signers.length
-        })`,
+        `neededSignatures must be between 1 and the total number of signers (${signers.length})`,
         neededSignatures
       )
     }
@@ -475,20 +456,11 @@ const templateParamFilters = {
   },
 }
 
-export const isNameAvailable = async name =>
-  !(await isNameUsed(name, {
-    provider: web3Providers.default,
-    registryAddress: contractAddresses.ensRegistry,
-  }))
-
 export const initDaoBuilder = (
   provider,
   ensRegistryAddress,
   ipfsConf = ipfsDefaultConf
 ) => {
-  // DEV only
-  // provider = new Web3.providers.WebsocketProvider('ws://localhost:8546')
-
   return {
     build: async (templateName, organizationName, settings = {}) => {
       if (!organizationName) {

--- a/src/ens-utils.js
+++ b/src/ens-utils.js
@@ -1,0 +1,31 @@
+import ENS from 'ethereum-ens'
+import { contractAddresses, web3Providers } from './environment'
+
+/**
+ * Resolves an ENS name to its address.
+ * @param {string} name Name to resolve
+ * @return {Promise} Resolves with the resolved address.
+ *   Resolves with an empty string if the name could not be resolved.
+ */
+export async function resolveEnsDomain(name) {
+  const ens = new ENS(web3Providers.default, contractAddresses.ensRegistry)
+
+  try {
+    return await ens.resolver(name).addr()
+  } catch (err) {
+    if (err.message === 'ENS name not found') {
+      return ''
+    }
+    // Don't know what happened; rethrow
+    throw err
+  }
+}
+
+/**
+ * Checks if a name is available on ENS.
+ * @param {string} name Name to check
+ * @return {Promise} Resolves with true or false
+ */
+export async function isEnsDomainAvailable(name) {
+  return !(await resolveEnsDomain(name))
+}

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Spring, animated } from 'react-spring'
 import { breakpoint } from '@aragon/ui'
+import { isEnsDomainAvailable } from '../ens-utils'
 import { noop } from '../utils'
 import { getUnknownBalance } from '../web3-utils'
-import { isNameAvailable } from '../aragonjs-wrapper'
 import springs from '../springs'
 
 import * as Steps from './steps'
@@ -249,7 +249,9 @@ class Onboarding extends React.PureComponent {
 
     const checkName = async () => {
       try {
-        const available = await isNameAvailable(filteredDomain)
+        const available = await isEnsDomainAvailable(
+          `${filteredDomain}.aragonid.eth`
+        )
 
         // The domain could have changed in the meantime
         if (filteredDomain === this.state[domainKey]) {


### PR DESCRIPTION
I will be removing `@aragon/wrapper`s ENS-related utilities soon (and also shifting them to use `ethereum-ens`), so this is a simple migration over that should change no functionality.