### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <a href="https://mainnet.aragon.org/#/a1/"><img src=".github/screenshot.png" /></a>
 
-- 📚 Read the [User Guide](https://wiki.aragon.org/tutorials/Aragon_User_Guide/) first, if you have any questions as a user.
+- 📚 Read the [User Guide](https://help.aragon.org/) first, if you have any questions as a user.
 - 💻 You may be interested in [Aragon Desktop](https://github.com/aragon/aragon-desktop/), the most decentralized Aragon experience to date.
 - 🏗 If you'd like to develop an Aragon app, please visit the [Aragon Developer Portal](https://hack.aragon.org).
 - 📝 Please report any issues and feedback in the [Aragon Chat #feedback](https://aragon.chat/channel/feedback) channel.


### PR DESCRIPTION
Update User Guide link. 

Current link points to page that informs the requested site lives now at: https://help.aragon.org/

However that does not seem ideal as it is not describing the same thing (user guide). I could not find one for the current release, so this line should probably be changed to say "Helpdesk" to reflect a larger collection of info is used instead of a tutorial.