### PR TITLE
chore: deploy nightly builds back on nightly.aragon.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_deploy:
   - npm install now --no-save
 deploy:
   - provider: script
-    script: ./scripts/travis_wait -i 60 -l 2400 "now -A now-preview.json --target production --token $NOW_TOKEN"
+    script: ./scripts/travis_wait -i 60 -l 2400 "now -A now-mainnet.json --prod --token $NOW_TOKEN"
     skip_cleanup: true
     on:
       branch: master

--- a/now-preview.json
+++ b/now-preview.json
@@ -1,9 +1,0 @@
-{
-  "version": 2,
-  "public": true,
-  "scope": "aragon",
-  "alias": "preview.aragon.org",
-  "builds": [
-    { "src": "package.json", "use": "@now/static-build", "config": { "distDir": "build/rinkeby" } }
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "build:ropsten": "cross-env REACT_APP_ETH_NETWORK_TYPE=ropsten npm run build",
     "lint": "eslint ./src",
     "test": "npm run lint",
-    "now-build": "cross-env REACT_APP_ASSET_BRIDGE=preview npm run build -- build/rinkeby",
+    "now-build": "npm run build:mainnet -- build && npm run build -- build/rinkeby",
     "publish:major": "node scripts/publish major --only-content --files build/",
     "publish:minor": "node scripts/publish minor --only-content --files build/",
     "publish:patch": "node scripts/publish patch --only-content --files build/",

--- a/src/environment.js
+++ b/src/environment.js
@@ -88,13 +88,6 @@ if (assetBridge === 'local') {
     [appIds['Survey']]: 'http://localhost:3004/',
     [appIds['Voting']]: 'http://localhost:3001/',
   })
-} else if (assetBridge === 'preview') {
-  Object.assign(appLocator, {
-    [appIds['Finance']]: 'https://nightly-finance.aragon.org/',
-    [appIds['TokenManager']]: 'https://nightly-token-manager.aragon.org/',
-    [appIds['Survey']]: 'https://nightly-survey.aragon.org/',
-    [appIds['Voting']]: 'https://nightly-voting.aragon.org/',
-  })
 } else if (assetBridge === 'ipfs') {
   // We don't need to provide anything here as by default, the apps will be loaded from IPFS
 } else if (assetBridge) {


### PR DESCRIPTION
Reverts the change to publish nightly builds onto `preview.aragon.org` from https://github.com/aragon/aragon/pull/898.