### PR TITLE
SignerPanel: fix error cases when Ethereum provider doesn't error with message

### DIFF
--- a/src/components/SignerPanel/SigningStatus.js
+++ b/src/components/SignerPanel/SigningStatus.js
@@ -48,7 +48,7 @@ class SigningStatus extends React.Component {
     if (status === STATUS_MSG_ERROR) return 'Error signing the message.'
   }
   getInfo() {
-    const { status, signError, walletProviderId } = this.props
+    const { status, walletProviderId } = this.props
     if (status === STATUS_TX_SIGNING) {
       return (
         <p>
@@ -78,20 +78,12 @@ class SigningStatus extends React.Component {
       return <p>Success! Your message has been signed.</p>
     }
     if (status === STATUS_TX_ERROR) {
-      return (
-        <React.Fragment>
-          <p>Your transaction wasn't signed and no tokens were sent.</p>
-          {signError && <p>Error: “{cleanErrorMessage(signError.message)}”</p>}
-        </React.Fragment>
+      return this.getErrorMessage(
+        "Your transaction wasn't signed and no tokens were sent."
       )
     }
     if (status === STATUS_MSG_ERROR) {
-      return (
-        <React.Fragment>
-          <p>Your message wasn't signed.</p>
-          {signError && <p>Error: “{cleanErrorMessage(signError.message)}”</p>}
-        </React.Fragment>
-      )
+      return this.getErrorMessage("Your message wasn't signed.")
     }
   }
   getCloseButton() {
@@ -100,6 +92,22 @@ class SigningStatus extends React.Component {
       return <SignerButton onClick={onClose}>Close</SignerButton>
     }
     return null
+  }
+  getErrorMessage(warning) {
+    const { signError } = this.props
+    const cleanedErrorMessage = cleanErrorMessage(
+      (signError && signError.message) || ''
+    )
+    return (
+      <React.Fragment>
+        <p>{warning}</p>
+        {cleanedErrorMessage ? (
+          <p>Error: “{cleanedErrorMessage}”</p>
+        ) : (
+          <p>There may have been a problem with your Ethereum provider.</p>
+        )}
+      </React.Fragment>
+    )
   }
   render() {
     const { status } = this.props


### PR DESCRIPTION
Unclear which providers error in this way, but we were erroneously making the assumption that an error thrown from the provider would always contain a message string.

See https://sentry.io/share/issue/54450fea43c74f0e86d2ca4a332121d8/ for an example.

Adds a new message to point the user at something wrong going on with their signing provider in such cases:

<img width="416" alt="Screen Shot 2019-08-12 at 12 07 24 AM" src="https://user-images.githubusercontent.com/4166642/62840081-3103ea80-bc95-11e9-9d95-8925af143a00.png">
