### PR TITLE
Organization: add current version details and add link to upgrade showcase

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -266,7 +266,7 @@ class App extends React.Component {
         const canUpgradeOrg = repos.some(
           ({ appId, currentVersion, latestVersion }) =>
             isKnownRepo(appId) &&
-            currentVersion.version.split('.')[0] !==
+            currentVersion.version.split('.')[0] <
               latestVersion.version.split('.')[0]
         )
         this.setState({ canUpgradeOrg, repos })

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -27,6 +27,9 @@ import { getAppPath, getPreferencesSearch } from './routing'
 import { APPS_STATUS_LOADING, DAO_STATUS_LOADING } from './symbols'
 import { addressesEqual } from './web3-utils'
 
+const SHOW_UPGRADE_MODAL_KEY = 'SHOW_UPGRADE_MODAL_FIRST_TIME'
+const OCTOBER_1ST_2019 = new Date('October 1 2019 00:00').getTime()
+
 class Wrapper extends React.PureComponent {
   static propTypes = {
     account: EthereumAddressType,
@@ -73,6 +76,17 @@ class Wrapper extends React.PureComponent {
 
   componentDidMount() {
     this.startIdentitySubscription()
+
+    // Show the upgrade showcase on first load up to a certain point in time
+    if (
+      localStorage.getItem(SHOW_UPGRADE_MODAL_KEY) !== 'false' &&
+      Date.now() < OCTOBER_1ST_2019
+    ) {
+      localStorage.setItem(SHOW_UPGRADE_MODAL_KEY, 'false')
+      this.setState({
+        upgradeModalOpened: true,
+      })
+    }
   }
 
   componentWillUnmount() {
@@ -226,7 +240,8 @@ class Wrapper extends React.PureComponent {
   }
   showOrgUpgradePanel = () => {
     this.setState({
-      orgUpgradePanelOpened: true,
+      // Only open the upgrade panel if the org can be upgraded
+      orgUpgradePanelOpened: this.props.canUpgradeOrg,
       upgradeModalOpened: false,
     })
   }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -24,7 +24,11 @@ import {
   RepoType,
 } from './prop-types'
 import { getAppPath, getPreferencesSearch } from './routing'
-import { APPS_STATUS_LOADING, DAO_STATUS_LOADING } from './symbols'
+import {
+  APP_MODE_ORG,
+  APPS_STATUS_LOADING,
+  DAO_STATUS_LOADING,
+} from './symbols'
 import { addressesEqual } from './web3-utils'
 
 const SHOW_UPGRADE_MODAL_KEY = 'SHOW_UPGRADE_MODAL_FIRST_TIME'
@@ -76,17 +80,7 @@ class Wrapper extends React.PureComponent {
 
   componentDidMount() {
     this.startIdentitySubscription()
-
-    // Show the upgrade showcase on first load up to a certain point in time
-    if (
-      localStorage.getItem(SHOW_UPGRADE_MODAL_KEY) !== 'false' &&
-      Date.now() < OCTOBER_1ST_2019
-    ) {
-      localStorage.setItem(SHOW_UPGRADE_MODAL_KEY, 'false')
-      this.setState({
-        upgradeModalOpened: true,
-      })
-    }
+    this.showOrgUpgradePanelIfFirstVisit()
   }
 
   componentWillUnmount() {
@@ -95,6 +89,9 @@ class Wrapper extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     this.updateIdentityEvents(prevProps)
+    if (prevProps.locator !== this.props.locator) {
+      this.showOrgUpgradePanelIfFirstVisit()
+    }
   }
 
   getAppInstancesGroups = memoize(apps =>
@@ -244,6 +241,19 @@ class Wrapper extends React.PureComponent {
       orgUpgradePanelOpened: this.props.canUpgradeOrg,
       upgradeModalOpened: false,
     })
+  }
+  showOrgUpgradePanelIfFirstVisit = () => {
+    // Show the upgrade showcase on first load up to a certain point in time
+    if (
+      this.props.locator.mode === APP_MODE_ORG &&
+      localStorage.getItem(SHOW_UPGRADE_MODAL_KEY) !== 'false' &&
+      Date.now() < OCTOBER_1ST_2019
+    ) {
+      localStorage.setItem(SHOW_UPGRADE_MODAL_KEY, 'false')
+      this.setState({
+        upgradeModalOpened: true,
+      })
+    }
   }
   hideOrgUpgradePanel = () => {
     this.setState({ orgUpgradePanelOpened: false })

--- a/src/apps/Organization/Organization.js
+++ b/src/apps/Organization/Organization.js
@@ -25,8 +25,10 @@ const Organization = React.memo(function Organization({
   account,
   apps,
   appsLoading,
+  canUpgradeOrg,
   daoAddress,
   onOpenApp,
+  onShowOrgVersionDetails,
   walletNetwork,
   walletWeb3,
   walletProviderId,
@@ -61,6 +63,27 @@ const Organization = React.memo(function Organization({
   const enableTransactions = !!account && walletNetwork === network.type
   const shortAddresses = layoutName !== 'large'
 
+  const organizationText = checksummedDaoAddr ? (
+    <span>
+      This organization is deployed on the Ethereum {network.name}.{' '}
+      {canUpgradeOrg ? (
+        <span>
+          <Link onClick={onShowOrgVersionDetails}>
+            A new software update is available
+          </Link>
+          .
+        </span>
+      ) : (
+        <span>
+          The current software version is 0.8 Camino. You can see{' '}
+          <Link onClick={onShowOrgVersionDetails}>what's new here</Link>.
+        </span>
+      )}
+    </span>
+  ) : (
+    'Resolving DAO address…'
+  )
+
   const depositFundsHelpText = appsLoading ? (
     ''
   ) : hasFinanceApp || hasAgentApp ? (
@@ -88,9 +111,7 @@ const Organization = React.memo(function Organization({
             ${textStyle('body2')}
           `}
         >
-          {checksummedDaoAddr
-            ? `This organization is deployed on the Ethereum ${network.name}.`
-            : 'Resolving DAO address…'}
+          {organizationText}
         </p>
         {checksummedDaoAddr && (
           <React.Fragment>
@@ -235,8 +256,10 @@ Organization.propTypes = {
   account: EthereumAddressType,
   apps: PropTypes.arrayOf(AppType).isRequired,
   appsLoading: PropTypes.bool.isRequired,
+  canUpgradeOrg: PropTypes.bool.isRequired,
   daoAddress: DaoAddressType.isRequired,
   onOpenApp: PropTypes.func.isRequired,
+  onShowOrgVersionDetails: PropTypes.func.isRequired,
   walletNetwork: PropTypes.string.isRequired,
   walletWeb3: PropTypes.object.isRequired,
   walletProviderId: PropTypes.string.isRequired,

--- a/src/components/Upgrade/UpgradeBanner.js
+++ b/src/components/Upgrade/UpgradeBanner.js
@@ -1,29 +1,15 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { Button, springs, useViewport } from '@aragon/ui'
 import Banner, { BANNER_HEIGHT } from '../Banner/Banner'
-import UpgradeModal from './UpgradeModal'
 import { banner } from './content'
 
 const SHOW_UPGRADE_MODAL_KEY = 'SHOW_UPGRADE_MODAL_FIRST_TIME'
 const OCTOBER_1ST_2019 = new Date('October 1 2019 00:00').getTime()
 
-function useUpgradeBanner(onUpgrade, visible) {
-  const [showModal, setShowModal] = useState(false)
-
-  const handleMoreInfo = useCallback(() => {
-    setShowModal(true)
-  }, [setShowModal])
-
-  const handleModalClose = useCallback(() => {
-    setShowModal(false)
-  }, [setShowModal])
-
-  const handleUpgrade = useCallback(() => {
-    setShowModal(false)
-    onUpgrade()
-  }, [setShowModal, onUpgrade])
+const UpgradeBanner = React.memo(({ visible, onMoreInfo }) => {
+  const { width } = useViewport()
 
   useEffect(() => {
     if (
@@ -32,24 +18,9 @@ function useUpgradeBanner(onUpgrade, visible) {
       Date.now() < OCTOBER_1ST_2019
     ) {
       localStorage.setItem(SHOW_UPGRADE_MODAL_KEY, 'false')
-      setShowModal(true)
+      onMoreInfo()
     }
-  }, [visible])
-
-  return { showModal, handleMoreInfo, handleModalClose, handleUpgrade }
-}
-
-const UpgradeBanner = React.memo(function UpgradeBanner({
-  visible,
-  onUpgrade,
-}) {
-  const { width } = useViewport()
-  const {
-    showModal,
-    handleMoreInfo,
-    handleModalClose,
-    handleUpgrade,
-  } = useUpgradeBanner(onUpgrade, visible)
+  }, [onMoreInfo, visible])
 
   return (
     <React.Fragment>
@@ -69,7 +40,7 @@ const UpgradeBanner = React.memo(function UpgradeBanner({
               <Banner
                 text={width > 500 ? banner.text.large : banner.text.small}
                 button={
-                  <Button onClick={handleMoreInfo} mode="normal" size="mini">
+                  <Button onClick={onMoreInfo} mode="normal" size="mini">
                     More info
                   </Button>
                 }
@@ -81,17 +52,12 @@ const UpgradeBanner = React.memo(function UpgradeBanner({
         /* eslint-enable react/prop-types */
         }
       </Transition>
-      <UpgradeModal
-        visible={showModal}
-        onClose={handleModalClose}
-        onUpgrade={handleUpgrade}
-      />
     </React.Fragment>
   )
 })
 
 UpgradeBanner.propTypes = {
-  onUpgrade: PropTypes.func.isRequired,
+  onMoreInfo: PropTypes.func.isRequired,
   visible: PropTypes.bool,
 }
 

--- a/src/components/Upgrade/UpgradeBanner.js
+++ b/src/components/Upgrade/UpgradeBanner.js
@@ -1,26 +1,12 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { Button, springs, useViewport } from '@aragon/ui'
 import Banner, { BANNER_HEIGHT } from '../Banner/Banner'
 import { banner } from './content'
 
-const SHOW_UPGRADE_MODAL_KEY = 'SHOW_UPGRADE_MODAL_FIRST_TIME'
-const OCTOBER_1ST_2019 = new Date('October 1 2019 00:00').getTime()
-
 const UpgradeBanner = React.memo(({ visible, onMoreInfo }) => {
   const { width } = useViewport()
-
-  useEffect(() => {
-    if (
-      visible &&
-      localStorage.getItem(SHOW_UPGRADE_MODAL_KEY) !== 'false' &&
-      Date.now() < OCTOBER_1ST_2019
-    ) {
-      localStorage.setItem(SHOW_UPGRADE_MODAL_KEY, 'false')
-      onMoreInfo()
-    }
-  }, [onMoreInfo, visible])
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/287.

Lifts the `UpgradeModal` (perhaps we should rename this to `VersionShowcase` or something later) up to be in `Wrapper` so it can be controlled from apps like Organization.

TODO:

- [x] Resolve conflicts between this and https://github.com/aragon/aragon/pull/949