### PR TITLE
PropTypes: move fetch-required fields of AppType to be non-required

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -66,17 +66,16 @@ export const ActivityStatusType = PropTypes.oneOf([
 ])
 
 export const AppType = PropTypes.shape({
-  abi: PropTypes.array.isRequired,
   appId: PropTypes.string.isRequired,
   baseUrl: PropTypes.string.isRequired,
   codeAddress: EthereumAddressType.isRequired,
-  functions: PropTypes.array.isRequired,
   hasWebApp: PropTypes.bool.isRequired,
-  name: PropTypes.string.isRequired,
   proxyAddress: EthereumAddressType.isRequired,
   src: PropTypes.string.isRequired,
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
 
+  // This content may not be available if the app's content couldn't be fetched
+  abi: PropTypes.array,
   appName: PropTypes.string,
   apmRegistry: PropTypes.string,
   content: PropTypes.shape({
@@ -84,14 +83,16 @@ export const AppType = PropTypes.shape({
     provider: PropTypes.string.isRequired,
   }),
   description: PropTypes.string,
+  functions: PropTypes.array,
   icons: PropTypes.arrayOf(
     PropTypes.shape({
       src: PropTypes.string.isRequired,
     })
   ),
+  isAragonOsInternalApp: PropTypes.bool,
   isForwarder: PropTypes.bool,
   kernelAddress: EthereumAddressType,
-  isAragonOsInternalApp: PropTypes.bool,
+  name: PropTypes.string,
   roles: PropTypes.array,
   status: PropTypes.string,
   version: PropTypes.string,


### PR DESCRIPTION
A few more of these fields can't be considered mandatory because they're fetched from the app's aragonPM repo content, which may or may not be available (depending on IPFS, network, etc.).