### PR TITLE
SignerPanel: adjust for new styles

### DIFF
--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -1,22 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Info, RadioList, SafeLink } from '@aragon/ui'
-import SignerButton from './SignerButton'
-import AddressLink from './AddressLink'
+import { ButtonText, Info, RadioList, GU } from '@aragon/ui'
 import LocalIdentityBadge from '../IdentityBadge/LocalIdentityBadge'
 import providerString from '../../provider-strings'
 import { getAppPath } from '../../routing'
+import AddressLink from './AddressLink'
+import SignerButton from './SignerButton'
 
 const RADIO_ITEM_TITLE_LENGTH = 30
 
 class ActionPathsContent extends React.Component {
   static propTypes = {
+    dao: PropTypes.string.isRequired,
     direct: PropTypes.bool.isRequired,
     intent: PropTypes.object.isRequired,
-    dao: PropTypes.string.isRequired,
-    onSign: PropTypes.func.isRequired,
     paths: PropTypes.array.isRequired,
     pretransaction: PropTypes.object,
+    onSign: PropTypes.func.isRequired,
     signingEnabled: PropTypes.bool,
     walletProviderId: PropTypes.string.isRequired,
   }
@@ -47,7 +47,7 @@ class ActionPathsContent extends React.Component {
         <p>This transaction will {showPaths ? 'eventually' : ''} perform</p>
         <div
           css={`
-            margin: 10px 0 10px 15px;
+            margin: ${0.5 * GU}px 0 ${0.5 * GU}px ${1 * GU}px;
             line-height: 1.6;
           `}
         >
@@ -75,7 +75,7 @@ class ActionPathsContent extends React.Component {
                 }
                 if (type === 'app') {
                   return (
-                    <SafeLink
+                    <ButtonText
                       key={index}
                       href={`#${getAppPath({
                         dao,
@@ -86,7 +86,7 @@ class ActionPathsContent extends React.Component {
                       css="margin-right: 2px"
                     >
                       {value.name}
-                    </SafeLink>
+                    </ButtonText>
                   )
                 }
                 if (type === 'role' || type === 'kernelNamespace') {
@@ -202,17 +202,25 @@ class ActionPathsContent extends React.Component {
     return (
       <React.Fragment>
         {showPaths ? (
-          <div css="margin-bottom: 40px">
-            <Info.Permissions title="Permission note:">
+          <div
+            css={`
+              margin-bottom: ${3 * GU}px;
+            `}
+          >
+            <Info mode="warning" title="Permission note">
               You cannot directly perform this action. You do not have the
               necessary permissions.
-            </Info.Permissions>
-            <div css="margin-top: 25px">
+            </Info>
+            <div
+              css={`
+                margin-top: ${4 * GU}px;
+              `}
+            >
               <RadioList
                 title="Action Requirement"
                 description={
                   paths.length > 1
-                    ? 'Here are some options you can use to perform it:'
+                    ? 'Here are some options to perform this action:'
                     : 'You can perform this action through:'
                 }
                 items={radioItems}
@@ -222,22 +230,29 @@ class ActionPathsContent extends React.Component {
             </div>
           </div>
         ) : (
-          <h2 css="margin-bottom: 10px">
+          <h2
+            css={`
+              margin-bottom: ${2 * GU}px;
+            `}
+          >
             You can directly perform this action:
           </h2>
         )}
-        <Info.Action icon={null} title="Action to be triggered">
+        <Info mode="description" title="Action to be triggered">
           {this.renderDescription(showPaths, intent)}
-        </Info.Action>
+        </Info>
         {pretransaction && (
-          <div css="margin-top: 20px">
-            <Info.Action title="Two transactions required">
-              This action requires two transactions to be signed in{' '}
-              {providerString('your Ethereum provider', walletProviderId)}.{' '}
-              {approveTransactionMessage}
-              Please confirm them one after another.
-            </Info.Action>
-          </div>
+          <Info
+            title="Two transactions required"
+            css={`
+              margin-top: ${3 * GU}px;
+            `}
+          >
+            This action requires two transactions to be signed in{' '}
+            {providerString('your Ethereum provider', walletProviderId)}.{' '}
+            {approveTransactionMessage}
+            Please confirm them one after another.
+          </Info>
         )}
         <SignerButton onClick={this.handleSign} disabled={!signingEnabled}>
           Create transaction

--- a/src/components/SignerPanel/AddressLink.js
+++ b/src/components/SignerPanel/AddressLink.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { SafeLink } from '@aragon/ui'
+import { ButtonText } from '@aragon/ui'
 import { EthereumAddressType } from '../../prop-types'
 import EtherscanLink from '../Etherscan/EtherscanLink'
 
@@ -9,9 +9,14 @@ const AddressLink = ({ children, to }) =>
     <EtherscanLink address={to}>
       {url =>
         url ? (
-          <SafeLink href={url} target="_blank">
+          <ButtonText
+            href={url}
+            target="_blank"
+            horizontalPadding="none"
+            css="padding: 0"
+          >
             {children || to}
-          </SafeLink>
+          </ButtonText>
         ) : (
           to
         )

--- a/src/components/SignerPanel/ConfirmMsgSign.js
+++ b/src/components/SignerPanel/ConfirmMsgSign.js
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 
 import { AppType, EthereumAddressType } from '../../prop-types'
-import ImpossibleContent from './ImpossibleContent'
 import SignMsgContent from './SignMsgContent'
 
 const ConfirmMsgSign = ({
@@ -11,21 +10,16 @@ const ConfirmMsgSign = ({
   intent,
   onClose,
   onSign,
-  signError,
   signingEnabled,
 }) => (
   <Fragment>
-    {!signError ? (
-      <SignMsgContent
-        account={account}
-        apps={apps}
-        intent={intent}
-        onSign={onSign}
-        signingEnabled={signingEnabled}
-      />
-    ) : (
-      <ImpossibleContent error={signError} intent={intent} onClose={onClose} />
-    )}
+    <SignMsgContent
+      account={account}
+      apps={apps}
+      intent={intent}
+      onSign={onSign}
+      signingEnabled={signingEnabled}
+    />
   </Fragment>
 )
 
@@ -35,7 +29,6 @@ ConfirmMsgSign.propTypes = {
   intent: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   onSign: PropTypes.func.isRequired,
-  signError: PropTypes.bool,
   signingEnabled: PropTypes.bool,
 }
 

--- a/src/components/SignerPanel/ConfirmTransaction.js
+++ b/src/components/SignerPanel/ConfirmTransaction.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ActionPathsContent from './ActionPathsContent'
-import ImpossibleContent from './ImpossibleContent'
+import ImpossibleAction from './ImpossibleAction'
 
 const ConfirmTransaction = ({
   direct,
@@ -30,7 +30,7 @@ const ConfirmTransaction = ({
       walletProviderId={walletProviderId}
     />
   ) : (
-    <ImpossibleContent error={signError} intent={intent} onClose={onClose} />
+    <ImpossibleAction error={signError} intent={intent} onClose={onClose} />
   )
 }
 

--- a/src/components/SignerPanel/ImpossibleAction.js
+++ b/src/components/SignerPanel/ImpossibleAction.js
@@ -1,35 +1,36 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Info } from '@aragon/ui'
 import AddressLink from './AddressLink'
 import SignerButton from './SignerButton'
 
-const ImpossibleContent = ({
+const ImpossibleAction = ({
   error,
   intent: { description, name, to },
   onClose,
 }) => (
-  <Fragment>
-    <Info.Permissions title="Action impossible">
+  <React.Fragment>
+    <Info mode="warning" title="Action impossible">
       The action {description && `“${description}”`} failed to execute
       {name && (
-        <Fragment>
-          on <AddressLink to={to}>{name}</AddressLink>}
-        </Fragment>
+        <React.Fragment>
+          {' '}
+          on <AddressLink to={to}>{name}</AddressLink>
+        </React.Fragment>
       )}
       .{' '}
       {error
         ? 'An error occurred when we tried to find a path or send a transaction for this action.'
         : 'You may not have the required permissions.'}
-    </Info.Permissions>
+    </Info>
     <SignerButton onClick={onClose}>Close</SignerButton>
-  </Fragment>
+  </React.Fragment>
 )
 
-ImpossibleContent.propTypes = {
+ImpossibleAction.propTypes = {
   error: PropTypes.bool,
   intent: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
 }
 
-export default ImpossibleContent
+export default ImpossibleAction

--- a/src/components/SignerPanel/SignMsgContent.js
+++ b/src/components/SignerPanel/SignMsgContent.js
@@ -1,8 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { Info, Text, SidePanelSeparator, theme } from '@aragon/ui'
-
+import { Info, GU, textStyle, useTheme } from '@aragon/ui'
 import SignerButton from './SignerButton'
 import ToggleContent from './ToggleContent'
 import LocalIdentityBadge from '../IdentityBadge/LocalIdentityBadge'
@@ -11,37 +9,46 @@ import { AppType, EthereumAddressType } from '../../prop-types'
 import { isHumanReadable } from '../../utils'
 
 const SignMsgContent = ({ apps, account, intent, onSign, signingEnabled }) => {
-  const locateAppInfo = (apps, requestingApp) =>
-    apps.find(({ proxyAddress }) => proxyAddress === requestingApp)
+  const { message, requestingApp: requestingAppAddress } = intent
 
-  const humanReadableMessage = isHumanReadable(intent.message)
+  const requestingApp = useMemo(
+    () =>
+      apps.find(({ proxyAddress }) => proxyAddress === requestingAppAddress),
+    [apps, requestingAppAddress]
+  )
+  const humanReadableMessage = isHumanReadable(message)
+
   return (
     <React.Fragment>
-      <span css="margin-right: 4px">
+      <p
+        css={`
+          margin-bottom: ${3 * GU}px;
+        `}
+      >
         You are about to sign this message with the connected account{' '}
-        <LocalIdentityBadge entity={account} />
-      </span>
-      <Separator />
+        <LocalIdentityBadge entity={account} compact />.
+      </p>
       <Label>Signature requested by</Label>
-      <AppInstanceLabel
-        app={locateAppInfo(apps, intent.requestingApp)}
-        proxyAddress={intent.requestingApp}
-        showIcon
-      />
-      <Separator />
+      <div
+        css={`
+          margin-bottom: ${3 * GU}px;
+        `}
+      >
+        <AppInstanceLabel
+          app={requestingApp}
+          proxyAddress={requestingAppAddress}
+          showIcon
+        />
+      </div>
       {humanReadableMessage ? (
         <React.Fragment>
           <Label>Message</Label>
-          <Info>{intent.message}</Info>
+          <Info mode="description">{message}</Info>
         </React.Fragment>
       ) : (
-        <React.Fragment>
-          <ToggleContent labelOpen="Hide message" labelClosed="Show message">
-            <React.Fragment>
-              <LongMessage>{intent.message}</LongMessage>
-            </React.Fragment>
-          </ToggleContent>
-        </React.Fragment>
+        <ToggleContent labelOpen="Hide message" labelClosed="Show message">
+          <Info mode="description">{message}</Info>
+        </ToggleContent>
       )}
       <SignerButton onClick={onSign} disabled={!signingEnabled}>
         Sign message
@@ -58,24 +65,18 @@ SignMsgContent.propTypes = {
   signingEnabled: PropTypes.bool,
 }
 
-const Separator = styled(SidePanelSeparator)`
-  margin-top: 18px;
-  margin-bottom: 18px;
-`
-
-const Label = styled(Text).attrs({
-  smallcaps: true,
-  color: theme.textSecondary,
-})`
-  display: block;
-  margin-bottom: 10px;
-`
-
-const LongMessage = styled(Info)`
-  margin-top: 10px;
-  max-height: 350px;
-  overflow-y: scroll;
-  word-break: break-word;
-`
+function Label(props) {
+  const theme = useTheme()
+  return (
+    <div
+      css={`
+        ${textStyle('label2')}
+        color: ${theme.surfaceContentSecondary};
+        margin-bottom: ${2 * GU}px;
+      `}
+      {...props}
+    />
+  )
+}
 
 export default SignMsgContent

--- a/src/components/SignerPanel/SignerButton.js
+++ b/src/components/SignerPanel/SignerButton.js
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
-import { Button } from '@aragon/ui'
+import { Button, GU } from '@aragon/ui'
 
 const SignerButton = styled(Button).attrs({
   mode: 'strong',
   wide: true,
 })`
-  margin-top: 20px;
+  margin-top: ${3 * GU}px;
 `
 
 export default SignerButton

--- a/src/components/SignerPanel/SignerPanel.js
+++ b/src/components/SignerPanel/SignerPanel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { SidePanel } from '@aragon/ui'
+import { SidePanel, GU } from '@aragon/ui'
 import { Transition, animated } from 'react-spring'
 import ConfirmTransaction from './ConfirmTransaction'
 import ConfirmMsgSign from './ConfirmMsgSign'
@@ -360,7 +360,6 @@ class SignerPanel extends React.PureComponent {
                               onClose={this.handleSignerClose}
                               intent={intent}
                               onSign={this.handleMsgSign}
-                              signError={Boolean(signError)}
                               signingEnabled={status === STATUS_MSG_CONFIRMING}
                             />
                           )}
@@ -396,7 +395,7 @@ class SignerPanel extends React.PureComponent {
 
 const Main = styled.div`
   position: relative;
-  margin: 0 -30px;
+  margin: 0 -${SidePanel.HORIZONTAL_PADDING}px;
   overflow-x: hidden;
   min-height: 0;
   flex-grow: 1;
@@ -407,13 +406,14 @@ const ScreenWrapper = styled(animated.div)`
   top: 0;
   left: 0;
   right: 0;
-  padding: 0 30px;
+  padding: 0 ${SidePanel.HORIZONTAL_PADDING}px;
   display: flex;
   min-height: 100%;
 `
 
 const Screen = styled.div`
   width: 100%;
+  margin-top: ${3 * GU}px;
 `
 
 export default function(props) {

--- a/src/components/SignerPanel/ToggleContent.js
+++ b/src/components/SignerPanel/ToggleContent.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { font, springs } from '@aragon/ui'
+import { IconDown, GU, springs, textStyle, useTheme } from '@aragon/ui'
 import { Transition, animated } from 'react-spring'
-
-import IconArrow from '../../icons/IconArrow'
 
 export default class ToggleContent extends React.Component {
   static propTypes = {
@@ -26,9 +24,17 @@ export default class ToggleContent extends React.Component {
       <div>
         <Label onClick={this.handleClick}>
           {opened ? labelOpen : labelClosed}{' '}
-          <Rotate opened={opened}>
-            <IconArrow />
-          </Rotate>
+          <div
+            css={`
+              display: flex;
+              align-items: center;
+              padding: 0 ${1 * GU}px;
+              transition: transform 150ms ease-in-out;
+              transform: rotate3d(0, 0, 1, ${opened ? 180 : 0}deg);
+            `}
+          >
+            <IconDown size="tiny" />
+          </div>
         </Label>
 
         <Transition
@@ -48,26 +54,30 @@ export default class ToggleContent extends React.Component {
   }
 }
 
-const Label = styled.button.attrs({ type: 'button' })`
-  cursor: pointer;
-  ${font({ weight: 'bold' })};
-  background: none;
-  border: 0;
-  outline: 0;
-  padding: 0;
-  img {
-    margin-left: 10px;
-  }
-  display: flex;
-  flex-direction: row;
-`
-const Content = styled(animated.div)`
-  overflow: hidden;
-`
+function Label(props) {
+  const theme = useTheme()
+  return (
+    <button
+      type="button"
+      css={`
+        cursor: pointer;
+        background: none;
+        border: 0;
+        outline: 0;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        ${textStyle('label2')}
+        color: ${theme.surfaceContentSecondary};
+        margin-bottom: ${2 * GU}px;
+      `}
+      {...props}
+    />
+  )
+}
 
-const Rotate = styled.div`
-  transform-origin: 50% 50%;
-  transform: rotate(${p => (p.opened ? 0 : 180)}deg);
-  transition: transform 200ms ease-in-out;
-  margin-left: 4px;
+const Content = styled(animated.div)`
+  max-height: 360px;
+  overflow: hidden;
+  overflow-y: scroll;
 `

--- a/src/components/SignerPanel/Web3Errors.js
+++ b/src/components/SignerPanel/Web3Errors.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Info, SafeLink, theme } from '@aragon/ui'
-import styled from 'styled-components'
+import { ButtonText, Info, GU } from '@aragon/ui'
 
 import AddressLink from './AddressLink'
 import SignerButton from './SignerButton'
@@ -15,7 +14,7 @@ const Web3ProviderError = ({
   actionText,
 }) => (
   <React.Fragment>
-    <Info.Action title="You can't perform any action">
+    <Info mode="description" title="You can't perform any action">
       {neededText} in order to perform{' '}
       {description ? `“${description}”` : 'this action'}
       {name && (
@@ -23,8 +22,15 @@ const Web3ProviderError = ({
           on <AddressLink to={to}>{name}</AddressLink>
         </React.Fragment>
       )}
-      .<p css="margin-top: 15px">{actionText}</p>
-    </Info.Action>
+      .
+      <p
+        css={`
+          margin-top: ${2 * GU}px;
+        `}
+      >
+        {actionText}
+      </p>
+    </Info>
     <SignerButton onClick={onClose}>Close</SignerButton>
   </React.Fragment>
 )
@@ -45,12 +51,17 @@ export const NoWeb3Provider = ({ intent, onClose }) => {
   const actionText = (
     <span>
       Please install and enable{' '}
-      <SafeLink
+      <ButtonText
         href={onElectron ? 'https://frame.sh/' : 'https://metamask.io/'}
         target="_blank"
+        horizontalPadding="none"
+        css={`
+          padding: 0;
+          font-weight: 600;
+        `}
       >
         {onElectron ? 'Frame' : 'Metamask'}
-      </SafeLink>
+      </ButtonText>
       .
     </span>
   )
@@ -88,7 +99,16 @@ export const AccountLocked = ({
       actionText={
         <span>
           Please unlock and{' '}
-          <ButtonLink onClick={onRequestEnable}>enable</ButtonLink>{' '}
+          <ButtonText
+            onClick={onRequestEnable}
+            horizontalPadding="none"
+            css={`
+              padding: 0;
+              font-weight: 600;
+            `}
+          >
+            enable
+          </ButtonText>{' '}
           {providerMessage}.
         </span>
       }
@@ -102,16 +122,6 @@ AccountLocked.propTypes = {
   onRequestEnable: PropTypes.func.isRequired,
   walletProviderId: PropTypes.string.isRequired,
 }
-
-const ButtonLink = styled.button.attrs({ type: 'button' })`
-  padding: 0;
-  font-size: inherit;
-  text-decoration: underline;
-  color: ${theme.textPrimary};
-  cursor: pointer;
-  background: none;
-  border: 0;
-`
 
 export const WrongNetwork = ({
   intent,


### PR DESCRIPTION
Adjusts the signer panel to the new styles:

<img width="200" alt="Screen Shot 2019-08-20 at 12 15 22 AM" src="https://user-images.githubusercontent.com/4166642/63303462-3211c900-c2e0-11e9-81e2-5e3dd7eb4819.png">

Feedback statuses are implemented in #907.

----------

### Most of the other modes

Direct:

<img width="200" alt="Screen Shot 2019-08-20 at 12 17 23 AM" src="https://user-images.githubusercontent.com/4166642/63303467-350cb980-c2e0-11e9-8e11-1d13b5415834.png">

Web3 not installed:

<img width="200" alt="Screen Shot 2019-08-20 at 12 17 34 AM" src="https://user-images.githubusercontent.com/4166642/63303468-376f1380-c2e0-11e9-9a2f-a2b028851314.png">

Provider not enabled:

<img width="200" alt="Screen Shot 2019-08-20 at 12 17 40 AM" src="https://user-images.githubusercontent.com/4166642/63303473-3b029a80-c2e0-11e9-8754-0f81532cf2a6.png">

Action impossible:

<img width="200" alt="Screen Shot 2019-08-20 at 12 20 21 AM" src="https://user-images.githubusercontent.com/4166642/63303500-4fdf2e00-c2e0-11e9-8899-548b8fd5a0d9.png">

-----

TODO:

- [ ] Rebase and merge after #899.