### PR TITLE
Notifications: use sanitized network type for service

### DIFF
--- a/src/components/GlobalPreferences/Notifications/NotificationsLogin.js
+++ b/src/components/GlobalPreferences/Notifications/NotificationsLogin.js
@@ -13,7 +13,6 @@ import {
   useTheme,
 } from '@aragon/ui'
 import { login } from './notification-service-api'
-import { network } from '../../../environment'
 import { validateEmail } from '../../../utils'
 import notificationPng from './notifications.png'
 
@@ -25,8 +24,6 @@ export default function NotificationsLogin({
   const [inputEmail, setInputEmail] = useState('')
   const [emailInvalid, setEmailInvalid] = useState(null)
   const [apiError, setApiError] = useState(null)
-  // The notifications API expects mainnet or rinkeby. This deviates from web3's getNetworkType which returns main
-  const ethNetwork = network.type === 'main' ? 'mainnet' : 'rinkeby'
 
   const handleEmailBlur = useCallback(e => {
     const email = e.target.value
@@ -52,14 +49,14 @@ export default function NotificationsLogin({
       }
 
       try {
-        await login({ email: inputEmail, dao, network: ethNetwork })
+        await login({ email: inputEmail, dao })
         onEmailChange(inputEmail)
       } catch (e) {
         setApiError(e.message)
         console.error('Failed to login', e)
       }
     },
-    [dao, ethNetwork, inputEmail, onEmailChange]
+    [dao, inputEmail, onEmailChange]
   )
 
   const theme = useTheme()

--- a/src/components/GlobalPreferences/Notifications/SubscriptionsForm.js
+++ b/src/components/GlobalPreferences/Notifications/SubscriptionsForm.js
@@ -14,7 +14,6 @@ import { AppType } from '../../../prop-types'
 import PropTypes from 'prop-types'
 import memoize from 'lodash.memoize'
 import styled from 'styled-components'
-import { getEthNetworkType } from '../../../local-settings'
 import { createSubscription } from './notification-service-api'
 import notificationImage from './notification.png'
 import LocalLabelAppBadge from '../../LocalLabelAppBadge/LocalLabelAppBadge'
@@ -108,7 +107,6 @@ export default function SubscriptionsForm({
           appContractAddress: proxyAddress,
           ensName: dao,
           eventName,
-          network: getEthNetworkType(),
           token,
         }
         await createSubscription(payload)

--- a/src/components/GlobalPreferences/Notifications/notification-service-api.js
+++ b/src/components/GlobalPreferences/Notifications/notification-service-api.js
@@ -10,8 +10,8 @@ import {
 import { network } from '../../../environment'
 
 // The notifications API expects mainnet or rinkeby. This deviates from web3's getNetworkType which returns main
-const sanitizeNetworkType = network =>
-  network.type === 'main' ? 'mainnet' : 'rinkeby'
+const sanitizeNetworkType = networkType =>
+  networkType === 'main' ? 'mainnet' : 'rinkeby'
 
 const isAuthTokenExpired = response =>
   response.statusCode === 401 && response.message === API_MESSAGE_EXPIRED_TOKEN


### PR DESCRIPTION
cc @2color moved the network sanitization to be embedded in the API calls themselves.