### PR TITLE
Onboarding: add URL routing for templates

### DIFF
--- a/src/onboarding/Create/Create.js
+++ b/src/onboarding/Create/Create.js
@@ -30,6 +30,12 @@ import {
   STATUS_DEPLOYMENT,
 } from './create-statuses'
 
+function useRouterArgs(location) {
+  const args = location.hash.split('/')
+  const setArgs = args => history.pushState(null, null, '#' + args.join('/'))
+  return [args, setArgs]
+}
+
 // Used during the template selection phase, since we don’t know yet what are
 // going to be the configuration steps.
 const CONFIGURE_PLACEHOLDER_SCREENS = [
@@ -70,6 +76,10 @@ function useConfigureState(templates, onScreenUpdate) {
   // The data stored by the configuration screens
   const [templateData, setTemplateData] = useState({})
 
+  // The template name requested through URL
+  const [args] = useRouterArgs(location)
+  const templateUrl = args[2]
+
   const updateTemplateScreen = useCallback(
     (templateId, screenIndex = 0) => {
       const template = getTemplateById(templates, templateId)
@@ -98,11 +108,19 @@ function useConfigureState(templates, onScreenUpdate) {
       templateScreenIndex,
     } = loadTemplateState()
 
-    if (templateId) {
+    const templateUrlFound = templates.find(
+      template =>
+        template.name.toLowerCase() === decodeURIComponent(templateUrl)
+    )
+    // A must be false or == b
+    if (
+      templateId &&
+      (!templateUrlFound || templateId === templateUrlFound.id)
+    ) {
       updateTemplateScreen(templateId, templateScreenIndex)
       setTemplateData(templateData)
     }
-  }, [updateTemplateScreen])
+  }, [templateUrl, templates, updateTemplateScreen])
 
   // Save the template state
   useEffect(() => {
@@ -131,7 +149,7 @@ function useConfigureState(templates, onScreenUpdate) {
         Math.min(template.screens.length, updatedScreenIndex)
       )
     },
-    [updateTemplateScreen, templateScreenIndex, template]
+    [templateScreenIndex, template, updateTemplateScreen]
   )
 
   const prevScreen = useCallback(() => {

--- a/src/onboarding/Create/Create.js
+++ b/src/onboarding/Create/Create.js
@@ -30,11 +30,7 @@ import {
   STATUS_DEPLOYMENT,
 } from './create-statuses'
 
-function useRouterArgs(location) {
-  const args = location.hash.split('/')
-  const setArgs = args => history.pushState(null, null, '#' + args.join('/'))
-  return [args, setArgs]
-}
+import { useRouterArgs } from '../../routing'
 
 // Used during the template selection phase, since we don’t know yet what are
 // going to be the configuration steps.

--- a/src/onboarding/Templates/Templates.js
+++ b/src/onboarding/Templates/Templates.js
@@ -44,7 +44,7 @@ function Templates({ onUse, templates }) {
   const handleDetailsClose = useCallback(() => {
     setArgs(['create'])
     setTemplateDetailsOpened(false)
-  }, [])
+  }, [setArgs])
 
   const handleDetailsUse = useCallback(
     (id, optionalApps) => {

--- a/src/onboarding/Templates/Templates.js
+++ b/src/onboarding/Templates/Templates.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { GU } from '@aragon/ui'
 import Carousel from '../../components/Carousel/Carousel'
@@ -6,19 +6,43 @@ import Header from '../Header/Header'
 import TemplateCard from './TemplateCard'
 import TemplateDetails from './TemplateDetails'
 
+// TODO: Make that generic
+function useRouterArgs(location) {
+  const args = location.hash.split('/')
+  const setArgs = args => history.pushState(null, null, '#/' + args.join('/'))
+  return [args, setArgs]
+}
+
 function Templates({ onUse, templates }) {
   const [templateDetailsOpened, setTemplateDetailsOpened] = useState(false)
   const [templateDetailsIndex, setTemplateDetailsIndex] = useState(0)
 
+  const [args, setArgs] = useRouterArgs(location)
+  const templateUrl = args[2]
+
+  useEffect(() => {
+    const templateIndex = templates.findIndex(
+      t => t.name.toLowerCase() === decodeURIComponent(templateUrl)
+    )
+    if (templateIndex !== -1) {
+      setTemplateDetailsIndex(templateIndex)
+      setTemplateDetailsOpened(true)
+    }
+  }, [templates, templateUrl])
+
   const handleOpen = useCallback(
     id => {
-      setTemplateDetailsIndex(templates.findIndex(t => t.id === id))
+      const templateIndex = templates.findIndex(t => t.id === id)
+      const template = templates[templateIndex]
+      setTemplateDetailsIndex(templateIndex)
       setTemplateDetailsOpened(true)
+      setArgs(['create', encodeURIComponent(template.name.toLowerCase())])
     },
-    [templates]
+    [setArgs, templates]
   )
 
   const handleDetailsClose = useCallback(() => {
+    setArgs(['create'])
     setTemplateDetailsOpened(false)
   }, [])
 

--- a/src/routing.js
+++ b/src/routing.js
@@ -158,3 +158,9 @@ export function getPreferencesSearch(screen, { labels } = {}) {
 
   return search
 }
+
+export function useRouterArgs(location) {
+  const args = location.hash.split('/')
+  const setArgs = args => history.pushState(null, null, '#/' + args.join('/'))
+  return [args, setArgs]
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1237971/68085024-a5cd6780-fe33-11e9-8fea-045b4cbef032.png)

This PR fixes #1131. It adds a routing parameter to `create/$template` and allow one to point directly to a template.

**Details**

- This adds a `useRouterArgs()` hooks to extract URL parameters from the hash.
- This is used in `onboarding/Templates/Templates.js` to open the right TemplateDetail component.
- This reset the URL to `#/create` when closing a template.
- This modify the behaviour when clicking on the Back button - the Details will stay opened, which makes sense from a history point of view.

- Once `#/create` is opened, it only check that metamask is connected, not that the fund are there nor the network. This is out-of-scope of this issue imo, but this have to be fixed. Network guard is proposed in #1139 

DEMO here: https://youtu.be/M3_CkTjAdGo <3