### PR TITLE
Hacks to work around current carousel bugs

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -105,22 +105,30 @@ function Carousel({ items, itemWidth, itemHeight, itemSpacing }) {
 
   // Update the transition during drag
   const bindDrag = useDrag(({ event, down, delta }) => {
-    const deltaMul = 3 * delta[0]
-    const updatedX = Math.max(lastX, Math.min(sideSpace, selectedX + deltaMul))
+    const updatedX = Math.max(lastX, Math.min(sideSpace, selectedX + delta[0]))
 
     if (down) {
       setX({
         x: updatedX,
         drag: delta[0] !== 0,
-        immediate: false, // TODO: keep going until we decelerate enough, then stick to an item
+        immediate: true, // TODO: keep going until we decelerate enough, then stick to an item
       })
     } else {
+      let target = selected
+      if (Math.abs(delta[0]) > itemWidth / 2) {
+        if (delta[0] > 0) {
+          target = Math.max(0, selected - 1)
+        } else {
+          target = Math.min(selected + 1, items.length - 1)
+        }
+      }
+
       setX({
-        x: xFromItem(selected),
+        x: xFromItem(target),
         drag: false,
         immediate: false,
       })
-      setSelected(itemFromX(updatedX))
+      setSelected(target)
     }
   })
 

--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -105,7 +105,8 @@ function Carousel({ items, itemWidth, itemHeight, itemSpacing }) {
 
   // Update the transition during drag
   const bindDrag = useDrag(({ event, down, delta }) => {
-    const updatedX = Math.max(lastX, Math.min(sideSpace, selectedX + delta[0]))
+    const deltaMul = 3 * delta[0]
+    const updatedX = Math.max(lastX, Math.min(sideSpace, selectedX + deltaMul))
 
     if (down) {
       setX({
@@ -160,13 +161,13 @@ function Carousel({ items, itemWidth, itemHeight, itemSpacing }) {
         {items.map((item, i) => (
           <AnimatedDiv
             key={i}
-            style={{
-              opacity: drag.interpolate(drag =>
-                drag || (i >= selected && i < selected + visibleItems)
-                  ? 1
-                  : 0.25
-              ),
-            }}
+            // style={{
+            //   opacity: drag.interpolate(drag =>
+            //     drag || (i >= selected && i < selected + visibleItems)
+            //       ? 1
+            //       : 0.25
+            //   ),
+            // }}
             css={`
               flex-grow: 0;
               flex-shrink: 0;


### PR DESCRIPTION
@bpierre 

This is just a hack and by no means a proper fix. It simply disables alpha animations and adds a multiplier to the drag delta to overcome getting stuck without having to deal with velocity yet.