### PR TITLE
Custom labels: refactor large screens to use SearchInput component

### DIFF
--- a/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
+++ b/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
@@ -17,7 +17,7 @@ function CustomLabels({ wrapper, dao, locator }) {
   const {
     filteredIdentities,
     handleSearchTermChange,
-    setSearchTerm,
+    onSearchTerm,
     searchTerm,
   } = useFilterIdentities(identities)
   const {
@@ -78,7 +78,7 @@ function CustomLabels({ wrapper, dao, locator }) {
           onImport={handleImport}
           onRemove={handleRemoveModalOpen}
           onSearchChange={handleSearchTermChange}
-          setSearchTerm={setSearchTerm}
+          onSearchTerm={onSearchTerm}
           onShare={handleShareModalOpen}
           onToggleAll={handleToggleAll}
           onToggleIdentity={handleToggleIdentity}

--- a/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
+++ b/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
@@ -17,6 +17,7 @@ function CustomLabels({ wrapper, dao, locator }) {
   const {
     filteredIdentities,
     handleSearchTermChange,
+    setSearchTerm,
     searchTerm,
   } = useFilterIdentities(identities)
   const {
@@ -77,6 +78,7 @@ function CustomLabels({ wrapper, dao, locator }) {
           onImport={handleImport}
           onRemove={handleRemoveModalOpen}
           onSearchChange={handleSearchTermChange}
+          setSearchTerm={setSearchTerm}
           onShare={handleShareModalOpen}
           onToggleAll={handleToggleAll}
           onToggleIdentity={handleToggleIdentity}

--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -18,6 +18,7 @@ import {
   IconTrash,
   Info,
   TextInput,
+  SearchInput,
   useTheme,
   useLayout,
   useToast,
@@ -38,6 +39,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
   onImport,
   onRemove,
   onSearchChange,
+  setSearchTerm,
   onShare,
   onShowLocalIdentityModal,
   onToggleAll,
@@ -77,6 +79,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
           <Filters
             searchTerm={searchTerm}
             onSearchChange={onSearchChange}
+            setSearchTerm={setSearchTerm}
             onImport={onImport}
             onShare={onShare}
             onExport={onExport}
@@ -182,6 +185,7 @@ LocalIdentities.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
+  setSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   onShowLocalIdentityModal: PropTypes.func.isRequired,
   onToggleAll: PropTypes.func.isRequired,
@@ -197,6 +201,7 @@ const Filters = React.memo(function Filters({
   onImport,
   onRemove,
   onSearchChange,
+  setSearchTerm,
   onShare,
   searchTerm,
   someSelected,
@@ -204,6 +209,10 @@ const Filters = React.memo(function Filters({
   const { layoutName } = useLayout()
   const compact = layoutName === 'small'
   const theme = useTheme()
+  const searchStyles = `
+    ${textStyle('body2')};
+    color: ${searchTerm.trim() ? theme.surfaceContent : theme.hint};
+  `
 
   return (
     <div
@@ -221,24 +230,35 @@ const Filters = React.memo(function Filters({
           position: relative;
         `}
       >
-        <TextInput
-          adornment={
-            <IconSearch
-              css={`
-                color: ${theme.surfaceOpened};
-              `}
-            />
-          }
-          adornmentPosition="end"
-          placeholder="Search"
-          onChange={onSearchChange}
-          value={searchTerm}
-          css={`
-            width: ${compact ? 25 * GU : 30 * GU}px;
-            ${textStyle('body2')};
-            color: ${searchTerm.trim() ? theme.surfaceContent : theme.hint};
-          `}
-        />
+        {compact ? (
+          <TextInput
+            adornment={
+              <IconSearch
+                css={`
+                  color: ${theme.surfaceOpened};
+                `}
+              />
+            }
+            adornmentPosition="end"
+            placeholder="Search"
+            onChange={onSearchChange}
+            value={searchTerm}
+            css={`
+              width: ${25 * GU}px;
+              ${searchStyles};
+            `}
+          />
+        ) : (
+          <SearchInput
+            onChange={setSearchTerm}
+            value={searchTerm}
+            placeholder="Search"
+            css={`
+              width: ${30 * GU}px;
+              ${searchStyles};
+            `}
+          />
+        )}
       </div>
       {!iOS && (
         <Import
@@ -288,6 +308,7 @@ Filters.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
+  setSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   someSelected: PropTypes.bool.isRequired,

--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -39,7 +39,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
   onImport,
   onRemove,
   onSearchChange,
-  setSearchTerm,
+  onSearchTerm,
   onShare,
   onShowLocalIdentityModal,
   onToggleAll,
@@ -79,7 +79,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
           <Filters
             searchTerm={searchTerm}
             onSearchChange={onSearchChange}
-            setSearchTerm={setSearchTerm}
+            onSearchTerm={onSearchTerm}
             onImport={onImport}
             onShare={onShare}
             onExport={onExport}
@@ -185,7 +185,7 @@ LocalIdentities.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
-  setSearchTerm: PropTypes.func.isRequired,
+  onSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   onShowLocalIdentityModal: PropTypes.func.isRequired,
   onToggleAll: PropTypes.func.isRequired,
@@ -201,7 +201,7 @@ const Filters = React.memo(function Filters({
   onImport,
   onRemove,
   onSearchChange,
-  setSearchTerm,
+  onSearchTerm,
   onShare,
   searchTerm,
   someSelected,
@@ -250,7 +250,7 @@ const Filters = React.memo(function Filters({
           />
         ) : (
           <SearchInput
-            onChange={setSearchTerm}
+            onChange={onSearchTerm}
             value={searchTerm}
             placeholder="Search"
             css={`
@@ -308,7 +308,7 @@ Filters.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
-  setSearchTerm: PropTypes.func.isRequired,
+  onSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   someSelected: PropTypes.bool.isRequired,

--- a/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
@@ -20,6 +20,7 @@ function useFilterIdentities(identities) {
     handleSearchTermChange: ({ currentTarget: { value } }) =>
       setSearchTerm(value),
     searchTerm,
+    setSearchTerm,
   }
 }
 

--- a/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
@@ -20,7 +20,7 @@ function useFilterIdentities(identities) {
     handleSearchTermChange: ({ currentTarget: { value } }) =>
       setSearchTerm(value),
     searchTerm,
-    setSearchTerm,
+    onSearchTerm: setSearchTerm,
   }
 }
 


### PR DESCRIPTION
With these changes larger screens use `SearchInput`. Smaller screens have extra functionality, that's why this is only implemented for larger screens.

Passes down `setSearchTerm` as `SearchInput` has a different API to `TextInput` (discussion with @bpierre about inputs sending the value + the event); when the API for inputs is updated this can be refactored into using only one handler.