### PR TITLE
HelpScout: add description to beacon button

### DIFF
--- a/src/components/HelpScoutBeacon/HelpScoutBeacon.js
+++ b/src/components/HelpScoutBeacon/HelpScoutBeacon.js
@@ -249,6 +249,7 @@ const ToggleDialogueButton = React.memo(({ open, onToggle }) => {
 
   return (
     <DiscButton
+      description="Help"
       onClick={onToggle}
       css={`
         display: flex;


### PR DESCRIPTION
🙈 Oops, forgot to include this required prop.