### PR TITLE
AppIFrame: fix iframe not being mounted in IE

### DIFF
--- a/src/components/App/AppIFrame.js
+++ b/src/components/App/AppIFrame.js
@@ -78,7 +78,7 @@ class AppIFrame extends React.Component {
     const containerNode = this.iframe.parentNode
     this.iframe.remove()
     this.iframe.src = src
-    containerNode.append(this.iframe)
+    containerNode.appendChild(this.iframe)
 
     this.loadingStart()
 


### PR DESCRIPTION
See https://sentry.io/share/issue/99924025ef204dea83126d7a0627e9a6/.

From a user:

> Pasted DAO link (https://mainnet.aragon.org/#/beneficent) into Microsoft Edge browser.
> Edge Version: 16.16299

Turns out [`parentNode.append()` isn't available on IE (and I guess Edge?)](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append#Browser_compatibility).