### PR TITLE
App center: polish from design review

### DIFF
--- a/src/apps/AppCenter/AppCard.js
+++ b/src/apps/AppCenter/AppCard.js
@@ -62,13 +62,12 @@ const CardMain = styled.section`
     compactMode
       ? `
           display: grid;
-          grid-template-columns: auto 1fr auto;
-          grid-template-rows: auto auto auto;
+          grid-template-columns: auto 1fr;
+          grid-template-rows: auto auto;
           grid-template-areas:
-            "empty topright"
             "icon title"
             "icon description";
-          padding: ${1.5 * GU}px ${1.5 * GU}px ${4 * GU}px ${3 * GU}px;
+          padding: ${3 * GU}px ${1.5 * GU}px ${1.5 * GU}px ${3 * GU}px;
         `
       : `
           display: flex;
@@ -117,10 +116,9 @@ const TagWrapper = styled.div`
   ${({ compactMode, link }) =>
     compactMode
       ? `
-        grid-area: topright;
-        text-align: right;
         position: absolute;
-        right: ${link ? 3.5 * GU : 0}px;
+        top: ${1.5 * GU}px;
+        right: ${(link ? 5 : 1.5) * GU}px;
       `
       : `
         max-width: 100%;
@@ -153,21 +151,14 @@ const Description = styled.p`
 `
 
 function StyledIconExternal({ compactMode, theme }) {
+  const paddingGU = compactMode ? 1.5 : 2
   return (
     <IconExternal
       css={`
         color: ${theme.surfaceIcon};
-        ${compactMode
-          ? `
-              grid-area: topright;
-              margin-left: auto;
-              margin-bottom: ${0.5 * GU}px;
-            `
-          : `
-              position: absolute;
-              top: ${2 * GU}px;
-              right: ${2 * GU}px;
-            `}
+        position: absolute;
+        top: ${paddingGU * GU}px;
+        right: ${paddingGU * GU}px;
       `}
     />
   )

--- a/src/apps/AppCenter/InstalledApps/AppContent.js
+++ b/src/apps/AppCenter/InstalledApps/AppContent.js
@@ -11,12 +11,11 @@ import {
   GU,
   blockExplorerUrl,
   textStyle,
-  useViewport,
+  useLayout,
   useTheme,
 } from '@aragon/ui'
 import AppIcon from '../../../components/AppIcon/AppIcon'
 import LocalIdentityBadge from '../../../components/IdentityBadge/LocalIdentityBadge'
-import { MENU_PANEL_WIDTH } from '../../../components/MenuPanel/MenuPanel'
 import Markdown from '../../../components/Markdown/Markdown'
 import { RepoType } from '../../../prop-types'
 import { useRepoDetails } from '../../../hooks'
@@ -24,13 +23,10 @@ import { network } from '../../../environment'
 import Screenshots from '../Screenshots'
 import { sanitizeCodeRepositoryUrl } from '../../../url-utils'
 
-// Exclude the width of MenuPanel
-const appBelow = (below, value) =>
-  below(value + (below('medium') ? 0 : MENU_PANEL_WIDTH))
-
 const AppContent = React.memo(
   ({ repo, repoVersions, onRequestUpgrade, onClose }) => {
     const theme = useTheme()
+    const { layoutName } = useLayout()
     const {
       name,
       instances,
@@ -52,8 +48,7 @@ const AppContent = React.memo(
     } = repo
     const repoDetails = useRepoDetails(baseUrl, detailsUrl)
     const canUpgrade = currentVersion.version !== latestVersion
-    const { below, breakpoints } = useViewport()
-    const compact = appBelow(below, breakpoints.medium)
+    const compact = layoutName === 'small'
 
     return (
       <React.Fragment>
@@ -130,7 +125,7 @@ const AppContent = React.memo(
                       mode="strong"
                       onClick={onRequestUpgrade}
                       css={`
-                        width: 128px;
+                        width: ${compact ? '100%' : '128px'};
                         margin: ${2.5 * GU}px 0;
                         align-self: center;
                       `}

--- a/src/apps/AppCenter/InstalledApps/AppContent.js
+++ b/src/apps/AppCenter/InstalledApps/AppContent.js
@@ -257,7 +257,7 @@ const Heading2 = styled.h2`
 `
 
 const DetailsGroup = styled.div`
-  margin-bottom: ${3.5 * GU}px;
+  margin-bottom: ${3 * GU}px;
 `
 
 const BreakLink = styled.div`

--- a/src/apps/AppCenter/InstalledApps/RepoVersions.js
+++ b/src/apps/AppCenter/InstalledApps/RepoVersions.js
@@ -119,7 +119,7 @@ RepoVersions.propTypes = {
 }
 
 const Td = styled.td`
-  padding: ${1.5 * GU}px 0;
+  padding: ${1 * GU}px 0;
 `
 
 export default RepoVersions

--- a/src/components/Markdown/Markdown.js
+++ b/src/components/Markdown/Markdown.js
@@ -40,7 +40,7 @@ const Wrapper = styled.section`
   h3,
   h4 {
     font-weight: bold;
-    margin: ${1 * GU}px 0;
+    margin-top: ${3 * GU}px;
     ${textStyle('label2')};
     color: ${({ theme }) => theme.contentSecondary};
   }


### PR DESCRIPTION
From https://github.com/aragon/aragon/pull/928#issuecomment-527278602:

> Update the app screenshots to ones with the new style

This will have to be checked separately, once we publish the new descriptions.

> The 'Upgrade app' button on the app detail view must be wide (100% minus 2GU padding on each side) when displayed on medium & small viewports

I've done this only for small layouts, as anything above small (medium, larger) has enough room to put the button on the right side.