### PR TITLE
Templates kit cleanup

### DIFF
--- a/src/templates/company/index.js
+++ b/src/templates/company/index.js
@@ -2,7 +2,13 @@
 import React from 'react'
 import BN from 'bn.js'
 import { network } from '../../environment'
-import { ClaimDomain, KnownAppBadge, Review, Tokens, Voting } from '../kit'
+import {
+  ClaimDomainScreen,
+  KnownAppBadge,
+  ReviewScreen,
+  TokensScreen,
+  VotingScreen,
+} from '../kit'
 
 import header from './header.svg'
 import icon from './icon.svg'
@@ -20,8 +26,6 @@ export default {
     Use transferrable tokens to represent ownership stake in your
     organization. Decisions are made based on stake-weighted voting.
   `,
-  // longdesc: '',
-  // caseStudyUrl: 'https://aragon.org/case-study/company',
   userGuide:
     'https://help.aragon.org/article/30-create-a-new-company-organization',
   sourceCodeUrl:
@@ -34,42 +38,46 @@ export default {
   ],
   optionalModules: [{ appName: 'agent.aragonpm.eth', label: 'Agent' }],
   screens: [
-    [data => completeDomain(data.domain) || 'Claim domain', ClaimDomain],
-    ['Configure template', Voting],
-    ['Configure template', Tokens],
+    [
+      data => completeDomain(data.domain) || 'Claim domain',
+      props => <ClaimDomainScreen screenProps={props} />,
+    ],
+    ['Configure template', props => <VotingScreen screenProps={props} />],
+    ['Configure template', props => <TokensScreen screenProps={props} />],
     [
       'Review information',
-      ({ back, data, next }) => (
-        <Review
-          back={back}
-          data={data}
-          next={next}
-          items={[
-            {
-              label: 'General info',
-              fields: [
-                ['Organization template', 'Company'],
-                ['Name', completeDomain(data.domain)],
-              ],
-            },
-            {
-              label: (
-                <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
-              ),
-              fields: Voting.formatReviewFields(data.voting),
-            },
-            {
-              label: (
-                <KnownAppBadge
-                  appName="token-manager.aragonpm.eth"
-                  label="Tokens"
-                />
-              ),
-              fields: Tokens.formatReviewFields(data.tokens),
-            },
-          ]}
-        />
-      ),
+      props => {
+        const { domain, voting, tokens } = props.data
+        return (
+          <ReviewScreen
+            screenProps={props}
+            items={[
+              {
+                label: 'General info',
+                fields: [
+                  ['Organization template', 'Company'],
+                  ['Name', completeDomain(domain)],
+                ],
+              },
+              {
+                label: (
+                  <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
+                ),
+                fields: VotingScreen.formatReviewFields(voting),
+              },
+              {
+                label: (
+                  <KnownAppBadge
+                    appName="token-manager.aragonpm.eth"
+                    label="Tokens"
+                  />
+                ),
+                fields: TokensScreen.formatReviewFields(tokens),
+              },
+            ]}
+          />
+        )
+      },
     ],
   ],
   prepareTransactions(createTx, data) {

--- a/src/templates/fundraising/index.js
+++ b/src/templates/fundraising/index.js
@@ -1,13 +1,5 @@
-/* eslint-disable react/prop-types */
-import React from 'react'
-import { ClaimDomain, Review, Voting, Tokens } from '../kit'
-
 import header from './header.svg'
 import icon from './icon.svg'
-
-function completeDomain(domain) {
-  return domain ? `${domain}.aragonid.eth` : ''
-}
 
 export default {
   disabled: true,
@@ -19,92 +11,9 @@ export default {
     Initialize a transparent and accountable crowdfunding campaign for your
     organization.
   `,
-  // longdesc: ``,
-  // caseStudyUrl: 'https://aragon.org/case-study/fundraising',
-  // TODO: Insert proper user guide URL
   userGuide: 'https://help.aragon.org/',
-  // sourceCodeUrl: 'https://github.com/aragon/dao-templates/tree/master/templates/',
   registry: 'aragonpm.eth',
   modules: [],
-  screens: [
-    [data => completeDomain(data.domain) || 'Claim domain', ClaimDomain],
-    ['Configure template', Voting],
-    ['Configure template', Tokens],
-    [
-      'Review information',
-      ({ back, data, next }) => (
-        <Review
-          back={back}
-          data={data}
-          next={next}
-          items={[
-            {
-              label: 'General info',
-              fields: [
-                ['Organization template', 'Fundraising'],
-                ['Name', completeDomain(data.domain)],
-              ],
-            },
-            {
-              label: 'Voting app',
-              fields: Voting.formatReviewFields(data.voting),
-            },
-            {
-              label: 'Tokens app',
-              fields: Tokens.formatReviewFields(data.tokens),
-            },
-          ]}
-        />
-      ),
-    ],
-  ],
-  prepareTransactions(createTx, data) {
-    const hasPayroll = false
-
-    const {
-      tokenName,
-      tokenSymbol,
-      subdomain,
-      holders,
-      stakes,
-      votingSettings,
-      financePeriod,
-    } = data
-
-    if (!hasPayroll) {
-      return [
-        {
-          name: 'Create organization',
-          transaction: createTx('newTokenAndInstance', [
-            tokenName,
-            tokenSymbol,
-            subdomain,
-            holders,
-            stakes,
-            votingSettings,
-            financePeriod,
-            true,
-          ]),
-        },
-      ]
-    }
-
-    return [
-      {
-        name: 'Create token',
-        transaction: createTx('newToken', [tokenName, tokenSymbol]),
-      },
-      {
-        name: 'Create organization',
-        transaction: createTx('newInstance', [
-          subdomain,
-          holders,
-          stakes,
-          votingSettings,
-          financePeriod,
-          true,
-        ]),
-      },
-    ]
-  },
+  screens: [],
+  prepareTransactions: () => [],
 }

--- a/src/templates/kit/Navigation.js
+++ b/src/templates/kit/Navigation.js
@@ -1,7 +1,7 @@
 import React, { useRef, useImperativeHandle } from 'react'
 import { Button, IconArrowLeft, GU, useTheme } from '@aragon/ui'
 
-const PrevNextFooter = React.forwardRef(function PrevNextFooter(
+const Navigation = React.forwardRef(function Navigation(
   {
     onNext,
     onBack,
@@ -63,4 +63,4 @@ const PrevNextFooter = React.forwardRef(function PrevNextFooter(
   )
 })
 
-export default PrevNextFooter
+export default Navigation

--- a/src/templates/kit/index.js
+++ b/src/templates/kit/index.js
@@ -1,14 +1,14 @@
-export { default as ClaimDomain } from './ClaimDomain'
+export { default as ClaimDomainScreen } from './screens/ClaimDomainScreen'
 export {
   default as DomainField,
 } from '../../components/DomainField/DomainField'
+export { default as Header } from '../../onboarding2/Header/Header'
 export {
   default as IdentityBadge,
 } from '../../components/IdentityBadge/LocalIdentityBadge'
-export { default as Header } from '../../onboarding2/Header/Header'
 export { default as KnownAppBadge } from './KnownAppBadge'
+export { default as Navigation } from './Navigation'
 export { default as PercentageField } from './PercentageField'
-export { default as PrevNextFooter } from './PrevNextFooter'
-export { default as Review } from './Review'
-export { default as Tokens } from './Tokens'
-export { default as Voting } from './Voting'
+export { default as ReviewScreen } from './screens/ReviewScreen'
+export { default as TokensScreen } from './screens/TokensScreen'
+export { default as VotingScreen } from './screens/VotingScreen'

--- a/src/templates/kit/screens/ClaimDomainScreen.js
+++ b/src/templates/kit/screens/ClaimDomainScreen.js
@@ -1,17 +1,26 @@
 import React, { useCallback, useState } from 'react'
 import { Info, GU, Link } from '@aragon/ui'
-import { useCheckDomain, DOMAIN_CHECK, DOMAIN_ERROR } from '../../check-domain'
-import { DomainField, Header, PrevNextFooter } from '.'
+import {
+  useCheckDomain,
+  DOMAIN_CHECK,
+  DOMAIN_ERROR,
+} from '../../../check-domain'
+import { DomainField, Header, Navigation } from '..'
 
 function ClaimDomain({
-  back,
-  data,
-  next,
-  screenIndex,
-  screens,
-  screenTitle = 'Claim a name',
+  dataKey = null,
+  screenProps: {
+    back,
+    data,
+    next,
+    screenIndex,
+    screens,
+    screenTitle = 'Claim a name',
+  },
 }) {
-  const [domain, setDomain] = useState(data.domain || '')
+  const screenData = (dataKey ? data[dataKey] : data) || {}
+
+  const [domain, setDomain] = useState(screenData.domain || '')
   const [displayError, setDisplayError] = useState(false)
   const domainCheckStatus = useCheckDomain(domain, true)
 
@@ -25,7 +34,7 @@ function ClaimDomain({
       event.preventDefault()
       setDisplayError(domainCheckStatus === DOMAIN_ERROR)
       if (domainCheckStatus === DOMAIN_CHECK) {
-        next({ ...data, domain })
+        next(dataKey ? { ...data, [dataKey]: domain } : { ...data, domain })
       }
     },
     [domain, next, data, domainCheckStatus]
@@ -74,7 +83,7 @@ function ClaimDomain({
         launch your organization.
       </Info>
 
-      <PrevNextFooter
+      <Navigation
         backEnabled
         nextEnabled={Boolean(domain.trim())}
         nextLabel={`Next: ${screens[screenIndex + 1][0]}`}

--- a/src/templates/kit/screens/ReviewScreen.js
+++ b/src/templates/kit/screens/ReviewScreen.js
@@ -45,13 +45,7 @@ function Review({
   })
 
   return (
-    <div
-      ref={containerRef}
-      tabIndex="0"
-      css={`
-        outline: 0;
-      `}
-    >
+    <div ref={containerRef} tabIndex="0" css="outline: 0">
       <Header title={screenTitle} subtitle={screenSubtitle} />
 
       <Accordion

--- a/src/templates/kit/screens/ReviewScreen.js
+++ b/src/templates/kit/screens/ReviewScreen.js
@@ -1,13 +1,18 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { Accordion, GU, Info, textStyle, useTheme } from '@aragon/ui'
-import Header from '../../onboarding2/Header/Header'
-import PrevNextFooter from './PrevNextFooter'
+import {
+  Accordion,
+  GU,
+  Info,
+  KEY_ENTER,
+  textStyle,
+  useKeyDown,
+  useTheme,
+} from '@aragon/ui'
+import { Header, Navigation } from '..'
 
 function Review({
-  back,
-  data,
-  next,
+  screenProps: { back, data, next },
   items,
   screenTitle = 'Review information',
   screenSubtitle = 'Have one last look at your settings below',
@@ -18,8 +23,35 @@ function Review({
     next(data)
   }, [data, next])
 
+  const containerRef = useRef()
+  const prevNextRef = useRef()
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.focus()
+    }
+  }, [])
+
+  useKeyDown(KEY_ENTER, () => {
+    // Don’t focus too early or the button will get clicked
+    setTimeout(() => {
+      if (
+        document.activeElement === containerRef.current &&
+        prevNextRef.current
+      ) {
+        prevNextRef.current.focusNext()
+      }
+    }, 0)
+  })
+
   return (
-    <React.Fragment>
+    <div
+      ref={containerRef}
+      tabIndex="0"
+      css={`
+        outline: 0;
+      `}
+    >
       <Header title={screenTitle} subtitle={screenSubtitle} />
 
       <Accordion
@@ -71,20 +103,19 @@ function Review({
         organization.
       </Info>
 
-      <PrevNextFooter
+      <Navigation
+        ref={prevNextRef}
         backEnabled
         nextEnabled
         nextLabel="Launch your organization"
         onBack={back}
         onNext={handleNext}
       />
-    </React.Fragment>
+    </div>
   )
 }
 
 Review.propTypes = {
-  back: PropTypes.func.isRequired,
-  next: PropTypes.func.isRequired,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.node.isRequired,

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -13,7 +13,7 @@ import {
   isAddress,
   useTheme,
 } from '@aragon/ui'
-import { Header, PrevNextFooter, IdentityBadge } from '.'
+import { Header, Navigation, IdentityBadge } from '..'
 
 function useFieldsLayout() {
   // In its own hook to be adapted on smaller views
@@ -52,14 +52,12 @@ function validationError(tokenName, tokenSymbol, members) {
 }
 
 function Tokens({
-  back,
-  data,
-  fields,
-  next,
-  screenIndex,
-  screens,
   accountStake = -1,
+  dataKey = 'tokens',
+  screenProps: { back, data, next, screenIndex, screens },
 }) {
+  const screenData = (dataKey ? data[dataKey] : data) || {}
+
   const theme = useTheme()
   const fieldsLayout = useFieldsLayout()
 
@@ -67,13 +65,12 @@ function Tokens({
 
   const fixedStake = accountStake !== -1
 
-  const { tokens: tokensData = {} } = data
-  const [tokenName, setTokenName] = useState(tokensData.tokenName || '')
-  const [tokenSymbol, setTokenSymbol] = useState(tokensData.tokenSymbol || '')
+  const [tokenName, setTokenName] = useState(screenData.tokenName || '')
+  const [tokenSymbol, setTokenSymbol] = useState(screenData.tokenSymbol || '')
 
   const [members, setMembers] = useState(
-    tokensData.members && tokensData.members.length > 0
-      ? tokensData.members
+    screenData.members && screenData.members.length > 0
+      ? screenData.members
       : [['', accountStake]]
   )
 
@@ -121,16 +118,14 @@ function Tokens({
       const error = validationError(tokenName, tokenSymbol, members)
       setFormError(error)
       if (!error) {
-        next({
-          ...data,
-          tokens: {
-            tokenName,
-            tokenSymbol,
-            members: members.filter(
-              ([account, stake]) => isAddress(account) && stake > 0
-            ),
-          },
-        })
+        const screenData = {
+          tokenName,
+          tokenSymbol,
+          members: members.filter(
+            ([account, stake]) => isAddress(account) && stake > 0
+          ),
+        }
+        next(dataKey ? { ...data, [dataKey]: screenData } : screenData)
       }
     },
     [data, next, tokenName, tokenSymbol, members]
@@ -279,7 +274,7 @@ function Tokens({
         distribution of this token.
       </Info>
 
-      <PrevNextFooter
+      <Navigation
         backEnabled
         nextEnabled={!disableNext}
         nextLabel={`Next: ${screens[screenIndex + 1][0]}`}
@@ -395,13 +390,13 @@ function MemberField({
   )
 }
 
-function formatReviewFields(tokensData) {
+function formatReviewFields(screenData) {
   return [
     [
       'Token name & symbol',
-      `${tokensData.tokenName} (${tokensData.tokenSymbol})`,
+      `${screenData.tokenName} (${screenData.tokenSymbol})`,
     ],
-    ...tokensData.members.map(([account], i) => [
+    ...screenData.members.map(([account], i) => [
       `Tokenholder #${i + 1}`,
       <IdentityBadge entity={account} />,
     ]),

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -15,7 +15,7 @@ import {
   useTheme,
   useViewport,
 } from '@aragon/ui'
-import { Header, PercentageField, PrevNextFooter } from '.'
+import { Header, PercentageField, Navigation } from '..'
 
 const MINUTE_IN_SECONDS = 60
 const HOUR_IN_SECONDS = MINUTE_IN_SECONDS * 60
@@ -53,17 +53,20 @@ function reduceFields(fields, [field, value]) {
   return fields
 }
 
-function Voting({ back, data, fields, next, screenIndex, screens }) {
-  const { voting: votingData = {} } = data
+function Voting({
+  dataKey = 'voting',
+  screenProps: { back, data, next, screenIndex, screens },
+}) {
+  const screenData = (dataKey ? data[dataKey] : data) || {}
 
   const [formError, setFormError] = useState()
 
   const [{ support, quorum, duration }, updateField] = useReducer(
     reduceFields,
     {
-      support: votingData.support || DEFAULT_SUPPORT,
-      quorum: votingData.quorum || DEFAULT_QUORUM,
-      duration: votingData.duration || DEFAULT_DURATION,
+      support: screenData.support || DEFAULT_SUPPORT,
+      quorum: screenData.quorum || DEFAULT_QUORUM,
+      duration: screenData.duration || DEFAULT_DURATION,
     }
   )
 
@@ -117,17 +120,15 @@ function Voting({ back, data, fields, next, screenIndex, screens }) {
       }
 
       if (!error) {
-        next({
-          ...data,
-          voting: {
-            support: Math.floor(support),
-            quorum: Math.floor(quorum),
-            duration,
-          },
-        })
+        const screenData = {
+          support: Math.floor(support),
+          quorum: Math.floor(quorum),
+          duration,
+        }
+        next(dataKey ? { ...data, [dataKey]: screenData } : screenData)
       }
     },
-    [data, next, support, quorum, duration, isPercentageFieldFocused]
+    [data, dataKey, duration, isPercentageFieldFocused, next, quorum, support]
   )
 
   return (
@@ -208,7 +209,7 @@ function Voting({ back, data, fields, next, screenIndex, screens }) {
           greater than these thresholds.
         </Info>
 
-        <PrevNextFooter
+        <Navigation
           ref={prevNextRef}
           backEnabled
           nextEnabled
@@ -377,11 +378,11 @@ function formatDuration(duration) {
     )
 }
 
-function formatReviewFields(votingData) {
+function formatReviewFields(screenData) {
   return [
-    ['Support', `${votingData.support}%`],
-    ['Minimum approval %', `${votingData.quorum}%`],
-    ['Vote duration', formatDuration(votingData.duration)],
+    ['Support', `${screenData.support}%`],
+    ['Minimum approval %', `${screenData.quorum}%`],
+    ['Vote duration', formatDuration(screenData.duration)],
   ]
 }
 

--- a/src/templates/membership/index.js
+++ b/src/templates/membership/index.js
@@ -2,7 +2,13 @@
 import React from 'react'
 import BN from 'bn.js'
 import { network } from '../../environment'
-import { ClaimDomain, KnownAppBadge, Review, Tokens, Voting } from '../kit'
+import {
+  ClaimDomainScreen,
+  KnownAppBadge,
+  ReviewScreen,
+  TokensScreen,
+  VotingScreen,
+} from '../kit'
 
 import header from './header.svg'
 import icon from './icon.svg'
@@ -20,8 +26,6 @@ export default {
     Use a non-transferrable token to represent membership. Decisions are
     made based on one-member-one-vote governance.
   `,
-  // longdesc: ``,
-  // caseStudyUrl: 'https://aragon.org/case-study/membership',
   userGuide:
     'https://help.aragon.org/article/34-create-a-new-membership-organization',
   sourceCodeUrl:
@@ -34,42 +38,49 @@ export default {
   ],
   optionalModules: [{ appName: 'agent.aragonpm.eth', label: 'Agent' }],
   screens: [
-    [data => completeDomain(data.domain) || 'Claim domain', ClaimDomain],
-    ['Configure template', Voting],
-    ['Configure template', props => <Tokens {...props} accountStake={1} />],
+    [
+      data => completeDomain(data.domain) || 'Claim domain',
+      props => <ClaimDomainScreen screenProps={props} />,
+    ],
+    ['Configure template', props => <VotingScreen screenProps={props} />],
+    [
+      'Configure template',
+      props => <TokensScreen screenProps={props} accountStake={1} />,
+    ],
     [
       'Review information',
-      ({ back, data, next }) => (
-        <Review
-          back={back}
-          data={data}
-          next={next}
-          items={[
-            {
-              label: 'General info',
-              fields: [
-                ['Organization template', 'Membership'],
-                ['Name', completeDomain(data.domain)],
-              ],
-            },
-            {
-              label: (
-                <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
-              ),
-              fields: Voting.formatReviewFields(data.voting),
-            },
-            {
-              label: (
-                <KnownAppBadge
-                  appName="token-manager.aragonpm.eth"
-                  label="Tokens"
-                />
-              ),
-              fields: Tokens.formatReviewFields(data.tokens),
-            },
-          ]}
-        />
-      ),
+      props => {
+        const { domain, voting, tokens } = props.data
+        return (
+          <ReviewScreen
+            screenProps={props}
+            items={[
+              {
+                label: 'General info',
+                fields: [
+                  ['Organization template', 'Membership'],
+                  ['Name', completeDomain(domain)],
+                ],
+              },
+              {
+                label: (
+                  <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
+                ),
+                fields: VotingScreen.formatReviewFields(voting),
+              },
+              {
+                label: (
+                  <KnownAppBadge
+                    appName="token-manager.aragonpm.eth"
+                    label="Tokens"
+                  />
+                ),
+                fields: TokensScreen.formatReviewFields(tokens),
+              },
+            ]}
+          />
+        )
+      },
     ],
   ],
   prepareTransactions(createTx, data) {

--- a/src/templates/reputation/index.js
+++ b/src/templates/reputation/index.js
@@ -2,7 +2,13 @@
 import React from 'react'
 import BN from 'bn.js'
 import { network } from '../../environment'
-import { ClaimDomain, KnownAppBadge, Review, Tokens, Voting } from '../kit'
+import {
+  ClaimDomainScreen,
+  KnownAppBadge,
+  ReviewScreen,
+  TokensScreen,
+  VotingScreen,
+} from '../kit'
 
 import header from './header.svg'
 import icon from './icon.svg'
@@ -20,8 +26,6 @@ export default {
     Use non-transferrable tokens to represent reputation. Decisions are made
     using reputation-weighted voting.
   `,
-  // longdesc: ``,
-  // caseStudyUrl: 'https://aragon.org/case-study/reputation',
   userGuide:
     'https://help.aragon.org/article/32-create-a-new-reputation-organization',
   sourceCodeUrl:
@@ -34,42 +38,46 @@ export default {
   ],
   optionalModules: [{ appName: 'agent.aragonpm.eth', label: 'Agent' }],
   screens: [
-    [data => completeDomain(data.domain) || 'Claim domain', ClaimDomain],
-    ['Configure template', Voting],
-    ['Configure template', Tokens],
+    [
+      data => completeDomain(data.domain) || 'Claim domain',
+      props => <ClaimDomainScreen screenProps={props} />,
+    ],
+    ['Configure template', props => <VotingScreen screenProps={props} />],
+    ['Configure template', props => <TokensScreen screenProps={props} />],
     [
       'Review information',
-      ({ back, data, next }) => (
-        <Review
-          back={back}
-          data={data}
-          next={next}
-          items={[
-            {
-              label: 'General info',
-              fields: [
-                ['Organization template', 'Reputation'],
-                ['Name', completeDomain(data.domain)],
-              ],
-            },
-            {
-              label: (
-                <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
-              ),
-              fields: Voting.formatReviewFields(data.voting),
-            },
-            {
-              label: (
-                <KnownAppBadge
-                  appName="token-manager.aragonpm.eth"
-                  label="Tokens"
-                />
-              ),
-              fields: Tokens.formatReviewFields(data.tokens),
-            },
-          ]}
-        />
-      ),
+      props => {
+        const { domain, voting, tokens } = props.data
+        return (
+          <ReviewScreen
+            screenProps={props}
+            items={[
+              {
+                label: 'General info',
+                fields: [
+                  ['Organization template', 'Reputation'],
+                  ['Name', completeDomain(domain)],
+                ],
+              },
+              {
+                label: (
+                  <KnownAppBadge appName="voting.aragonpm.eth" label="Voting" />
+                ),
+                fields: VotingScreen.formatReviewFields(voting),
+              },
+              {
+                label: (
+                  <KnownAppBadge
+                    appName="token-manager.aragonpm.eth"
+                    label="Tokens"
+                  />
+                ),
+                fields: TokensScreen.formatReviewFields(tokens),
+              },
+            ]}
+          />
+        )
+      },
     ],
   ],
   prepareTransactions(createTx, data) {


### PR DESCRIPTION
- Remove longDesc and caseStudyUrl template entries (until we need them).
- Move and rename the screen components into screens/.
- Add a prop type for screen-specific props.
- Unify the way screen components accept screen-specific props.
- Rename PrevNextFooter => Navigation.