### PR TITLE
Templates: update copy from 'required apps' to 'included apps'

### DIFF
--- a/src/onboarding/Templates/TemplateDetails.js
+++ b/src/onboarding/Templates/TemplateDetails.js
@@ -163,7 +163,7 @@ function TemplateDetails({ template, visible, onUse, onClose }) {
 
           {template.apps && template.apps.length > 0 && (
             <Field
-              label="Required apps"
+              label="Included apps"
               css={`
                 margin-bottom: ${4 * GU}px;
               `}


### PR DESCRIPTION
cc @dizzypaty we may want to come up with a different way of displaying this information in the future. As it is, it's a bit confusing—is it all the installed apps, or just the ones I'm configuring?

From our earlier conversations, we meant it to be only the apps that were being configured, but that also doesn't do a great job of advertising that a template is doing So Much More<sup>TM</sup>.

E.g. on our Reputation template, we don't show the Vault (for good reason—it doesn't have a UI), but we do show the Finance app, even though it's not being configured:

<img width="250" alt="Screen Shot 2019-10-23 at 6 07 57 PM" src="https://user-images.githubusercontent.com/4166642/67412809-444e0300-f5c0-11e9-8c24-1941c864d365.png">

For the Open Enterprise template, we show all the apps, even though most of them don't have any configuration:

<img width="250" alt="Screen Shot 2019-10-23 at 6 07 43 PM" src="https://user-images.githubusercontent.com/4166642/67412850-592a9680-f5c0-11e9-8fa0-5232c0b69633.png">

-----

Perhaps we could use a different section and visual indicator to denominate the apps that require configuration?

The current "optional apps" section is very clear.