### PR TITLE
Permissions: fix a crash when an app is active during load

### DIFF
--- a/src/apps/Permissions/AppPermissions.js
+++ b/src/apps/Permissions/AppPermissions.js
@@ -15,16 +15,20 @@ function AppPermissions({
 }) {
   const permissions = usePermissionsByRole()
 
+  const appProxyAddress = app ? app.proxyAddress : null
+
   const appPermissions = useMemo(
     () =>
-      permissions.filter(
-        permission =>
-          permission.app && permission.app.proxyAddress === app.proxyAddress
-      ),
-    [permissions, app.proxyAddress]
+      appProxyAddress
+        ? permissions.filter(
+            permission =>
+              permission.app && permission.app.proxyAddress === appProxyAddress
+          )
+        : [],
+    [permissions, appProxyAddress]
   )
 
-  if (loading) {
+  if (loading || !appProxyAddress) {
     return <EmptyBlock>Loading permissions…</EmptyBlock>
   }
 


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/1158

The passed `app` object can be undefined, which now shows the loading state.

