### PR TITLE
Update ENS API changes from @aragon/wrapper

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -487,9 +487,6 @@ export const initDaoBuilder = (
   ensRegistryAddress,
   ipfsConf = ipfsDefaultConf
 ) => {
-  // DEV only
-  // provider = new Web3.providers.WebsocketProvider('ws://localhost:8546')
-
   return {
     build: async (templateName, organizationName, settings = {}) => {
       if (!organizationName) {

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -1,11 +1,6 @@
 import BN from 'bn.js'
 import resolvePathname from 'resolve-pathname'
-import Aragon, {
-  providers,
-  setupTemplates,
-  isNameUsed,
-  ensResolve,
-} from '@aragon/wrapper'
+import Aragon, { providers, setupTemplates, ensResolve } from '@aragon/wrapper'
 import {
   appOverrides,
   sortAppsPair,
@@ -23,6 +18,7 @@ import {
   getWeb3,
   getUnknownBalance,
   getMainAccount,
+  isEmptyAddress,
   isValidEnsName,
 } from './web3-utils'
 import SandboxedWorker from './worker/SandboxedWorker'
@@ -191,6 +187,25 @@ export const pollNetwork = pollEvery((provider, onNetwork) => {
   }
 }, POLL_DELAY_NETWORK)
 
+const resolveEnsDomain = async (domain, opts) => {
+  try {
+    return await ensResolve(domain, opts)
+  } catch (err) {
+    if (err.message === 'ENS name not defined.') {
+      return ''
+    }
+    throw err
+  }
+}
+
+export const isEnsDomainAvailable = async name => {
+  const addr = await resolveEnsDomain(name, {
+    provider: web3Providers.default,
+    registryAddress: contractAddresses.ensRegistry,
+  })
+  return addr === '' || isEmptyAddress(addr)
+}
+
 // Subscribe to aragon.js observables
 const subscribe = (
   wrapper,
@@ -291,17 +306,6 @@ const subscribe = (
   }
 
   return subscriptions
-}
-
-const resolveEnsDomain = async (domain, opts) => {
-  try {
-    return await ensResolve(domain, opts)
-  } catch (err) {
-    if (err.message === 'ENS name not defined.') {
-      return ''
-    }
-    throw err
-  }
 }
 
 const initWrapper = async (
@@ -477,12 +481,6 @@ const templateParamFilters = {
     return [name, signers, neededSignatures]
   },
 }
-
-export const isNameAvailable = async name =>
-  !(await isNameUsed(name, {
-    provider: web3Providers.default,
-    registryAddress: contractAddresses.ensRegistry,
-  }))
 
 export const initDaoBuilder = (
   provider,

--- a/src/onboarding/Onboarding.js
+++ b/src/onboarding/Onboarding.js
@@ -5,7 +5,7 @@ import { Spring, animated } from 'react-spring'
 import { breakpoint } from '@aragon/ui'
 import { noop } from '../utils'
 import { getUnknownBalance } from '../web3-utils'
-import { isNameAvailable } from '../aragonjs-wrapper'
+import { isEnsDomainAvailable } from '../aragonjs-wrapper'
 import springs from '../springs'
 
 import * as Steps from './steps'
@@ -249,7 +249,9 @@ class Onboarding extends React.PureComponent {
 
     const checkName = async () => {
       try {
-        const available = await isNameAvailable(filteredDomain)
+        const available = await isEnsDomainAvailable(
+          `${filteredDomain}.aragonid.eth`
+        )
 
         // The domain could have changed in the meantime
         if (filteredDomain === this.state[domainKey]) {


### PR DESCRIPTION
Supercedes https://github.com/aragon/aragon/pull/897.

See associated PR in aragon.js: https://github.com/aragon/aragon.js/pull/369.

I'll keep the ENS resolution as part of `@aragon/wrapper` for now, until we can remove it completely with something like [`ens-lite`](https://github.com/jefflau/ens-lite).