### PR TITLE
SignerPanel: Add warning for some Ethereum providers marking second+ transactions as potentially failing

### DIFF
--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -284,14 +284,28 @@ class ActionPathsContent extends React.Component {
         {pretransaction && (
           <Info
             title="Two transactions required"
+            mode="warning"
             css={`
               margin-top: ${3 * GU}px;
             `}
           >
-            This action requires two transactions to be signed in{' '}
-            {getProviderString('your Ethereum provider', walletProviderId)}.{' '}
-            {approveTransactionMessage}
-            Please confirm them one after another.
+            <p>
+              This action requires two transactions to be signed in{' '}
+              {getProviderString('your Ethereum provider', walletProviderId)}.{' '}
+              {approveTransactionMessage}
+              Please confirm them one after another.
+            </p>
+            <p
+              css={`
+                margin-top: ${1 * GU}px;
+              `}
+            >
+              In some situations,{' '}
+              {getProviderString('your Ethereum provider', walletProviderId)}{' '}
+              may warn you that the second transaction will fail.{' '}
+              <strong css="font-weight: 800">Please ignore this warning</strong>
+              .
+            </p>
           </Info>
         )}
         <SignerButton onClick={this.handleSign} disabled={!signingEnabled}>


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/1244 (quick fix to warn users).

<img width="432" alt="Screen Shot 2020-01-23 at 8 46 08 PM" src="https://user-images.githubusercontent.com/4166642/73018199-68b8b600-3e21-11ea-8bc4-3972a860c952.png">