### PR TITLE
Custom labels reset selection on import

### DIFF
--- a/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
+++ b/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
@@ -10,11 +10,10 @@ import useFilterIdentities from './useFilterIdentities'
 import useSelectIdentities from './useSelectIdentities'
 import useIdentitiesActions from './useIdentitiesActions'
 import useLocalIdentityModal from './useLocalIdentityModal'
+import useSort from './useSort'
 
 function CustomLabels({ wrapper, dao, locator }) {
-  const { identities, sortIdentities, handleToggleSort } = useLocalIdentities(
-    wrapper
-  )
+  const { identities } = useLocalIdentities(wrapper)
   const {
     filteredIdentities,
     handleSearchTermChange,
@@ -50,6 +49,9 @@ function CustomLabels({ wrapper, dao, locator }) {
     () => handleSearchTermChange({ currentTarget: { value: '' } }),
     [handleSearchTermChange]
   )
+  const { sortedIdentities, sort, handleToggleSort } = useSort(
+    filteredIdentities
+  )
 
   return (
     <React.Fragment>
@@ -68,7 +70,7 @@ function CustomLabels({ wrapper, dao, locator }) {
       ) : (
         <LocalIdentities
           allSelected={allSelected}
-          identities={filteredIdentities}
+          identities={sortedIdentities}
           identitiesSelected={identitiesSelected}
           onClear={handleClearSearchTerm}
           onExport={handleExport}
@@ -82,7 +84,7 @@ function CustomLabels({ wrapper, dao, locator }) {
           searchTerm={searchTerm}
           onShowLocalIdentityModal={handleShowLocalIdentityModal}
           someSelected={someSelected}
-          sortIdentities={sortIdentities}
+          sort={sort}
         />
       )}
     </React.Fragment>

--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -26,7 +26,7 @@ import {
 import EmptyFilteredIdentities from './EmptyFilteredIdentities'
 import Import from './Import'
 import LocalIdentityBadge from '../../IdentityBadge/LocalIdentityBadge'
-import { ASC, DESC } from './useLocalIdentities'
+import { ASC, DESC } from './useSort'
 import { iOS } from '../../../utils'
 
 const LocalIdentities = React.memo(function LocalIdentities({
@@ -45,7 +45,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
   onToggleSort,
   searchTerm,
   someSelected,
-  sortIdentities,
+  sort,
 }) {
   const { layoutName } = useLayout()
   const compact = layoutName === 'small'
@@ -142,7 +142,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
               >
                 Custom label{' '}
               </span>
-              {sortIdentities === ASC ? (
+              {sort === ASC ? (
                 <IconArrowDown size="small" />
               ) : (
                 <IconArrowUp size="small" />
@@ -189,7 +189,7 @@ LocalIdentities.propTypes = {
   onToggleSort: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   someSelected: PropTypes.bool.isRequired,
-  sortIdentities: PropTypes.oneOf([ASC, DESC]).isRequired,
+  sort: PropTypes.oneOf([ASC, DESC]).isRequired,
 }
 
 const Filters = React.memo(function Filters({

--- a/src/components/GlobalPreferences/CustomLabels/useLocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useLocalIdentities.js
@@ -1,32 +1,26 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useIdentity } from '../../IdentityManager/IdentityManager'
 
-const ASC = Symbol('asc')
-const DESC = Symbol('desc')
-const sortDesc = (a, b) => b.name.localeCompare(a.name)
-const sortAsc = (a, b) => a.name.localeCompare(b.name)
-
 function useLocalIdentities(wrapper) {
   const cancelled = useRef()
   const { identityEvents$ } = useIdentity()
   const [identities, setIdentities] = useState([])
-  const [sort, setSort] = useState(ASC)
 
   const handleGetAll = useCallback(async () => {
     if (!wrapper) {
       return
     }
     const localIdentities = await wrapper.getLocalIdentities()
-    const identities = Object.entries(localIdentities)
-      .map(([address, identity]) => ({
+    const identities = Object.entries(localIdentities).map(
+      ([address, identity]) => ({
         ...identity,
         address,
-      }))
-      .sort(sort === ASC ? sortAsc : sortDesc)
+      })
+    )
     if (!cancelled.current) {
       setIdentities(identities)
     }
-  }, [wrapper, cancelled, sort])
+  }, [wrapper, cancelled])
 
   useEffect(() => {
     cancelled.current = false
@@ -40,12 +34,7 @@ function useLocalIdentities(wrapper) {
     }
   }, [handleGetAll, identityEvents$])
 
-  return {
-    identities,
-    sortIdentities: sort,
-    handleToggleSort: () => setSort(sort === ASC ? DESC : ASC),
-  }
+  return { identities }
 }
 
-export { ASC, DESC }
 export default useLocalIdentities

--- a/src/components/GlobalPreferences/CustomLabels/useSelectIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useSelectIdentities.js
@@ -47,6 +47,10 @@ function useSelectIdentities(identities, filteredIdentities) {
     }
   }, [initialSelected, setSelected, firstRender])
 
+  useEffect(() => {
+    setFirstRender(true)
+  }, [identities])
+
   return {
     allSelected,
     handleToggleIdentity,

--- a/src/components/GlobalPreferences/CustomLabels/useSelectIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useSelectIdentities.js
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useSelected } from '../../../hooks'
 
 function useSelectIdentities(identities, filteredIdentities) {
-  const [firstRender, setFirstRender] = useState(true)
+  const [resetSelection, setResetSelection] = useState(true)
   const initialSelected = useMemo(
     () => new Map(identities.map(({ address }) => [address, true])),
     [identities]
@@ -41,14 +41,14 @@ function useSelectIdentities(identities, filteredIdentities) {
   )
 
   useEffect(() => {
-    if (initialSelected.size && firstRender) {
-      setFirstRender(false)
+    if (initialSelected.size && resetSelection) {
+      setResetSelection(false)
       setSelected(initialSelected)
     }
-  }, [initialSelected, setSelected, firstRender])
+  }, [initialSelected, setSelected, resetSelection])
 
   useEffect(() => {
-    setFirstRender(true)
+    setResetSelection(true)
   }, [identities])
 
   return {

--- a/src/components/GlobalPreferences/CustomLabels/useSort.js
+++ b/src/components/GlobalPreferences/CustomLabels/useSort.js
@@ -1,0 +1,22 @@
+import { useMemo, useState } from 'react'
+
+const ASC = Symbol('asc')
+const DESC = Symbol('desc')
+const sortDesc = (a, b) => b.name.localeCompare(a.name)
+const sortAsc = (a, b) => a.name.localeCompare(b.name)
+
+function useSort(filteredIdentities) {
+  const [sort, setSort] = useState(ASC)
+  const sortedIdentities = useMemo(
+    () => filteredIdentities.sort(sort === ASC ? sortAsc : sortDesc),
+    [filteredIdentities, sort]
+  )
+  return {
+    sortedIdentities,
+    sort,
+    handleToggleSort: () => setSort(sort === ASC ? DESC : ASC),
+  }
+}
+
+export { ASC, DESC }
+export default useSort


### PR DESCRIPTION
This change makes it so that whenever `identities` change then the selection is reset (all selected).

Sorting was resetting the selected identities so now these changes include a decoupling of sorting as an independent hook