### PR TITLE
Favourite Organizations: check address equality with checksums included

### DIFF
--- a/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/Favorites.js
@@ -45,7 +45,9 @@ class Favorites extends React.Component {
     const localDaos = [
       ...favoriteDaos
         .map(dao => ({ ...dao, favorited: true }))
-        .sort(dao => (dao.address === currentDao.address ? -1 : 0)),
+        .sort(dao =>
+          addressesEqual(dao.address, currentDao.address) ? -1 : 0
+        ),
     ]
 
     // If the current DAO is favorited, it is already in the local list
@@ -55,13 +57,17 @@ class Favorites extends React.Component {
   }
 
   isDaoFavorited({ address }) {
-    return this.props.favoriteDaos.some(dao => dao.address === address)
+    return this.props.favoriteDaos.some(dao =>
+      addressesEqual(dao.address, address)
+    )
   }
 
   currentDaoWithFavoriteState() {
     const { currentDao } = this.props
     const { localDaos } = this.state
-    const daoItem = localDaos.find(dao => currentDao.address === dao.address)
+    const daoItem = localDaos.find(dao =>
+      addressesEqual(currentDao.address, dao.address)
+    )
     return {
       ...currentDao,
       favorited: daoItem ? daoItem.favorited : false,
@@ -72,10 +78,10 @@ class Favorites extends React.Component {
     window.location.hash = ''
   }
 
-  handleDaoOpened = address => {
+  handleOpenOrg = address => {
     const { currentDao, favoriteDaos } = this.props
-    const dao = [currentDao, ...favoriteDaos].find(
-      dao => dao.address === address
+    const dao = [currentDao, ...favoriteDaos].find(dao =>
+      addressesEqual(dao.address, address)
     )
     window.location.hash = `/${(dao && dao.name) || address}`
   }
@@ -85,7 +91,7 @@ class Favorites extends React.Component {
 
     this.setState({
       localDaos: localDaos.map(dao =>
-        dao.address === address ? { ...dao, favorited } : dao
+        addressesEqual(dao.address, address) ? { ...dao, favorited } : dao
       ),
     })
   }
@@ -120,11 +126,13 @@ class Favorites extends React.Component {
     })
 
     const favoriteItems = [...allItems].sort((org, org2) => {
+      const { name = '' } = org
+      const { name: name2 = '' } = org
       return addressesEqual(org.address, currentDao.address)
         ? -1
         : addressesEqual(org2.address, currentDao.address)
         ? 1
-        : org.name.localeCompare(org2.name)
+        : name.localeCompare(name2)
     })
 
     return (
@@ -136,7 +144,7 @@ class Favorites extends React.Component {
       >
         <FavoritesMenu
           items={favoriteItems}
-          onActivate={this.handleDaoOpened}
+          onActivate={this.handleOpenOrg}
           onFavoriteUpdate={this.handleFavoriteUpdate}
         />
         <FavoritesMenuItemButton

--- a/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
+++ b/src/components/MenuPanel/OrganizationSwitcher/OrganizationSwitcher.js
@@ -8,17 +8,18 @@ import {
   textStyle,
   useTheme,
 } from '@aragon/ui'
-import { FavoriteDaoType, DaoItemType } from '../../../prop-types'
-import { FavoriteDaosConsumer } from '../../../contexts/FavoriteDaosContext'
+import { DaoItemType } from '../../../prop-types'
+import { useFavoriteDaos } from '../../../contexts/FavoriteDaosContext'
 import OrganizationItem from './OrganizationItem'
 import Favorites from './Favorites'
 
 const OrganizationSwitcher = React.memo(function OrganizationSwitcher({
   currentDao,
-  favoriteDaos,
-  updateFavoriteDaos,
+  loading,
 }) {
   const theme = useTheme()
+
+  const { favoriteDaos, updateFavoriteDaos } = useFavoriteDaos()
 
   const buttonRef = useRef(null)
   const [menuOpened, setMenuOpened] = useState(false)
@@ -39,60 +40,6 @@ const OrganizationSwitcher = React.memo(function OrganizationSwitcher({
     [closeMenu, updateFavoriteDaos]
   )
 
-  return (
-    <div
-      css={`
-        display: flex;
-        align-items: center;
-        position: relative;
-      `}
-    >
-      <ButtonBase
-        ref={buttonRef}
-        onClick={handleToggleMenu}
-        css={`
-          flex-grow: 1;
-          padding: ${2 * GU}px ${2 * GU}px ${2 * GU}px ${3 * GU}px;
-          width: 100%;
-          height: 100%;
-          min-width: ${28 * GU}px;
-          border-radius: 0;
-          &:active {
-            background: ${theme.surfacePressed};
-          }
-        `}
-      >
-        <OrganizationItem
-          dao={currentDao}
-          css={`
-            ${textStyle('body1')}
-          `}
-        />
-      </ButtonBase>
-      <Popover
-        onClose={closeMenu}
-        visible={menuOpened}
-        opener={buttonRef.current}
-      >
-        <Favorites
-          favoriteDaos={favoriteDaos}
-          currentDao={currentDao}
-          onUpdate={handleFavoritesUpdate}
-        />
-      </Popover>
-    </div>
-  )
-})
-
-OrganizationSwitcher.propTypes = {
-  currentDao: DaoItemType.isRequired,
-
-  // These are coming from <FavoriteDaosConsumer /> (end of this file).
-  favoriteDaos: PropTypes.arrayOf(FavoriteDaoType).isRequired,
-  updateFavoriteDaos: PropTypes.func.isRequired,
-}
-
-function OrganizationSwitcherWithFavorites({ loading, ...props }) {
   if (loading) {
     return (
       <div
@@ -114,25 +61,56 @@ function OrganizationSwitcherWithFavorites({ loading, ...props }) {
       </div>
     )
   }
-  if (props.currentDao.address) {
+  if (currentDao.address) {
     return (
-      <FavoriteDaosConsumer>
-        {({ favoriteDaos, updateFavoriteDaos }) => (
-          <OrganizationSwitcher
-            {...props}
-            favoriteDaos={favoriteDaos}
-            updateFavoriteDaos={updateFavoriteDaos}
+      <div
+        css={`
+          display: flex;
+          align-items: center;
+          position: relative;
+        `}
+      >
+        <ButtonBase
+          ref={buttonRef}
+          onClick={handleToggleMenu}
+          css={`
+            flex-grow: 1;
+            padding: ${2 * GU}px ${2 * GU}px ${2 * GU}px ${3 * GU}px;
+            width: 100%;
+            height: 100%;
+            min-width: ${28 * GU}px;
+            border-radius: 0;
+            &:active {
+              background: ${theme.surfacePressed};
+            }
+          `}
+        >
+          <OrganizationItem
+            dao={currentDao}
+            css={`
+              ${textStyle('body1')}
+            `}
           />
-        )}
-      </FavoriteDaosConsumer>
+        </ButtonBase>
+        <Popover
+          onClose={closeMenu}
+          visible={menuOpened}
+          opener={buttonRef.current}
+        >
+          <Favorites
+            favoriteDaos={favoriteDaos}
+            currentDao={currentDao}
+            onUpdate={handleFavoritesUpdate}
+          />
+        </Popover>
+      </div>
     )
   }
-  return null
-}
+})
 
-OrganizationSwitcherWithFavorites.propTypes = {
-  loading: PropTypes.bool.isRequired,
+OrganizationSwitcher.propTypes = {
   currentDao: DaoItemType.isRequired,
+  loading: PropTypes.bool.isRequired,
 }
 
-export default OrganizationSwitcherWithFavorites
+export default OrganizationSwitcher

--- a/src/contexts/FavoriteDaosContext.js
+++ b/src/contexts/FavoriteDaosContext.js
@@ -1,8 +1,9 @@
 import React, { useContext } from 'react'
-import PropTypes from 'prop-types'
-import StoredList from '../StoredList'
-import { network } from '../environment'
 import uniqby from 'lodash.uniqby'
+import PropTypes from 'prop-types'
+import { network } from '../environment'
+import StoredList from '../StoredList'
+import { addressesEqual } from '../web3-utils'
 
 const FavoriteDaosContext = React.createContext()
 
@@ -16,7 +17,7 @@ const filterFavoritesDaos = daos =>
         name: dao.name || '',
         address: dao.address,
       })),
-    dao => dao.address
+    dao => dao.address.toLowerCase()
   )
 
 class FavoriteDaosProvider extends React.Component {
@@ -42,13 +43,15 @@ class FavoriteDaosProvider extends React.Component {
 
   isAddressFavorited = address => {
     return (
-      this.state.favoriteDaos.findIndex(dao => dao.address === address) > -1
+      this.state.favoriteDaos.findIndex(dao =>
+        addressesEqual(dao.address, address)
+      ) > -1
     )
   }
 
   addFavorite = dao => {
-    const daoIndex = this.state.favoriteDaos.findIndex(
-      ({ address }) => address === dao.address
+    const daoIndex = this.state.favoriteDaos.findIndex(({ address }) =>
+      addressesEqual(address, dao.address)
     )
     if (daoIndex === -1) {
       this.setState({
@@ -58,8 +61,8 @@ class FavoriteDaosProvider extends React.Component {
   }
 
   removeFavoriteByAddress = address => {
-    const daoIndex = this.state.favoriteDaos.findIndex(
-      dao => dao.address === address
+    const daoIndex = this.state.favoriteDaos.findIndex(({ address }) =>
+      addressesEqual(address, address)
     )
     if (daoIndex > -1) {
       const favs = storedList.remove(daoIndex)


### PR DESCRIPTION
I'm surprised we've gotten away for so long without doing this in `FavoritesDao`.

Fixes the issue with seeing duplicates in the org switcher and onboarding's suggestions list.