### PR TITLE
Upgrade @aragon/ui to 1.0.0-alpha.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@aragon/templates-tokens": "^1.2.1",
-    "@aragon/ui": "^1.0.0-alpha.26",
+    "@aragon/ui": "^1.0.0-alpha.27",
     "@aragon/wrapper": "^5.0.0-rc.17",
     "@babel/polyfill": "^7.0.0",
     "@sentry/browser": "^5.5.0",


### PR DESCRIPTION
Fixes the missing `SearchInput` error.