### PR TITLE
SignerPanel: consolidate external transaction props into intent object

### DIFF
--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -260,8 +260,13 @@ class ActionPathsContent extends React.Component {
                   that has not been reviewed or audited. This means that it
                   might behave unexpectedly. Please{' '}
                   <strong css="font-weight: 800">
-                    be sure you trust this contract
+                    make sure you trust the contract at
                   </strong>{' '}
+                  <LocalIdentityBadge
+                    entity={intent.to}
+                    fontSize="small"
+                    compact
+                  />{' '}
                   before proceeding.
                 </span>
               )}

--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -13,8 +13,6 @@ class ActionPathsContent extends React.Component {
   static propTypes = {
     dao: PropTypes.string.isRequired,
     direct: PropTypes.bool.isRequired,
-    installed: PropTypes.bool.isRequired,
-    external: PropTypes.bool.isRequired,
     intent: PropTypes.object.isRequired,
     paths: PropTypes.array.isRequired,
     pretransaction: PropTypes.object,
@@ -175,10 +173,8 @@ class ActionPathsContent extends React.Component {
   }
   render() {
     const {
-      installed,
-      intent,
       direct,
-      external,
+      intent,
       paths,
       pretransaction,
       signingEnabled,
@@ -245,14 +241,14 @@ class ActionPathsContent extends React.Component {
         <Info mode="description" title="Action to be triggered">
           {this.renderDescription(showPaths, intent)}
         </Info>
-        {external && (
+        {intent.external && (
           <div
             css={`
               margin-top: ${3 * GU}px;
             `}
           >
             <Info mode="warning" title="Warning">
-              {installed ? (
+              {intent.installed ? (
                 `Be aware that this is an attempt to execute a transaction on
                  another app that is installed in this organization. You may
                  want to double check that app’s functionality before

--- a/src/components/SignerPanel/ConfirmTransaction.js
+++ b/src/components/SignerPanel/ConfirmTransaction.js
@@ -4,11 +4,9 @@ import ActionPathsContent from './ActionPathsContent'
 import ImpossibleAction from './ImpossibleAction'
 
 const ConfirmTransaction = ({
+  dao,
   direct,
   intent,
-  installed,
-  external,
-  dao,
   onClose,
   onSign,
   paths,
@@ -22,10 +20,8 @@ const ConfirmTransaction = ({
 
   return possible ? (
     <ActionPathsContent
-      direct={direct}
       dao={dao}
-      external={external}
-      installed={installed}
+      direct={direct}
       intent={intent}
       onSign={onSign}
       paths={paths}
@@ -39,11 +35,9 @@ const ConfirmTransaction = ({
 }
 
 ConfirmTransaction.propTypes = {
-  direct: PropTypes.bool.isRequired,
-  installed: PropTypes.bool.isRequired,
-  intent: PropTypes.object.isRequired,
-  external: PropTypes.bool.isRequired,
   dao: PropTypes.string,
+  direct: PropTypes.bool.isRequired,
+  intent: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   onSign: PropTypes.func.isRequired,
   paths: PropTypes.array.isRequired,


### PR DESCRIPTION
Cleans up the props here by adding this metadata into the transformed `intent` object.

cc @dizzypaty I've also added another identity badge (I don't think having more here hurts, since this is such a sensitive thing):

<img width="451" alt="Screen Shot 2019-08-22 at 11 33 50 AM" src="https://user-images.githubusercontent.com/4166642/63503933-bdea4780-c4d0-11e9-9b53-c08151112182.png">
