### PR TITLE
Templates: various fixes

### DIFF
--- a/src/onboarding/Configure/ConfigureTemplateScreens.js
+++ b/src/onboarding/Configure/ConfigureTemplateScreens.js
@@ -52,9 +52,6 @@ function ConfigureTemplateScreens({
           <AnimatedDiv
             style={{ opacity, transform, position }}
             css={`
-              display: grid;
-              align-items: center;
-              justify-content: center;
               top: 0;
               left: 0;
               right: 0;
@@ -62,6 +59,7 @@ function ConfigureTemplateScreens({
           >
             <div
               css={`
+                margin: 0 auto;
                 max-width: ${82 * GU}px;
                 padding: 0 ${3 * GU}px ${(below('medium') ? 9 : 3) * GU}px
                   ${3 * GU}px;

--- a/src/onboarding/Header/Header.js
+++ b/src/onboarding/Header/Header.js
@@ -27,14 +27,14 @@ function Header({
         {title}
       </h1>
       {subtitle && (
-        <p
+        <div
           css={`
             ${textStyle('title4')};
             color: ${theme.contentSecondary};
           `}
         >
           {subtitle}
-        </p>
+        </div>
       )}
     </header>
   )

--- a/src/onboarding/Templates/TemplateDetails.js
+++ b/src/onboarding/Templates/TemplateDetails.js
@@ -165,7 +165,6 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
             <Field
               label="Required apps"
               css={`
-                height: 150px;
                 margin-bottom: ${4 * GU}px;
               `}
             >
@@ -209,47 +208,44 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
                 height: 150px;
               `}
             >
-              {template.optionalApps.map(({ appName, label }, index) => (
-                <div
-                  key={index}
-                  css={`
-                    display: flex;
-                    justify-content: space-between;
-                    margin-top: ${2 * GU}px;
-
-                    & + & {
-                      margin-top: ${1.5 * GU}px;
-                    }
-                  `}
-                >
-                  <KnownAppBadge appName={appName} label={label} />
+              {() =>
+                template.optionalApps.map(({ appName, label }, index) => (
                   <div
+                    key={index}
                     css={`
                       display: flex;
-                      align-items: center;
-                      ${unselectable}
+                      justify-content: space-between;
+                      margin-top: ${2 * GU}px;
+
+                      & + & {
+                        margin-top: ${1.5 * GU}px;
+                      }
                     `}
                   >
-                    <Checkbox
-                      checked={templateOptionalApps[appName]}
-                      onChange={() => {
-                        setTemplateOptionalApps(apps => ({
-                          ...apps,
-                          [appName]: !apps[appName],
-                        }))
-                      }}
+                    <KnownAppBadge appName={appName} label={label} />
+                    <label
                       css={`
-                        margin-right: ${1.5 * GU}px;
-                        border-color: ${theme.hint};
-                        &:active {
-                          border-color: ${theme.hint};
-                        }
+                        display: flex;
+                        align-items: center;
                       `}
-                    />
-                    Include
+                    >
+                      <Checkbox
+                        checked={templateOptionalApps[appName]}
+                        onChange={() => {
+                          setTemplateOptionalApps(apps => ({
+                            ...apps,
+                            [appName]: !apps[appName],
+                          }))
+                        }}
+                        css={`
+                          margin-right: ${1.5 * GU}px;
+                        `}
+                      />
+                      Include
+                    </label>
                   </div>
-                </div>
-              ))}
+                ))
+              }
             </Field>
           )}
           {verticalMode && (

--- a/src/onboarding/Templates/TemplateDetails.js
+++ b/src/onboarding/Templates/TemplateDetails.js
@@ -117,9 +117,9 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
               )}
               {template.userGuideUrl && (
                 <Field label="User guide">
-                  <Link href={template.userGuide}>
+                  <Link href={template.userGuideUrl}>
                     {sanitizeCodeRepositoryUrl(
-                      stripUrlProtocol(template.userGuide)
+                      stripUrlProtocol(template.userGuideUrl)
                     )}
                   </Link>
                 </Field>

--- a/src/templates/kit/Duration.js
+++ b/src/templates/kit/Duration.js
@@ -1,0 +1,134 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Field, GU, TextInput, useTheme, useViewport } from '@aragon/ui'
+
+const MINUTE_IN_SECONDS = 60
+const HOUR_IN_SECONDS = MINUTE_IN_SECONDS * 60
+const DAY_IN_SECONDS = HOUR_IN_SECONDS * 24
+
+function Duration({ duration, onUpdate, label }) {
+  const theme = useTheme()
+  const { above } = useViewport()
+
+  // Calculate the units based on the initial duration (in seconds).
+  const [baseDays, baseHours, baseMinutes] = useMemo(() => {
+    let remaining = duration
+
+    const days = Math.floor(remaining / DAY_IN_SECONDS)
+    remaining -= days * DAY_IN_SECONDS
+
+    const hours = Math.floor(remaining / HOUR_IN_SECONDS)
+    remaining -= hours * HOUR_IN_SECONDS
+
+    const minutes = Math.floor(remaining / MINUTE_IN_SECONDS)
+    remaining -= minutes * MINUTE_IN_SECONDS
+
+    return [days, hours, minutes]
+  }, [duration])
+
+  // Local units state − updated from the initial duration if needed.
+  const [minutes, setMinutes] = useState(baseMinutes)
+  const [hours, setHours] = useState(baseHours)
+  const [days, setDays] = useState(baseDays)
+
+  // If any of the units change, call onUpdate() with the updated duration,
+  // so that it can get updated if the “next” button gets pressed.
+  useEffect(() => {
+    onUpdate(
+      minutes * MINUTE_IN_SECONDS +
+        hours * HOUR_IN_SECONDS +
+        days * DAY_IN_SECONDS
+    )
+  }, [onUpdate, minutes, hours, days])
+
+  // Invoked by handleDaysChange etc. to update a local unit.
+  const updateLocalUnit = useCallback((event, stateSetter) => {
+    const value = Number(event.target.value)
+    if (!isNaN(value)) {
+      stateSetter(value)
+    }
+  }, [])
+
+  const handleDaysChange = useCallback(
+    event => updateLocalUnit(event, setDays),
+    [updateLocalUnit]
+  )
+  const handleHoursChange = useCallback(
+    event => updateLocalUnit(event, setHours),
+    [updateLocalUnit]
+  )
+  const handleMinutesChange = useCallback(
+    event => updateLocalUnit(event, setMinutes),
+    [updateLocalUnit]
+  )
+
+  return (
+    <Field label={label}>
+      {({ id }) => (
+        <div
+          css={`
+            display: flex;
+            padding-top: ${0.5 * GU}px;
+            width: 100%;
+          `}
+        >
+          {[
+            ['Days', handleDaysChange, days],
+            ['Hours', handleHoursChange, hours],
+            [
+              above('medium') ? 'Minutes' : 'Min.',
+              handleMinutesChange,
+              minutes,
+            ],
+          ].map(([label, handler, value], index) => (
+            <div
+              key={label}
+              css={`
+                flex-grow: 1;
+                max-width: ${17 * GU}px;
+                & + & {
+                  margin-left: ${2 * GU}px;
+                }
+              `}
+            >
+              <TextInput
+                id={index === 0 ? id : undefined}
+                adornment={
+                  <span
+                    css={`
+                      padding: 0 ${1.5 * GU}px;
+                      color: ${theme.contentSecondary};
+                    `}
+                  >
+                    {label}
+                  </span>
+                }
+                adornmentPosition="end"
+                adornmentSettings={{
+                  width: 8 * GU,
+                  padding: 0,
+                }}
+                onChange={handler}
+                value={value}
+                wide
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </Field>
+  )
+}
+
+Duration.propTypes = {
+  duration: PropTypes.number,
+  label: PropTypes.node,
+  onUpdate: PropTypes.func.isRequired,
+}
+
+Duration.defaultProps = {
+  duration: 0,
+  label: 'Duration',
+}
+
+export default Duration

--- a/src/templates/kit/index.js
+++ b/src/templates/kit/index.js
@@ -3,6 +3,7 @@ export { default as ClaimDomainScreen } from './screens/ClaimDomainScreen'
 export {
   default as DomainField,
 } from '../../components/DomainField/DomainField'
+export { default as Duration } from './Duration'
 export { default as Header } from '../../onboarding/Header/Header'
 export {
   default as IdentityBadge,

--- a/src/templates/kit/screens/ClaimDomainScreen.js
+++ b/src/templates/kit/screens/ClaimDomainScreen.js
@@ -42,6 +42,8 @@ function ClaimDomainScreen({
     }
   }, [])
 
+  const nextScreen = screens[screenIndex + 1]
+
   return (
     <form>
       <Header title={screenTitle} />
@@ -80,8 +82,12 @@ function ClaimDomainScreen({
 
       <Navigation
         backEnabled
-        nextEnabled={Boolean(domain.trim())}
-        nextLabel={`Next: ${screens[screenIndex + 1][0]}`}
+        nextEnabled={Boolean(nextScreen && domain.trim())}
+        nextLabel={
+          nextScreen
+            ? `Next: ${screens[screenIndex + 1][0]}`
+            : 'Launch your organization'
+        }
         onBack={back}
         onNext={handleSubmit}
       />

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -487,9 +487,18 @@ function formatReviewFields(screenData) {
       'Token name & symbol',
       `${screenData.tokenName} (${screenData.tokenSymbol})`,
     ],
-    ...screenData.members.map(([account], i) => [
+    ...screenData.members.map(([account, amount], i) => [
       `Tokenholder #${i + 1}`,
-      <IdentityBadge entity={account} />,
+      <div css="display: flex">
+        <IdentityBadge entity={account} />
+        <span
+          css={`
+            margin-left: ${2 * GU}px;
+          `}
+        >
+          {amount} {screenData.tokenSymbol}
+        </span>
+      </div>,
     ]),
   ]
 }

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -376,7 +376,7 @@ Tokens.defaultProps = {
   accountStake: -1,
   dataKey: 'tokens',
   appLabel: 'Tokens',
-  editMembers: false,
+  editMembers: true,
 }
 
 function MemberField({

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -14,7 +14,13 @@ import {
   isAddress,
   useTheme,
 } from '@aragon/ui'
-import { Header, Navigation, IdentityBadge, ScreenPropsType } from '..'
+import {
+  KnownAppBadge,
+  Header,
+  Navigation,
+  IdentityBadge,
+  ScreenPropsType,
+} from '..'
 
 function useFieldsLayout() {
   // In its own hook to be adapted for smaller views
@@ -55,6 +61,7 @@ function validationError(tokenName, tokenSymbol, members) {
 function Tokens({
   accountStake,
   dataKey,
+  appLabel,
   screenProps: { back, data, next, screenIndex, screens },
 }) {
   const screenData = (dataKey ? data[dataKey] : data) || {}
@@ -192,7 +199,29 @@ function Tokens({
       <div>
         <Header
           title="Configure template"
-          subtitle="Choose your Tokens app settings below."
+          subtitle={
+            <span
+              css={`
+                display: flex;
+                align-items: center;
+                justify-content: center;
+              `}
+            >
+              Choose your
+              <span
+                css={`
+                  display: flex;
+                  margin: 0 ${1.5 * GU}px;
+                `}
+              >
+                <KnownAppBadge
+                  appName="token-manager.aragonpm.eth"
+                  label={appLabel}
+                />
+              </span>
+              settings below.
+            </span>
+          }
         />
 
         <div
@@ -319,6 +348,7 @@ function Tokens({
 }
 
 Tokens.propTypes = {
+  appLabel: PropTypes.string,
   accountStake: PropTypes.number,
   dataKey: PropTypes.string,
   screenProps: ScreenPropsType.isRequired,
@@ -327,6 +357,7 @@ Tokens.propTypes = {
 Tokens.defaultProps = {
   accountStake: -1,
   dataKey: 'tokens',
+  appLabel: 'Tokens',
 }
 
 function MemberField({

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -39,14 +39,17 @@ function validateDuplicateAddresses(members) {
   return validAddresses.length === new Set(validAddresses).size
 }
 
-function validationError(tokenName, tokenSymbol, members) {
-  if (!members.some(([address]) => isAddress(address))) {
+function validationError(tokenName, tokenSymbol, members, editMembers) {
+  if (editMembers && !members.some(([address]) => isAddress(address))) {
     return 'You need at least one valid address.'
   }
-  if (!members.some(([address, stake]) => isAddress(address) && stake > 0)) {
+  if (
+    editMembers &&
+    !members.some(([address, stake]) => isAddress(address) && stake > 0)
+  ) {
     return 'You need at least one valid address with a positive balance.'
   }
-  if (!validateDuplicateAddresses(members)) {
+  if (editMembers && !validateDuplicateAddresses(members)) {
     return 'One of your members is using the same address than another member. Please ensure every member address is unique.'
   }
   if (!tokenName.trim()) {
@@ -62,6 +65,7 @@ function Tokens({
   accountStake,
   dataKey,
   appLabel,
+  editMembers,
   screenProps: { back, data, next, screenIndex, screens },
 }) {
   const screenData = (dataKey ? data[dataKey] : data) || {}
@@ -152,7 +156,12 @@ function Tokens({
   const handleSubmit = useCallback(
     event => {
       event.preventDefault()
-      const error = validationError(tokenName, tokenSymbol, members)
+      const error = validationError(
+        tokenName,
+        tokenSymbol,
+        members,
+        editMembers
+      )
       setFormError(error)
       if (!error) {
         const screenData = {
@@ -169,7 +178,7 @@ function Tokens({
         )
       }
     },
-    [data, dataKey, members, next, tokenName, tokenSymbol]
+    [data, dataKey, editMembers, members, next, tokenName, tokenSymbol]
   )
 
   // Focus the token name as soon as it becomes available
@@ -190,7 +199,7 @@ function Tokens({
   const disableNext =
     !tokenName ||
     !tokenSymbol ||
-    members.every(([account, stake]) => !account || stake < 0)
+    (editMembers && members.every(([account, stake]) => !account || stake < 0))
 
   return (
     <form
@@ -280,44 +289,46 @@ function Tokens({
           </Field>
         </div>
       </div>
-      <Field
-        label={
-          <div
-            css={`
-              width: 100%;
-              ${fieldsLayout}
-            `}
-          >
-            <div>Tokenholders</div>
-            {!fixedStake && <div>Balances</div>}
-          </div>
-        }
-      >
-        <div ref={membersRef}>
-          {members.map((member, index) => (
-            <MemberField
-              key={index}
-              index={index}
-              member={member}
-              onRemove={removeMember}
-              hideRemoveButton={hideRemoveButton}
-              onUpdate={updateMember}
-              displayStake={!fixedStake}
-            />
-          ))}
-        </div>
-        <Button
-          icon={
-            <IconPlus
+      {editMembers && (
+        <Field
+          label={
+            <div
               css={`
-                color: ${theme.accent};
+                width: 100%;
+                ${fieldsLayout}
               `}
-            />
+            >
+              <div>Tokenholders</div>
+              {!fixedStake && <div>Balances</div>}
+            </div>
           }
-          label="Add more"
-          onClick={addMember}
-        />
-      </Field>
+        >
+          <div ref={membersRef}>
+            {members.map((member, index) => (
+              <MemberField
+                key={index}
+                index={index}
+                member={member}
+                onRemove={removeMember}
+                hideRemoveButton={hideRemoveButton}
+                onUpdate={updateMember}
+                displayStake={!fixedStake}
+              />
+            ))}
+          </div>
+          <Button
+            icon={
+              <IconPlus
+                css={`
+                  color: ${theme.accent};
+                `}
+              />
+            }
+            label="Add more"
+            onClick={addMember}
+          />
+        </Field>
+      )}
 
       {formError && (
         <Info
@@ -336,8 +347,10 @@ function Tokens({
         `}
       >
         These settings will determine the name and symbol of the token that will
-        be created for your organization. Add members to define the initial
-        distribution of this token.
+        be created for your organization.
+        {editMembers
+          ? ' Add members to define the initial distribution of this token.'
+          : ''}
       </Info>
 
       <Navigation
@@ -356,12 +369,14 @@ Tokens.propTypes = {
   accountStake: PropTypes.number,
   dataKey: PropTypes.string,
   screenProps: ScreenPropsType.isRequired,
+  editMembers: PropTypes.bool,
 }
 
 Tokens.defaultProps = {
   accountStake: -1,
   dataKey: 'tokens',
   appLabel: 'Tokens',
+  editMembers: false,
 }
 
 function MemberField({

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -15,10 +15,10 @@ import {
   useTheme,
 } from '@aragon/ui'
 import {
-  KnownAppBadge,
   Header,
-  Navigation,
   IdentityBadge,
+  KnownAppBadge,
+  Navigation,
   ScreenPropsType,
 } from '..'
 

--- a/src/templates/kit/screens/TokensScreen.js
+++ b/src/templates/kit/screens/TokensScreen.js
@@ -162,7 +162,11 @@ function Tokens({
             ([account, stake]) => isAddress(account) && stake > 0
           ),
         }
-        next(dataKey ? { ...data, [dataKey]: screenData } : screenData)
+        next(
+          dataKey
+            ? { ...data, [dataKey]: screenData }
+            : { ...data, ...screenData }
+        )
       }
     },
     [data, dataKey, members, next, tokenName, tokenSymbol]

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -165,7 +165,7 @@ function VotingScreen({
         ref={handleSupportRef}
         label={
           <React.Fragment>
-            Support
+            Support %
             <Help hint="What’s the support?">
               <strong>Support</strong> is the percentage of votes on a proposal
               that the total support must be greater than for the proposal to be
@@ -289,7 +289,7 @@ function formatDuration(duration) {
 
 function formatReviewFields(screenData) {
   return [
-    ['Support', `${screenData.support}%`],
+    ['Support %', `${screenData.support}%`],
     ['Minimum approval %', `${screenData.quorum}%`],
     ['Vote duration', formatDuration(screenData.duration)],
   ]

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -126,7 +126,11 @@ function VotingScreen({
           quorum: Math.floor(quorum),
           duration,
         }
-        next(dataKey ? { ...data, [dataKey]: screenData } : screenData)
+        next(
+          dataKey
+            ? { ...data, [dataKey]: screenData }
+            : { ...data, ...screenData }
+        )
       }
     },
     [data, dataKey, duration, isPercentageFieldFocused, next, quorum, support]

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -119,11 +119,7 @@ function VotingScreen({
           quorum: Math.floor(quorum),
           duration,
         }
-        next(
-          dataKey
-            ? { ...data, [dataKey]: screenData }
-            : { ...data, ...screenData }
-        )
+        next({ ...data, ...(dataKey ? { [dataKey]: screenData } : screenData) })
       }
     },
     [data, dataKey, duration, isPercentageFieldFocused, next, quorum, support]

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -1,22 +1,13 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useState,
-  useRef,
-} from 'react'
+import React, { useCallback, useReducer, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { GU, Help, Info } from '@aragon/ui'
 import {
-  Field,
-  GU,
-  Help,
-  Info,
-  TextInput,
-  useTheme,
-  useViewport,
-} from '@aragon/ui'
-import { Header, PercentageField, Navigation, ScreenPropsType } from '..'
+  Duration,
+  Header,
+  Navigation,
+  PercentageField,
+  ScreenPropsType,
+} from '..'
 
 const MINUTE_IN_SECONDS = 60
 const HOUR_IN_SECONDS = MINUTE_IN_SECONDS * 60
@@ -186,7 +177,21 @@ function VotingScreen({
         onChange={handleQuorumChange}
       />
 
-      <VoteDuration duration={duration} onUpdate={handleDurationChange} />
+      <Duration
+        duration={duration}
+        onUpdate={handleDurationChange}
+        label={
+          <React.Fragment>
+            Vote duration
+            <Help hint="What’s the vote duration?">
+              <strong>Vote Duration</strong> is the length of time that the vote
+              will be open for participation. For example, if the Vote Duration
+              is set to 24 hours, then tokenholders have 24 hours to participate
+              in the vote.
+            </Help>
+          </React.Fragment>
+        }
+      />
 
       {formError && (
         <Info
@@ -228,142 +233,6 @@ VotingScreen.propTypes = {
 
 VotingScreen.defaultProps = {
   dataKey: 'voting',
-}
-
-function VoteDuration({ duration = 0, onUpdate }) {
-  const theme = useTheme()
-  const { above } = useViewport()
-
-  // Calculate the units based on the initial duration (in seconds).
-  const [baseDays, baseHours, baseMinutes] = useMemo(() => {
-    let remaining = duration
-
-    const days = Math.floor(remaining / DAY_IN_SECONDS)
-    remaining -= days * DAY_IN_SECONDS
-
-    const hours = Math.floor(remaining / HOUR_IN_SECONDS)
-    remaining -= hours * HOUR_IN_SECONDS
-
-    const minutes = Math.floor(remaining / MINUTE_IN_SECONDS)
-    remaining -= minutes * MINUTE_IN_SECONDS
-
-    return [days, hours, minutes]
-  }, [duration])
-
-  // Local units state − updated from the initial duration if needed.
-  const [minutes, setMinutes] = useState(baseMinutes)
-  const [hours, setHours] = useState(baseHours)
-  const [days, setDays] = useState(baseDays)
-
-  // If any of the units change, call onUpdate() with the updated duration,
-  // so that it can get updated if the “next” button gets pressed.
-  useEffect(() => {
-    onUpdate(
-      minutes * MINUTE_IN_SECONDS +
-        hours * HOUR_IN_SECONDS +
-        days * DAY_IN_SECONDS
-    )
-  }, [onUpdate, minutes, hours, days])
-
-  // Invoked by handleDaysChange etc. to update a local unit.
-  const updateLocalUnit = useCallback((event, stateSetter) => {
-    const value = Number(event.target.value)
-    if (!isNaN(value)) {
-      stateSetter(value)
-    }
-  }, [])
-
-  const handleDaysChange = useCallback(
-    event => updateLocalUnit(event, setDays),
-    [updateLocalUnit]
-  )
-  const handleHoursChange = useCallback(
-    event => updateLocalUnit(event, setHours),
-    [updateLocalUnit]
-  )
-  const handleMinutesChange = useCallback(
-    event => updateLocalUnit(event, setMinutes),
-    [updateLocalUnit]
-  )
-
-  return (
-    <Field
-      label={
-        <React.Fragment>
-          vote duration
-          <Help hint="What’s the vote duration?">
-            <strong>Vote Duration</strong> is the length of time that the vote
-            will be open for participation. For example, if the Vote Duration is
-            set to 24 hours, then tokenholders have 24 hours to participate in
-            the vote.
-          </Help>
-        </React.Fragment>
-      }
-    >
-      {({ id }) => (
-        <div
-          css={`
-            display: flex;
-            padding-top: ${0.5 * GU}px;
-            width: 100%;
-          `}
-        >
-          {[
-            ['Days', handleDaysChange, days],
-            ['Hours', handleHoursChange, hours],
-            [
-              above('medium') ? 'Minutes' : 'Min.',
-              handleMinutesChange,
-              minutes,
-            ],
-          ].map(([label, handler, value], index) => (
-            <div
-              key={label}
-              css={`
-                flex-grow: 1;
-                max-width: ${17 * GU}px;
-                & + & {
-                  margin-left: ${2 * GU}px;
-                }
-              `}
-            >
-              <TextInput
-                id={index === 0 ? id : undefined}
-                adornment={
-                  <span
-                    css={`
-                      padding: 0 ${2 * GU}px;
-                      color: ${theme.contentSecondary};
-                    `}
-                  >
-                    {label}
-                  </span>
-                }
-                adornmentPosition="end"
-                adornmentSettings={{
-                  width: 8 * GU,
-                  padding: 0,
-                }}
-                onChange={handler}
-                value={value}
-                wide
-                css="text-align: center"
-              />
-            </div>
-          ))}
-        </div>
-      )}
-    </Field>
-  )
-}
-
-VoteDuration.propTypes = {
-  duration: PropTypes.number,
-  onUpdate: PropTypes.func.isRequired,
-}
-
-VoteDuration.defaultProps = {
-  duration: 0,
 }
 
 function formatDuration(duration) {

--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -4,6 +4,7 @@ import { GU, Help, Info } from '@aragon/ui'
 import {
   Duration,
   Header,
+  KnownAppBadge,
   Navigation,
   PercentageField,
   ScreenPropsType,
@@ -46,6 +47,7 @@ function reduceFields(fields, [field, value]) {
 }
 
 function VotingScreen({
+  appLabel,
   dataKey,
   screenProps: { back, data, next, screenIndex, screens },
 }) {
@@ -137,7 +139,26 @@ function VotingScreen({
     >
       <Header
         title="Configure template"
-        subtitle="Choose your Voting app settings below."
+        subtitle={
+          <span
+            css={`
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            `}
+          >
+            Choose your
+            <span
+              css={`
+                display: flex;
+                margin: 0 ${1.5 * GU}px;
+              `}
+            >
+              <KnownAppBadge appName="voting.aragonpm.eth" label={appLabel} />
+            </span>
+            settings below.
+          </span>
+        }
       />
 
       <PercentageField
@@ -227,11 +248,13 @@ function VotingScreen({
 }
 
 VotingScreen.propTypes = {
+  appLabel: PropTypes.string,
   dataKey: PropTypes.string,
   screenProps: ScreenPropsType.isRequired,
 }
 
 VotingScreen.defaultProps = {
+  appLabel: 'Voting',
   dataKey: 'voting',
 }
 

--- a/src/url-utils.js
+++ b/src/url-utils.js
@@ -53,9 +53,9 @@ export function repoBaseUrl(repo, gateway = ipfsDefaultConf.gateway) {
   )
 }
 
-// Removes the HTTP protocol of a URL
+// Removes the HTTP protocol of a URL, and the final slash.
 export function stripUrlProtocol(url = '') {
-  return url.replace(/^https?:\/\//, '')
+  return url.replace(/^https?:\/\//, '').replace(/\/$/, '')
 }
 
 const CODE_REPO_SERVICES = [


### PR DESCRIPTION
- `TokensScreen` review summary: display the amount of tokens in front of each account.
- `ConfigureTemplateScreen`: always use the maximum width.
- Templates kit: add `Duration`.
- `stripUrlProtocol()`: also remove the final slash.
- `onboarding/Header`: use a `<div>` for the subtitle to allow nested block elements.
- `TemplateDetails`: apps / required apps fixes.
  - Ensure each checkbox has its own label.
  - Remove the default height.
  - Remove the custom styles on the checkboxes.
- `TemplateDetails`: display the user guide URL.
- `TokensScreen` / `VotingScreen`: prevent the entire data to be overwritten (when `dataKey` was set to `null`).
- `TokensScreen`: allow to not have any member.
- `TokensScreen` subtitle: custom label + use AppBadge.
- `VotingScreen` subtitle: custom label + use AppBadge.
- `ClaimDomainScreen`: label the “next” button properly if this is the last screen.

