### PR TITLE
guiStyle: fix logic for setting initial guiStyle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -100,7 +100,7 @@ class App extends React.Component {
     })
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const { clientTheme, walletAccount } = this.props
     const { wrapper } = this.state
 
@@ -110,7 +110,7 @@ class App extends React.Component {
 
     if (
       wrapper &&
-      (!prevProps.wrapper || clientTheme !== prevProps.clientTheme)
+      (!prevState.wrapper || clientTheme !== prevProps.clientTheme)
     ) {
       wrapper.setGuiStyle(clientTheme.appearance, clientTheme.theme)
     }


### PR DESCRIPTION
Oops, I think `wrapper` is never passed as props in `App.js` so I think this is what we actually meant?