### PR TITLE
Onboarding: clamp value of Voting's support and quorum to their max values

### DIFF
--- a/src/templates/company/index.js
+++ b/src/templates/company/index.js
@@ -17,6 +17,24 @@ function completeDomain(domain) {
   return domain ? `${domain}.aragonid.eth` : ''
 }
 
+function adjustVotingSettings(support, quorum) {
+  // The max value for both support and quorum is 100% - 1
+  const onePercent = new BN(10).pow(new BN(16))
+  const hundredPercent = onePercent.mul(new BN(100))
+
+  let adjustedSupport = onePercent.mul(new BN(support))
+  if (adjustedSupport.eq(hundredPercent)) {
+    adjustedSupport = adjustedSupport.sub(new BN(1))
+  }
+
+  let adjustedQuorum = onePercent.mul(new BN(quorum))
+  if (adjustedQuorum.eq(hundredPercent)) {
+    adjustedQuorum = adjustedQuorum.sub(new BN(1))
+  }
+
+  return [adjustedSupport.toString(), adjustedQuorum.toString()]
+}
+
 export default {
   id: 'company-template.aragonpm.eth',
   name: 'Company',
@@ -95,9 +113,10 @@ export default {
     const accounts = members.map(([account]) => account)
 
     const { support, quorum, duration } = voting
-    const onePercent = new BN(10).pow(new BN(16))
-    const adjustedSupport = onePercent.mul(new BN(support)).toString()
-    const adjustedQuorum = onePercent.mul(new BN(quorum)).toString()
+    const [adjustedSupport, adjustedQuorum] = adjustVotingSettings(
+      support,
+      quorum
+    )
     const adjustedDuration = new BN(duration).toString()
     const votingSettings = [adjustedSupport, adjustedQuorum, adjustedDuration]
 

--- a/src/templates/membership/index.js
+++ b/src/templates/membership/index.js
@@ -17,6 +17,24 @@ function completeDomain(domain) {
   return domain ? `${domain}.aragonid.eth` : ''
 }
 
+function adjustVotingSettings(support, quorum) {
+  // The max value for both support and quorum is 100% - 1
+  const onePercent = new BN(10).pow(new BN(16))
+  const hundredPercent = onePercent.mul(new BN(100))
+
+  let adjustedSupport = onePercent.mul(new BN(support))
+  if (adjustedSupport.eq(hundredPercent)) {
+    adjustedSupport = adjustedSupport.sub(new BN(1))
+  }
+
+  let adjustedQuorum = onePercent.mul(new BN(quorum))
+  if (adjustedQuorum.eq(hundredPercent)) {
+    adjustedQuorum = adjustedQuorum.sub(new BN(1))
+  }
+
+  return [adjustedSupport.toString(), adjustedQuorum.toString()]
+}
+
 export default {
   id: 'membership-template.aragonpm.eth',
   name: 'Membership',
@@ -94,9 +112,10 @@ export default {
     const accounts = members.map(([account]) => account)
 
     const { support, quorum, duration } = voting
-    const onePercent = new BN(10).pow(new BN(16))
-    const adjustedSupport = onePercent.mul(new BN(support)).toString()
-    const adjustedQuorum = onePercent.mul(new BN(quorum)).toString()
+    const [adjustedSupport, adjustedQuorum] = adjustVotingSettings(
+      support,
+      quorum
+    )
     const adjustedDuration = new BN(duration).toString()
     const votingSettings = [adjustedSupport, adjustedQuorum, adjustedDuration]
 

--- a/src/templates/reputation/index.js
+++ b/src/templates/reputation/index.js
@@ -17,6 +17,24 @@ function completeDomain(domain) {
   return domain ? `${domain}.aragonid.eth` : ''
 }
 
+function adjustVotingSettings(support, quorum) {
+  // The max value for both support and quorum is 100% - 1
+  const onePercent = new BN(10).pow(new BN(16))
+  const hundredPercent = onePercent.mul(new BN(100))
+
+  let adjustedSupport = onePercent.mul(new BN(support))
+  if (adjustedSupport.eq(hundredPercent)) {
+    adjustedSupport = adjustedSupport.sub(new BN(1))
+  }
+
+  let adjustedQuorum = onePercent.mul(new BN(quorum))
+  if (adjustedQuorum.eq(hundredPercent)) {
+    adjustedQuorum = adjustedQuorum.sub(new BN(1))
+  }
+
+  return [adjustedSupport.toString(), adjustedQuorum.toString()]
+}
+
 export default {
   id: 'reputation-template.aragonpm.eth',
   name: 'Reputation',
@@ -95,9 +113,10 @@ export default {
     const accounts = members.map(([account]) => account)
 
     const { support, quorum, duration } = voting
-    const onePercent = new BN(10).pow(new BN(16))
-    const adjustedSupport = onePercent.mul(new BN(support)).toString()
-    const adjustedQuorum = onePercent.mul(new BN(quorum)).toString()
+    const [adjustedSupport, adjustedQuorum] = adjustVotingSettings(
+      support,
+      quorum
+    )
     const adjustedDuration = new BN(duration).toString()
     const votingSettings = [adjustedSupport, adjustedQuorum, adjustedDuration]
 


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/1070. Clamps the support and quorum values to be `1e18 (100%) - 1`.

The Voting app's frontend is even smart enough to know this is 100% :smile::

<img width="1177" alt="Screen Shot 2019-10-09 at 7 56 25 PM" src="https://user-images.githubusercontent.com/4166642/66507286-33d15f00-eacf-11e9-9e91-20768d95bae8.png">
