### PR TITLE
chore: update manifest's start_url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
     "src": "images/icon.png",
     "sizes": "192x192"
   }],
-  "start_url": "/build/index.html"
+  "start_url": "index.html"
 }


### PR DESCRIPTION
I think this has changed since a long time ago, but might as well update it since the `index.html` is now in the root of the deployed folder.