### PR TITLE
Preferences, Activity: make panels fullwidth on smaller screens

### DIFF
--- a/src/components/Activity/ActivityList.js
+++ b/src/components/Activity/ActivityList.js
@@ -52,6 +52,7 @@ function ActivityList({ apps }) {
   return (
     <div
       css={`
+        /* Use 20px as the padding setting for popper is 10px */
         width: ${below('medium') ? `calc(100vw - 20px)` : `${42 * GU}px`};
       `}
     >

--- a/src/components/Activity/ActivityList.js
+++ b/src/components/Activity/ActivityList.js
@@ -26,7 +26,7 @@ const getAppByProxyAddress = (proxyAddress, apps) =>
 
 function ActivityList({ apps }) {
   const theme = useTheme()
-  const { height } = useViewport()
+  const { below, height } = useViewport()
   const { activities, clearActivities } = useContext(ActivityContext)
   const activityItems = useMemo(
     () =>
@@ -52,7 +52,7 @@ function ActivityList({ apps }) {
   return (
     <div
       css={`
-        width: ${42 * GU}px;
+        width: ${below('medium') ? `calc(100vw - 20px)` : `${42 * GU}px`};
       `}
     >
       <div

--- a/src/components/OrgView/GlobalPreferencesButton/GlobalPreferencesButton.js
+++ b/src/components/OrgView/GlobalPreferencesButton/GlobalPreferencesButton.js
@@ -61,6 +61,7 @@ function GlobalPreferencesButton({ onOpen }) {
       >
         <ul
           css={`
+            /* Use 20px as the padding setting for popper is 10px */
             width: ${below('medium') ? `calc(100vw - 20px)` : `${42 * GU}px`};
             padding: 0;
             margin: 0;

--- a/src/components/OrgView/GlobalPreferencesButton/GlobalPreferencesButton.js
+++ b/src/components/OrgView/GlobalPreferencesButton/GlobalPreferencesButton.js
@@ -9,6 +9,7 @@ import {
   RADIUS,
   textStyle,
   useTheme,
+  useViewport,
 } from '@aragon/ui'
 import IconNetwork from './IconNetwork'
 import IconCustomLabels from './IconCustomLabels'
@@ -17,6 +18,7 @@ import IconHelpAndFeedback from './IconHelpAndFeedback'
 
 function GlobalPreferencesButton({ onOpen }) {
   const theme = useTheme()
+  const { below } = useViewport()
   const [opened, setOpened] = useState(false)
   const containerRef = useRef()
 
@@ -59,7 +61,7 @@ function GlobalPreferencesButton({ onOpen }) {
       >
         <ul
           css={`
-            width: ${42 * GU}px;
+            width: ${below('medium') ? `calc(100vw - 20px)` : `${42 * GU}px`};
             padding: 0;
             margin: 0;
             list-style: none;


### PR DESCRIPTION
As discussed with @dizzypaty.

<img width="706" alt="Screen Shot 2019-09-10 at 12 16 27 AM" src="https://user-images.githubusercontent.com/4166642/64572685-4c2f4c00-d360-11e9-902b-106837482317.png">
<img width="701" alt="Screen Shot 2019-09-10 at 12 16 41 AM" src="https://user-images.githubusercontent.com/4166642/64572692-4f2a3c80-d360-11e9-80e1-b0b692a682eb.png">