### PR TITLE
Onboarding: allow token stakes to be defined

### DIFF
--- a/src/templates/company/index.js
+++ b/src/templates/company/index.js
@@ -36,7 +36,7 @@ export default {
   screens: [
     [data => completeDomain(data.domain) || 'Claim domain', ClaimDomain],
     ['Configure template', Voting],
-    ['Configure template', props => <Tokens {...props} accountStake={1} />],
+    ['Configure template', Tokens],
     [
       'Review information',
       ({ back, data, next }) => (


### PR DESCRIPTION
Oops 😄

The company template's stakes should not be locked.