### PR TITLE
Add opt-in centralised cache

### DIFF
--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -10,6 +10,8 @@ import {
   appOverrides,
   sortAppsPair,
   ipfsDefaultConf,
+  defaultFeatherNode,
+  featherCacheEnabled,
   web3Providers,
   contractAddresses,
   defaultGasPriceFn,
@@ -373,10 +375,13 @@ const initWrapper = async (
 
   const account = await getMainAccount(web3)
   try {
+    // Initialise wrapper
     await wrapper.init({
       accounts: {
         providedAccounts: account ? [account] : [],
       },
+      featherNode: defaultFeatherNode,
+      hydrateFromFeather: featherCacheEnabled,
     })
   } catch (err) {
     if (err.message === 'Provided daoAddress is not a DAO') {

--- a/src/components/GlobalPreferences/Network/Network.js
+++ b/src/components/GlobalPreferences/Network/Network.js
@@ -7,13 +7,25 @@ import {
   Info,
   GU,
   TextInput,
+  Checkbox,
   textStyle,
   useLayout,
   useTheme,
 } from '@aragon/ui'
-import { defaultEthNode, ipfsDefaultConf, network } from '../../../environment'
+import {
+  defaultEthNode,
+  ipfsDefaultConf,
+  defaultFeatherNode,
+  featherCacheEnabled,
+  network,
+} from '../../../environment'
 import { InvalidNetworkType, InvalidURI, NoConnection } from '../../../errors'
-import { setDefaultEthNode, setIpfsGateway } from '../../../local-settings'
+import {
+  setDefaultEthNode,
+  setIpfsGateway,
+  setFeatherNode,
+  setFeatherCacheEnabled,
+} from '../../../local-settings'
 import keycodes from '../../../keycodes'
 import { sanitizeNetworkType } from '../../../network-config'
 import { checkValidEthNode } from '../../../web3-utils'
@@ -22,11 +34,15 @@ function Network({ wrapper }) {
   const {
     ethNode,
     ipfsGateway,
+    featherNode,
+    cacheEnabled,
     handleNetworkChange,
     handleClearCache,
     networkError,
     handleEthNodeChange,
     handleIpfsGatewayChange,
+    handleFeatherNodeChange,
+    handleFeatherEnabledChange,
     network,
   } = useNetwork(wrapper)
   const theme = useTheme()
@@ -84,6 +100,30 @@ function Network({ wrapper }) {
             `}
           />
         </Label>
+        <Label theme={theme}>
+          Feather Cache Node
+          <TextInput
+            value={featherNode}
+            wide
+            onChange={handleFeatherNodeChange}
+            css={`
+              ${textStyle('body2')};
+              color: ${theme.contentSecondary};
+            `}
+          />
+          <Checkbox
+            onChange={handleFeatherEnabledChange}
+            checked={cacheEnabled}
+          />
+          <span
+            css={`
+              color: ${theme.surfaceContentSecondary};
+              ${textStyle('body3')}
+            `}
+          >
+            Enable cache
+          </span>
+        </Label>
         <Button mode="strong" onClick={handleNetworkChange} wide={compact}>
           Save changes
         </Button>
@@ -126,6 +166,8 @@ const useNetwork = wrapper => {
   const [networkError, setNetworkError] = useState(null)
   const [ethNode, setEthNodeValue] = useState(defaultEthNode)
   const [ipfsGateway, setIpfsGatewayValue] = useState(ipfsDefaultConf.gateway)
+  const [featherNode, setFeatherNodeValue] = useState(defaultFeatherNode)
+  const [cacheEnabled, setCacheEnabledValue] = useState(featherCacheEnabled)
 
   const handleNetworkChange = useCallback(async () => {
     try {
@@ -137,9 +179,12 @@ const useNetwork = wrapper => {
 
     setDefaultEthNode(ethNode)
     setIpfsGateway(ipfsGateway)
+    setFeatherNode(featherNode)
+    setFeatherCacheEnabled(cacheEnabled)
+
     // For now, we have to reload the page to propagate the changes
     window.location.reload()
-  }, [ethNode, ipfsGateway])
+  }, [ethNode, ipfsGateway, featherNode, cacheEnabled])
   const handleClearCache = useCallback(async () => {
     await wrapper.cache.clear()
     window.localStorage.clear()
@@ -166,6 +211,8 @@ const useNetwork = wrapper => {
     ethNode,
     network,
     ipfsGateway,
+    featherNode,
+    cacheEnabled,
     handleNetworkChange,
     handleClearCache,
     networkError,
@@ -173,6 +220,9 @@ const useNetwork = wrapper => {
       setEthNodeValue(value),
     handleIpfsGatewayChange: ({ currentTarget: { value } }) =>
       setIpfsGatewayValue(value),
+    handleFeatherNodeChange: ({ currentTarget: { value } }) =>
+      setFeatherNodeValue(value),
+    handleFeatherEnabledChange: enabled => setCacheEnabledValue(enabled),
   }
 }
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -5,6 +5,8 @@ import {
   getDefaultEthNode,
   getEthNetworkType,
   getIpfsGateway,
+  getFeatherNode,
+  getFeatherCacheEnabled,
 } from './local-settings'
 import { getNetworkConfig } from './network-config'
 import { noop } from './utils'
@@ -100,6 +102,9 @@ export { appLocator, appOverrides }
 export const ipfsDefaultConf = {
   gateway: getIpfsGateway(),
 }
+
+export const defaultFeatherNode = getFeatherNode()
+export const featherCacheEnabled = getFeatherCacheEnabled()
 
 const networkConfig = getNetworkConfig(networkType)
 export const network = networkConfig.settings

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -5,6 +5,8 @@ const ENS_REGISTRY_ADDRESS = 'ENS_REGISTRY_ADDRESS'
 const ETH_NETWORK_TYPE = 'ETH_NETWORK_TYPE'
 const ETH_SUBSCRIPTION_EVENT_DELAY = 'ETH_SUBSCRIPTION_EVENT_DELAY'
 const IPFS_GATEWAY = 'IPFS_GATEWAY'
+const FEATHER_NODE = 'FEATHER_NODE'
+const FEATHER_CACHE_ENABLED = 'FEATHER_CACHED_ENABLED'
 const SELECTED_CURRENCY = 'SELECTED_CURRENCY'
 const SENTRY_DSN = 'SENTRY_DSN'
 
@@ -19,6 +21,8 @@ const CONFIGURATION_VARS = [
     process.env.REACT_APP_ETH_SUBSCRIPTION_EVENT_DELAY,
   ],
   [IPFS_GATEWAY, process.env.REACT_APP_IPFS_GATEWAY],
+  [FEATHER_NODE, process.env.REACT_APP_FEATHER_NODE],
+  [FEATHER_CACHE_ENABLED, process.env.REACT_APP_FEATHER_CACHE_ENABLED],
   [SELECTED_CURRENCY, process.env.REACT_APP_SELECTED_CURRENCY],
   [SENTRY_DSN, process.env.REACT_APP_SENTRY_DSN],
 ].reduce(
@@ -80,6 +84,22 @@ export function getIpfsGateway() {
 
 export function setIpfsGateway(gateway) {
   return setLocalSetting(IPFS_GATEWAY, gateway)
+}
+
+export function getFeatherNode() {
+  return getLocalSetting(FEATHER_NODE, 'http://bzz.cool:3333')
+}
+
+export function setFeatherNode(node) {
+  return setLocalSetting(FEATHER_NODE, node)
+}
+
+export function getFeatherCacheEnabled() {
+  return getLocalSetting(FEATHER_CACHE_ENABLED, 'false') === 'true'
+}
+
+export function setFeatherCacheEnabled(enabled) {
+  return setLocalSetting(FEATHER_CACHE_ENABLED, enabled)
 }
 
 export function getSelectedCurrency() {


### PR DESCRIPTION
**PoC, do not merge**

Adds support for [Feather](https://github.com/onbjerg/feather), a cache server for Aragon orgs.

The implementation itself is [around 11 lines of code](https://github.com/aragon/aragon/compare/master...onbjerg:feather-cache?expand=1#diff-c1957ab402163ee0da348f170f242479R328-R343), the rest is adding two settings:

- The Feather node URL
- An opt-in

Users can opt in to having organisations they visit cached. When they visit an organisation that is in cache, then it is served near instantly on any device they have opted in to this service on.

Users can run their own caching servers if they wish to defer trust to someone else. Currently a PoC server is running on http://bzz.cool:3333.

There are some additional steps I would like to take in the future on this, namely a verification mechanism for the cache. 

**[Video I sent to a friend demoing Feather](https://www.youtube.com/watch?v=BwMZyWVjeSY)**