### PR TITLE
Permissions: bring back to feature parity with old version

### DIFF
--- a/src/apps/Permissions/AppPermissions.js
+++ b/src/apps/Permissions/AppPermissions.js
@@ -31,8 +31,7 @@ function AppPermissions({ app, loading, onBack, onManageRole }) {
         heading={
           <span
             css={`
-              ${textStyle('body2')}
-              font-weight: 600;
+              ${textStyle('body1')}
             `}
           >
             Available permissions

--- a/src/apps/Permissions/AppPermissions.js
+++ b/src/apps/Permissions/AppPermissions.js
@@ -6,7 +6,13 @@ import { usePermissionsByRole } from '../../contexts/PermissionsContext'
 import EmptyBlock from './EmptyBlock'
 import PermissionsView from './PermissionsView'
 
-function AppPermissions({ app, loading, onBack, onManageRole }) {
+function AppPermissions({
+  app,
+  loading,
+  onAssignPermission,
+  onBack,
+  onManageRole,
+}) {
   const permissions = usePermissionsByRole()
 
   if (loading) {
@@ -37,6 +43,7 @@ function AppPermissions({ app, loading, onBack, onManageRole }) {
             Available permissions
           </span>
         }
+        onAssignPermission={onAssignPermission}
         onManageRole={onManageRole}
         permissions={appPermissions}
         showApps={false}
@@ -48,6 +55,7 @@ function AppPermissions({ app, loading, onBack, onManageRole }) {
 AppPermissions.propTypes = {
   app: AppType, // may not be available if still loading
   loading: PropTypes.bool.isRequired,
+  onAssignPermission: PropTypes.func.isRequired,
   onManageRole: PropTypes.func.isRequired,
   onBack: PropTypes.func.isRequired,
 }

--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -164,7 +164,7 @@ class AssignPermissionPanel extends React.PureComponent {
           <EntitySelector
             includeAnyEntity
             apps={this.getNamedApps()}
-            label="Grant permission to"
+            label="Assign to entity"
             labelCustomAddress="Grant permission to"
             selectedIndex={assignEntityIndex}
             onChange={this.handleEntityChange}
@@ -172,7 +172,7 @@ class AssignPermissionPanel extends React.PureComponent {
           />
 
           {selectedApp && (
-            <Field label="To perform action">
+            <Field label="Action">
               <DropDown
                 placeholder="Select an action"
                 items={rolesItems}

--- a/src/apps/Permissions/Home/AllPermissions.js
+++ b/src/apps/Permissions/Home/AllPermissions.js
@@ -16,7 +16,12 @@ import PermissionsView from '../PermissionsView'
 
 const ENTITY_TYPES = ['All entities', 'Accounts', 'Apps']
 
-function AllPermissions({ loading, permissions, onManageRole }) {
+function AllPermissions({
+  loading,
+  permissions,
+  onAssignPermission,
+  onManageRole,
+}) {
   const [selectedEntityType, setSelectedEntityType] = useState(-1)
   const [searchTerms, setSearchTerms] = useState('')
   const { layoutName } = useLayout()
@@ -69,6 +74,7 @@ function AllPermissions({ loading, permissions, onManageRole }) {
   return (
     <PermissionsView
       permissions={filteredPermissions}
+      onAssignPermission={onAssignPermission}
       onManageRole={onManageRole}
       heading={
         layoutName === 'large' && (
@@ -90,6 +96,7 @@ function AllPermissions({ loading, permissions, onManageRole }) {
 
 AllPermissions.propTypes = {
   loading: PropTypes.bool.isRequired,
+  onAssignPermission: PropTypes.func.isRequired,
   onManageRole: PropTypes.func.isRequired,
   permissions: PropTypes.array.isRequired,
 }

--- a/src/apps/Permissions/Home/AllPermissions.js
+++ b/src/apps/Permissions/Home/AllPermissions.js
@@ -147,8 +147,7 @@ function Heading({
         <div
           css={`
             white-space: nowrap;
-            ${textStyle('body2')}
-            font-weight: 600;
+            ${textStyle('body1')}
           `}
         >
           All assigned permissions
@@ -161,8 +160,8 @@ function Heading({
             `}
           >
             <DropDown
-              header="Type"
-              placeholder="Type"
+              header="Entity"
+              placeholder="Entity"
               items={ENTITY_TYPES}
               selected={selectedEntityType}
               onChange={handleEntityDropDownChange}

--- a/src/apps/Permissions/Home/Home.js
+++ b/src/apps/Permissions/Home/Home.js
@@ -9,6 +9,7 @@ import AllPermissions from './AllPermissions'
 function Home({
   apps,
   appsLoading,
+  onAssignPermission,
   onChangeTab,
   onManageRole,
   onOpenApp,
@@ -37,6 +38,7 @@ function Home({
       <AllPermissions
         permissions={permissionsFiltered}
         loading={appsLoading || permissionsLoading}
+        onAssignPermission={onAssignPermission}
         onManageRole={onManageRole}
       />
     </React.Fragment>
@@ -47,6 +49,7 @@ Home.propTypes = {
   apps: PropTypes.arrayOf(AppType).isRequired,
   appsLoading: PropTypes.bool.isRequired,
   permissionsLoading: PropTypes.bool.isRequired,
+  onAssignPermission: PropTypes.func.isRequired,
   onManageRole: PropTypes.func.isRequired,
   onOpenApp: PropTypes.func.isRequired,
   onChangeTab: PropTypes.func.isRequired,

--- a/src/apps/Permissions/Home/Home.js
+++ b/src/apps/Permissions/Home/Home.js
@@ -28,6 +28,7 @@ function Home({
   const permissionsFiltered = permissions.filter(
     permission =>
       permission.app &&
+      (permission.entities.length > 0 || permission.manager) &&
       Boolean(permission.app.isAragonOsInternalApp) === internalAppsOnly
   )
 

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -25,7 +25,7 @@ const SET_PERMISSION_MANAGER = Symbol('SET_PERMISSION_MANAGER')
 const REMOVE_PERMISSION_MANAGER = Symbol('REMOVE_PERMISSION_MANAGER')
 
 const UPDATE_ACTIONS = new Map([
-  [NO_UPDATE_ACTION, { label: 'Select an action', message: null }],
+  [NO_UPDATE_ACTION, { label: 'Select an update', message: null }],
   [
     SET_PERMISSION_MANAGER,
     {
@@ -292,7 +292,7 @@ class ManageRolePanel extends React.PureComponent {
             )}
           </Field>
 
-          <Field label="Permission">
+          <Field label="Action">
             {(role && role.name) || 'Unnamed permission'}
           </Field>
 
@@ -303,7 +303,7 @@ class ManageRolePanel extends React.PureComponent {
           )}
 
           {isUpdateAction && (
-            <Field label="Action">
+            <Field label="Update">
               <DropDown
                 items={updateActionsItems}
                 selected={updateActionIndex}

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -286,16 +286,18 @@ class ManageRolePanel extends React.PureComponent {
             margin-top: ${3 * GU}px;
           `}
         >
-          <Field label="App">
+          <Field label="On app">
             {app && (
               <AppInstanceLabel app={app} proxyAddress={app.proxyAddress} />
             )}
           </Field>
 
-          <Field label="Action description">{role && role.name}</Field>
+          <Field label="Permission">
+            {(role && role.name) || 'Unnamed permission'}
+          </Field>
 
           {(action === VIEW_PERMISSION || isUpdateAction) && (
-            <Field label="Manager">
+            <Field label="Managed by">
               <FlexRow>{this.renderManager()}</FlexRow>
             </Field>
           )}

--- a/src/apps/Permissions/Permissions.js
+++ b/src/apps/Permissions/Permissions.js
@@ -192,6 +192,7 @@ function Permissions({
         <Home
           apps={apps}
           appsLoading={appsLoading}
+          onAssignPermission={createPermission}
           onChangeTab={setHomeTab}
           onManageRole={manageRole}
           onOpenApp={openApp}
@@ -205,6 +206,7 @@ function Permissions({
         <AppPermissions
           app={location.app}
           loading={appsLoading}
+          onAssignPermission={createPermission}
           onBack={openHome}
           onManageRole={manageRole}
         />

--- a/src/apps/Permissions/PermissionsIdentityBadge.js
+++ b/src/apps/Permissions/PermissionsIdentityBadge.js
@@ -1,5 +1,9 @@
 import React from 'react'
-import { isAnyEntity, isBurnEntity } from '../../permissions'
+import {
+  isAnyEntity,
+  isBurnEntity,
+  isUnassignedEntity,
+} from '../../permissions'
 import { EthereumAddressType } from '../../prop-types'
 import LocalIdentityBadge from '../../components/IdentityBadge/LocalIdentityBadge'
 
@@ -8,6 +12,8 @@ function PermissionsIdentityBadge({ entity, ...props }) {
     ? 'Any account'
     : isBurnEntity(entity)
     ? 'Discarded'
+    : isUnassignedEntity(entity)
+    ? 'Not assigned'
     : entity
   return <LocalIdentityBadge entity={entityLabel} {...props} />
 }

--- a/src/apps/Permissions/PermissionsView.js
+++ b/src/apps/Permissions/PermissionsView.js
@@ -16,7 +16,11 @@ import {
 } from '@aragon/ui'
 import { usePermissions } from '../../contexts/PermissionsContext'
 import LocalIdentityBadge from '../../components/IdentityBadge/LocalIdentityBadge'
-import { isBurnEntity } from '../../permissions'
+import {
+  getUnassignedEntity,
+  isBurnEntity,
+  isUnassignedEntity,
+} from '../../permissions'
 import PermissionsIdentityBadge from './PermissionsIdentityBadge'
 
 const PermissionsView = React.memo(function PermissionsView({
@@ -138,12 +142,21 @@ function EntryActions({ entry, onAssignPermission, onManageRole }) {
   if (isBurnEntity(manager)) {
     actions.push([handleManageRole, IconView, 'View permission'])
   } else {
-    actions.push(
-      ...[
-        [handleManageRole, IconEdit, 'Manage role'],
-        [onAssignPermission, IconCirclePlus, 'Assign permission'],
-      ]
-    )
+    if (isUnassignedEntity(manager)) {
+      actions.push([
+        handleManageRole,
+        IconEdit,
+        entities.length > 0 ? 'Re-initialize permission' : 'Create permission',
+      ])
+    } else {
+      actions.push(
+        ...[
+          [handleManageRole, IconEdit, 'Manage role'],
+          [onAssignPermission, IconCirclePlus, 'Assign permission'],
+        ]
+      )
+    }
+
     if (entities.length === 1 && entityAddress) {
       actions.push([
         handleRevokePermission,
@@ -232,7 +245,11 @@ function EntryEntities({ entities }) {
         ${textStyle('body2')}
       `}
     >
-      {entities.length === 0 ? 'Not assigned' : `${entities.length} entities`}
+      {entities.length === 0 ? (
+        <PermissionsIdentityBadge entity={getUnassignedEntity()} />
+      ) : (
+        `${entities.length} entities`
+      )}
     </span>
   )
 }

--- a/src/contexts/PermissionsContext.js
+++ b/src/contexts/PermissionsContext.js
@@ -165,7 +165,7 @@ function usePermissionsByRole() {
 
   return useMemo(
     () =>
-      permissionsByRole(permissions).map(
+      permissionsByRole(apps, permissions).map(
         ({ appAddress, entities, roleBytes, ...permission }) => {
           const app = apps.find(app =>
             addressesEqual(app.proxyAddress, appAddress)


### PR DESCRIPTION
Also adds a few stylistic changes as noted by @dizzypaty.

Features:

- Context menu actions
- Show unassigned roles in app view

All "entities" are now being shown as IdentityBadges:

<img width="1129" alt="Screen Shot 2019-09-10 at 1 27 58 PM" src="https://user-images.githubusercontent.com/4166642/64615120-d237ab00-d3d1-11e9-963b-c3df4511b1eb.png">