### PR TITLE
Rename "modules" to "apps"

### DIFF
--- a/src/onboarding/Templates/TemplateDetails.js
+++ b/src/onboarding/Templates/TemplateDetails.js
@@ -163,7 +163,7 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
 
           {template.modules && template.modules.length > 0 && (
             <Field
-              label="Required modules"
+              label="Required apps"
               css={`
                 height: 150px;
                 margin-bottom: ${4 * GU}px;
@@ -204,7 +204,7 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
           )}
           {template.optionalModules && template.optionalModules.length > 0 && (
             <Field
-              label="Optional modules"
+              label="Optional apps"
               css={`
                 height: 150px;
               `}


### PR DESCRIPTION
Users are used to referring to these bits of code as "apps", not "modules", and we don't call them "modules" anywhere else in the frontend.