### PR TITLE
Send the full abi for the eventsource

### DIFF
--- a/src/components/GlobalPreferences/Notifications/SubscriptionsForm.js
+++ b/src/components/GlobalPreferences/Notifications/SubscriptionsForm.js
@@ -98,18 +98,15 @@ export default function SubscriptionsForm({
       setIsSubmitting(true)
       const { abi, appName, proxyAddress } = selectedApp
       const eventName = eventNames[selectedEventIdx]
-
-      const abiSubset = [
-        abi.find(({ name, type }) => type === 'event' && name === eventName),
-      ]
+      const abiEventSubset = abi.filter(({ name, type }) => type === 'event')
 
       try {
         const payload = {
-          abi: abiSubset,
+          abi: abiEventSubset,
           appName,
           appContractAddress: proxyAddress,
           ensName: dao,
-          eventName: eventNames[selectedEventIdx],
+          eventName,
           network: getEthNetworkType(),
           token,
         }


### PR DESCRIPTION
## What

- Submit the ABI with all events when creating a subscription. 

## Why
- The ABI is used to create eventsources which are shared across subscriptions for polling events. Because subscriptions can be to unique events, we need to have the ABI with all the events. 