### PR TITLE
Permissions: fix the entire view jumping when using scrollIntoView()

### DIFF
--- a/src/apps/Permissions/Permissions.js
+++ b/src/apps/Permissions/Permissions.js
@@ -77,9 +77,12 @@ function Permissions({
 
   // `localPath` should change every time we navigate into and out of a detailed
   // permissions view, so this ensures the user starts at the top of the screen
-  // on every navigation change
+  // on every navigation change.
   useEffect(() => {
-    scrollTopElement.current.scrollIntoView()
+    // The `false` is only here as a quick fix to prevent the top banner to
+    // disappear when present. It will get removed once the issue with the top
+    // banner is identified and fixed.
+    scrollTopElement.current.scrollIntoView(false)
   }, [localPath])
 
   const location = getLocation(localPath, apps)

--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -11,7 +11,6 @@ import {
   ToastHub,
   breakpoint,
   springs,
-  useLayout,
   useTheme,
   useToast,
   useViewport,
@@ -284,10 +283,10 @@ const AnimatedWrap = styled(animated.div)`
 const GlobalPreferencesWithDependencies = React.memo(
   function GlobalPreferencesWithDependencies(props) {
     const { optedOut } = useHelpScout()
-    const { layoutName } = useLayout()
+    const { below } = useViewport()
     return (
       <ToastHub
-        shift={optedOut ? 0 : layoutName === 'small' ? 5.5 * GU : 6.5 * GU}
+        shift={optedOut ? 0 : below('medium') ? 5.5 * GU : 6.5 * GU}
         timeout={TIMEOUT_TOAST}
       >
         <AnimatedGlobalPreferences {...props} />

--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -296,7 +296,7 @@ const GlobalPreferencesWithDependencies = React.memo(
 
 export { TIMEOUT_TOAST }
 export default React.memo(props => (
-  <Layout>
+  <Layout paddingBottom={0}>
     <GlobalPreferencesWithDependencies {...props} />
   </Layout>
 ))

--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -242,15 +242,13 @@ function AnimatedGlobalPreferences(props) {
               ),
             }}
           >
-            <Layout paddingBottom={0}>
-              <GlobalPreferences
-                {...props}
-                compact={compact}
-                sectionIndex={sectionIndex}
-                subsection={subsection}
-                onNavigation={handleNavigation}
-              />
-            </Layout>
+            <GlobalPreferences
+              {...props}
+              compact={compact}
+              sectionIndex={sectionIndex}
+              subsection={subsection}
+              onNavigation={handleNavigation}
+            />
           </AnimatedWrap>
         ))
       /* eslint-enable react/prop-types */

--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -243,13 +243,15 @@ function AnimatedGlobalPreferences(props) {
               ),
             }}
           >
-            <GlobalPreferences
-              {...props}
-              compact={compact}
-              sectionIndex={sectionIndex}
-              subsection={subsection}
-              onNavigation={handleNavigation}
-            />
+            <Layout paddingBottom={0}>
+              <GlobalPreferences
+                {...props}
+                compact={compact}
+                sectionIndex={sectionIndex}
+                subsection={subsection}
+                onNavigation={handleNavigation}
+              />
+            </Layout>
           </AnimatedWrap>
         ))
       /* eslint-enable react/prop-types */
@@ -296,7 +298,5 @@ const GlobalPreferencesWithDependencies = React.memo(
 
 export { TIMEOUT_TOAST }
 export default React.memo(props => (
-  <Layout paddingBottom={0}>
-    <GlobalPreferencesWithDependencies {...props} />
-  </Layout>
+  <GlobalPreferencesWithDependencies {...props} />
 ))


### PR DESCRIPTION
After https://github.com/aragon/aragon/pull/971, only the top banner seems to disappearing from using `scrollIntoView`.