### PR TITLE
Fix a crash when going to the client home from the preferences

### DIFF
--- a/src/components/GlobalPreferences/SharedIdentities/useSharedLink.js
+++ b/src/components/GlobalPreferences/SharedIdentities/useSharedLink.js
@@ -74,10 +74,8 @@ function useSharedLink({ wrapper, toast, locator, onScreenChange }) {
     setSelected(initialSelected)
   }, [initialSelected, setSelected])
   useEffect(() => {
-    const {
-      preferences: { params },
-    } = locator
-    if (!params.has('labels')) {
+    const { preferences: { params } = {} } = locator
+    if (!params || !params.has('labels')) {
       return
     }
     try {


### PR DESCRIPTION
For example by changing the URL from `/myorg?preferences=/custom-labels` to `/`.