### PR TITLE
OrgIcon: fix border radius in Chrome

### DIFF
--- a/src/components/OrgIcon/OrgIcon.js
+++ b/src/components/OrgIcon/OrgIcon.js
@@ -20,7 +20,6 @@ function OrgIcon({ orgAddress, size }) {
         display: inline-flex;
         justify-content: center;
         align-items: center;
-        border-radius: ${!knownOrgImage ? '50%' : '0'};
       `}
     >
       {knownOrgImage ? (
@@ -32,7 +31,12 @@ function OrgIcon({ orgAddress, size }) {
           css="object-fit: contain"
         />
       ) : (
-        <EthIdenticon address={orgAddress} />
+        <EthIdenticon
+          address={orgAddress}
+          css={`
+            border-radius: 50%;
+          `}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
Chrome seems to have introduced a bug where setting a `mask-image` results in a higher-level overflow to not work (see rinkeby.aragon.org with latest Chrome).

This moves the border-radius to be applied directly at the level that the `mask-image` is applied.