### PR TITLE
Onboarding: remove preferences having empty tabs in small viewports

### DIFF
--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {
+  Bar,
   ButtonIcon,
   GU,
   Header,
@@ -10,6 +11,7 @@ import {
   Tabs,
   breakpoint,
   springs,
+  textStyle,
   useTheme,
   useToast,
   useViewport,
@@ -49,6 +51,7 @@ function GlobalPreferences({
   subsection,
   wrapper,
 }) {
+  const theme = useTheme()
   const toast = useToast()
   const { dao } = locator
 
@@ -72,6 +75,9 @@ function GlobalPreferences({
 
   useEsc(onClose)
 
+  const tabItems = VALUES.filter(
+    (_, index) => !!wrapper || index === NETWORK_INDEX
+  )
   return (
     <Layout>
       <Close
@@ -98,13 +104,30 @@ function GlobalPreferences({
         />
       ) : (
         <React.Fragment>
-          <Tabs
-            items={VALUES.filter(
-              (_, index) => !!wrapper || index === NETWORK_INDEX
-            )}
-            onChange={onNavigation}
-            selected={sectionIndex}
-          />
+          {tabItems.length > 1 ? (
+            <Tabs
+              items={tabItems}
+              onChange={onNavigation}
+              selected={sectionIndex}
+            />
+          ) : (
+            <Bar>
+              <div
+                css={`
+                  display: flex;
+                  height: 100%;
+                  align-items: center;
+                  padding-left: ${compact ? 2 * GU : 3 * GU}px;
+                  color: ${compact
+                    ? theme.surfaceContent
+                    : theme.surfaceContentSecondary};
+                  ${textStyle('body2')}
+                `}
+              >
+                {tabItems[0]}
+              </div>
+            </Bar>
+          )}
           <main>
             {sectionIndex === CUSTOM_LABELS_INDEX && (
               <CustomLabels dao={dao} wrapper={wrapper} locator={locator} />


### PR DESCRIPTION
Replaces the Preferences' tab bar with a visually similar version when there's only one item.

This is just for now; we should eventually handle this better in aragonUI: https://github.com/aragon/aragon-ui/issues/595.

Currently:

<img width="500" alt="Screen Shot 2019-09-10 at 1 48 13 PM" src="https://user-images.githubusercontent.com/4166642/64615439-7faabe80-d3d2-11e9-8299-fbf95cdf6923.png">

With the change:

<img width="500" alt="Screen Shot 2019-09-10 at 1 46 29 PM" src="https://user-images.githubusercontent.com/4166642/64615543-ab2da900-d3d2-11e9-94d1-6d3f30e4e956.png">
