### PR TITLE
Automatically open the system menu when a system app instance is active

### DIFF
--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -65,12 +65,42 @@ function MenuPanel({
   const [systemAppsOpened, setSystemAppsOpened] = useState(
     systemAppsOpenedState.isOpen()
   )
-  const [systemAppsToggled, setSystemAppsToggled] = useState(false)
+  const [showSystemsAppsAnimation, setShowSystemsAppsAnimation] = useState(
+    false
+  )
+
+  const appGroups = useMemo(
+    () =>
+      appInstanceGroups
+        .filter(appGroup => appGroup.hasWebApp)
+        .map(appGroup => ({
+          ...appGroup,
+          icon: <AppIcon app={appGroup.app} />,
+        })),
+    [appInstanceGroups]
+  )
+
+  const showConsole = consoleVisible || activeInstanceId === 'console'
+  const menuApps = [APP_HOME, appGroups]
+  const systemApps = [
+    APP_PERMISSIONS,
+    APP_APPS_CENTER,
+    APP_ORGANIZATION,
+    ...(showConsole ? [APP_CONSOLE] : []),
+  ]
+
+  const isSystemAppActive = useMemo(
+    () => systemApps.some(systemApp => systemApp.appId === activeInstanceId),
+    [activeInstanceId, systemApps]
+  )
 
   const handleToggleSystemApps = useCallback(() => {
-    setSystemAppsOpened(opened => !opened)
-    systemAppsOpenedState.set(!systemAppsOpenedState.isOpen())
-    setSystemAppsToggled(true)
+    setSystemAppsOpened(opened => {
+      const openedState = !opened
+      systemAppsOpenedState.set(openedState)
+      return openedState
+    })
+    setShowSystemsAppsAnimation(true)
   }, [])
 
   const renderAppGroup = useCallback(
@@ -126,34 +156,12 @@ function MenuPanel({
     [appsStatus, activeInstanceId, renderAppGroup]
   )
 
-  const appGroups = useMemo(
-    () =>
-      appInstanceGroups
-        .filter(appGroup => appGroup.hasWebApp)
-        .map(appGroup => ({
-          ...appGroup,
-          icon: <AppIcon app={appGroup.app} />,
-        })),
-    [appInstanceGroups]
-  )
-
-  const showConsole = consoleVisible || activeInstanceId === 'console'
-  const menuApps = [APP_HOME, appGroups]
-  const systemApps = [
-    APP_PERMISSIONS,
-    APP_APPS_CENTER,
-    APP_ORGANIZATION,
-    ...(showConsole ? [APP_CONSOLE] : []),
-  ]
-
-  // Automatically open the menu if a system app instance is active
   useEffect(() => {
-    const isSystemAppActive =
-      systemApps.some(systemApp => systemApp.appId === activeInstanceId) ||
-      systemAppsOpenedState.isOpen()
-    setSystemAppsOpened(isSystemAppActive)
-    setSystemAppsToggled(true)
-  }, [systemApps, activeInstanceId, systemAppsToggled, systemAppsOpened])
+    // Automatically toggle the system apps menu if a system app is activated/deactivated
+    // If the user has manually opened the system apps menu, keep it open
+    setSystemAppsOpened(isSystemAppActive || systemAppsOpenedState.isOpen())
+    setShowSystemsAppsAnimation(true)
+  }, [isSystemAppActive])
 
   return (
     <Main>
@@ -200,7 +208,7 @@ function MenuPanel({
             config={springs.smooth}
             from={{ openProgress: 0 }}
             to={{ openProgress: Number(systemAppsOpened) }}
-            immediate={!systemAppsToggled}
+            immediate={!showSystemsAppsAnimation}
             native
           >
             {({ openProgress }) => (

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -145,6 +145,15 @@ function MenuPanel({
     ...(showConsole ? [APP_CONSOLE] : []),
   ]
 
+  // Automatically open the menu if a system app instance is active
+  useEffect(() => {
+    const isSystemAppActive =
+      systemApps.some(systemApp => systemApp.appId === activeInstanceId) ||
+      systemAppsOpened
+    setSystemAppsOpened(isSystemAppActive)
+    setSystemAppsToggled(true)
+  }, [systemApps, activeInstanceId, systemAppsToggled, systemAppsOpened])
+
   return (
     <Main>
       <div

--- a/src/components/MenuPanel/MenuPanel.js
+++ b/src/components/MenuPanel/MenuPanel.js
@@ -69,6 +69,7 @@ function MenuPanel({
 
   const handleToggleSystemApps = useCallback(() => {
     setSystemAppsOpened(opened => !opened)
+    systemAppsOpenedState.set(!systemAppsOpenedState.isOpen())
     setSystemAppsToggled(true)
   }, [])
 
@@ -149,7 +150,7 @@ function MenuPanel({
   useEffect(() => {
     const isSystemAppActive =
       systemApps.some(systemApp => systemApp.appId === activeInstanceId) ||
-      systemAppsOpened
+      systemAppsOpenedState.isOpen()
     setSystemAppsOpened(isSystemAppActive)
     setSystemAppsToggled(true)
   }, [systemApps, activeInstanceId, systemAppsToggled, systemAppsOpened])


### PR DESCRIPTION
- Opens the system menu when one of the corresponding app instances becomes active.
Closes #1224 

