### PR TITLE
Changes to fix aragen automatic deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /coverage
 
 # production
-/build
+build/
 
 # misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 
 # testing
-/coverage
+coverage/
 
 # production
-/build
+build/
 
 # misc
 .DS_Store
@@ -21,8 +21,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-/public/apps
-/public/aragon-ui
+public/apps/
+public/aragon-ui/
 
 # ignore lock files
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /coverage
 
 # production
-build/
+/build
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "rimraf": "^2.6.2"
   },
   "scripts": {
-    "ui-assets": "copy-aragon-ui-assets -n aragon-ui ./build",
     "start": "node scripts/start",
     "start:local": "node scripts/launch-local",
     "start:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main npm start",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "rimraf": "^2.6.2"
   },
   "scripts": {
+    "ui-assets": "copy-aragon-ui-assets -n aragon-ui ./build",
     "start": "node scripts/start",
     "start:local": "node scripts/launch-local",
     "start:mainnet": "cross-env REACT_APP_ETH_NETWORK_TYPE=main npm start",

--- a/scripts/build-local
+++ b/scripts/build-local
@@ -7,8 +7,11 @@ const {
   DEFAULT_LOCAL_IPFS_GATEWAY,
 } = require('./config/local')
 
-execute('rimraf build/', { stdio: 'inherit' })
+execute('rimraf ./build', { stdio: 'inherit' })
 execute('npm run ui-assets', { stdio: 'inherit' })
+execute(`copy-aragon-ui-assets -n aragon-ui ./build`, {
+  stdio: 'inherit',
+})
 
 process.env.REACT_APP_PACKAGE_VERSION = version
 process.env.REACT_APP_ETH_NETWORK_TYPE = 'local'

--- a/scripts/build-local
+++ b/scripts/build-local
@@ -8,7 +8,6 @@ const {
 } = require('./config/local')
 
 execute('rimraf ./build', { stdio: 'inherit' })
-execute('npm run ui-assets', { stdio: 'inherit' })
 execute(`copy-aragon-ui-assets -n aragon-ui ./build`, {
   stdio: 'inherit',
 })


### PR DESCRIPTION
When trying to do the automatic deployment of aragen I notice that the `ui-assets` npm script was still been used by the `build:local` script. 