### PR TITLE
ESLint: error on react hook dependency issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   rules: {
     'react/prop-types': 'warn',
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
     'import/no-unresolved': [
       'error',
       { ignore: ['^react(-dom)?$', '^styled-components$'] },


### PR DESCRIPTION
I think we may have introduced this rule with a warning initially to avoid having to fix all of them in one go, but we've now either set up specific areas to ignore, or have already fixed all of them so we should lift it up to be an error :).