### PR TITLE
Preferences: adjust spacing in custom labels

### DIFF
--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -172,7 +172,7 @@ function LocalIdentities({
                     label="Toggle sort"
                     onClick={onToggleSort}
                     css={`
-                      padding: ${0.5 * GU}px ${1 * GU}px;
+                      padding: ${0.5 * GU}px ${3 * GU}px;
                       position: relative;
                       left: ${-3 * GU}px;
                       border-radius: 0;
@@ -187,6 +187,7 @@ function LocalIdentities({
                     <span
                       css={`
                         margin-right: ${1 * GU}px;
+                        ${textStyle('label2')}
                       `}
                     >
                       Custom label{' '}

--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -400,7 +400,7 @@ const List = styled.ul`
   padding: 0;
   list-style: none;
   overflow: hidden;
-  width: calc(100% + ${6 * GU}px);
+  width: calc(100% + ${5 * GU}px);
   position: relative;
   left: -${3 * GU}px;
   background: ${({ surface }) => surface};


### PR DESCRIPTION
Was working on fixes from [here](https://www.notion.so/aragon/Design-review-0-8-II-eefe2d081a7d49f4b08602f76e50be6a) but have to take another direction, don't want this to get lost:

- [x] LocalIdentities: fix header styles and spacing
- [x] Fix overflow on Local Identities list for mobile