### PR TITLE
Upgrade Org: fix upgrade transaction for orgs with non-known apps

### DIFF
--- a/src/components/Upgrade/UpgradeOrganizationPanel.js
+++ b/src/components/Upgrade/UpgradeOrganizationPanel.js
@@ -33,22 +33,24 @@ const REGISTRY = ['aragonpm.eth', 'https://etherscan.io/address/aragonpm.eth']
 const UpgradeOrganizationPanel = React.memo(
   ({ repos = [], opened, onClose, daoAddress, wrapper }) => {
     const theme = useTheme()
+    const knownUpgradableRepos = useMemo(
+      () => repos.filter(repo => isKnownRepo(repo.appId)),
+      [repos]
+    )
     const [currentVersions, newVersions] = useMemo(
       () =>
-        repos
-          .filter(repo => isKnownRepo(repo.appId))
-          .reduce(
-            (results, repo) => [
-              [...results[0], repo.currentVersion],
-              [...results[1], repo.latestVersion],
-            ],
-            [[], []]
-          ),
-      [repos]
+        knownUpgradableRepos.reduce(
+          (results, repo) => [
+            [...results[0], repo.currentVersion],
+            [...results[1], repo.latestVersion],
+          ],
+          [[], []]
+        ),
+      [knownUpgradableRepos]
     )
 
     const handleUpgradeAll = useCallback(async () => {
-      const upgradeIntents = repos.map(({ appId, versions }) => {
+      const upgradeIntents = knownUpgradableRepos.map(({ appId, versions }) => {
         const newContractAddress = versions[versions.length - 1].contractAddress
         return [
           daoAddress.address,
@@ -80,7 +82,7 @@ const UpgradeOrganizationPanel = React.memo(
         // The user just can't perform this action, show the signing panel's error screen
         await wrapper.performTransactionPath([])
       }
-    }, [daoAddress, onClose, repos, wrapper])
+    }, [knownUpgradableRepos, daoAddress, onClose, wrapper])
 
     return (
       <SidePanel


### PR DESCRIPTION
Oops 🙈, if you had more than just the known apps installed and there were major updates available for them, this would try to also include them in the upgrade.

This now selects only the short list of known repos (Finance, Tokens, Voting) to be part of this "organization upgrade".

Fixes some bugs with the upgrade panel along with https://github.com/aragon/aragon.js/pull/385.