### PR TITLE
useLocalIdentity: handle remove case

### DIFF
--- a/src/components/IdentityBadge/LocalIdentityBadge.js
+++ b/src/components/IdentityBadge/LocalIdentityBadge.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react'
+import React, { useCallback, useContext } from 'react'
 import PropTypes from 'prop-types'
 import { LocalIdentityModalContext } from '../LocalIdentityModal/LocalIdentityModalManager'
+import { useLocalIdentity } from '../../hooks'
 import { isAddress } from '../../web3-utils'
 import {
   IdentityContext,
@@ -12,18 +13,9 @@ import LocalIdentityPopoverTitle from './LocalIdentityPopoverTitle'
 function LocalIdentityBadge({ entity, forceAddress, ...props }) {
   const address = isAddress(entity) ? entity : null
 
-  const { resolve, identityEvents$ } = useContext(IdentityContext)
+  const { identityEvents$ } = useContext(IdentityContext)
   const { showLocalIdentityModal } = useContext(LocalIdentityModalContext)
-  const [label, setLabel] = useState(null)
-
-  const handleResolve = useCallback(async () => {
-    try {
-      const { name = null } = await resolve(address)
-      setLabel(name)
-    } catch (e) {
-      // address does not resolve to identity
-    }
-  }, [address, resolve])
+  const { name: label, handleResolve } = useLocalIdentity(address)
 
   const handleClick = useCallback(() => {
     showLocalIdentityModal(address)
@@ -35,55 +27,6 @@ function LocalIdentityBadge({ entity, forceAddress, ...props }) {
         /* user cancelled modify intent */
       })
   }, [address, identityEvents$, handleResolve, showLocalIdentityModal])
-
-  const handleEvent = useCallback(
-    updatedAddress => {
-      if (updatedAddress.toLowerCase() === address.toLowerCase()) {
-        handleResolve()
-      }
-    },
-    [address, handleResolve]
-  )
-
-  const handleRemove = useCallback(
-    async addresses => {
-      const exists = addresses.find(
-        addr => addr.toLowerCase() === address.toLowerCase()
-      )
-      if (exists) {
-        setLabel(null)
-      }
-    },
-    [address]
-  )
-
-  const clearLabel = useCallback(() => {
-    setLabel(null)
-  }, [])
-
-  useEffect(() => {
-    handleResolve()
-    const subscription = identityEvents$.subscribe(event => {
-      switch (event.type) {
-        case identityEventTypes.MODIFY:
-          return handleEvent(event.address)
-        case identityEventTypes.IMPORT:
-          return handleResolve()
-        case identityEventTypes.REMOVE:
-          return handleRemove(event.addresses)
-      }
-    })
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [
-    clearLabel,
-    entity,
-    handleEvent,
-    handleResolve,
-    handleRemove,
-    identityEvents$,
-  ])
 
   if (address === null) {
     return <IdentityBadgeWithNetwork {...props} customLabel={entity} />


### PR DESCRIPTION
Oops, this must've been missed earlier when cleaning up the CLEAR and adding the REMOVE modes.

Fixes remove not updating labels on the menu panels.

Also consolidates the logic in `LocalIdentityBadge` to use `useLocalIdentity()`.