### PR TITLE
OnboardingTopBar: remove unneeded prop type

### DIFF
--- a/src/components/Error/ErrorScreen.js
+++ b/src/components/Error/ErrorScreen.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ButtonBase, Card, GU, useTheme, useViewport } from '@aragon/ui'
+import { Card, GU, useTheme, useViewport } from '@aragon/ui'
 import HelpScoutBeacon from '../HelpScoutBeacon/HelpScoutBeacon'
 import HomeButton from '../HomeButton/HomeButton'
 
 import eagleSvg from '../../assets/eagle.svg'
-import logo from '../../assets/logo.png'
 import notFoundImage from '../../assets/dao-not-found.png'
 
 const EAGLE_DIMENSIONS = [1307, 877]

--- a/src/onboarding/Onboarding/OnboardingTopBar.js
+++ b/src/onboarding/Onboarding/OnboardingTopBar.js
@@ -1,13 +1,6 @@
 import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
-import {
-  Button,
-  ButtonBase,
-  GU,
-  IconSettings,
-  RADIUS,
-  useTheme,
-} from '@aragon/ui'
+import { Button, GU, IconSettings, useTheme } from '@aragon/ui'
 import AccountModule from '../../components/AccountModule/AccountModule'
 import HomeButton from '../../components/HomeButton/HomeButton'
 
@@ -87,7 +80,6 @@ function OnboardingTopBar({ status, solid }) {
 }
 
 OnboardingTopBar.propTypes = {
-  onHome: PropTypes.func.isRequired,
   status: PropTypes.string.isRequired,
   solid: PropTypes.bool,
 }


### PR DESCRIPTION
After the last update (bbb1038a10dcb1556a0822fcff2dd59495170b1b) the prop
and imports were not removed.