### PR TITLE
Onboarding: small fixes to slippage tooltips

### DIFF
--- a/src/templates/kit/screens/FundraisingScreen.js
+++ b/src/templates/kit/screens/FundraisingScreen.js
@@ -714,6 +714,17 @@ function FundraisingScreen({
                   />
                 )}
               </InlineField>
+              <InlineField label={<SlippageLabel slippageToken="ANT" />}>
+                {({ id }) => (
+                  <ConfigInput
+                    id={id}
+                    label="%"
+                    onChange={bindUpdate('slippageAnt')}
+                    value={fields.slippageAnt}
+                    width={INPUT_MEDIUM}
+                  />
+                )}
+              </InlineField>
             </div>
           </Section>
         </div>
@@ -846,7 +857,7 @@ function SlippageLabel({ slippageToken }) {
   return (
     <React.Fragment>
       {slippageToken} slippage %
-      <Help hint="What’s the DAI slippage %?">
+      <Help hint={`What’s the ${slippageToken} slippage %?`}>
         <p>
           <strong>{slippageToken} slippage %</strong> defines the maximum price
           slippage in {slippageToken} that may occur on orders during any given

--- a/src/templates/kit/screens/FundraisingScreen.js
+++ b/src/templates/kit/screens/FundraisingScreen.js
@@ -714,17 +714,6 @@ function FundraisingScreen({
                   />
                 )}
               </InlineField>
-              <InlineField label={<SlippageLabel slippageToken="ANT" />}>
-                {({ id }) => (
-                  <ConfigInput
-                    id={id}
-                    label="%"
-                    onChange={bindUpdate('slippageAnt')}
-                    value={fields.slippageAnt}
-                    width={INPUT_MEDIUM}
-                  />
-                )}
-              </InlineField>
             </div>
           </Section>
         </div>
@@ -856,7 +845,7 @@ function ConfigInput({
 function SlippageLabel({ slippageToken }) {
   return (
     <React.Fragment>
-      DAI slippage %
+      {slippageToken} slippage %
       <Help hint="What’s the DAI slippage %?">
         <p>
           <strong>{slippageToken} slippage %</strong> defines the maximum price


### PR DESCRIPTION
Hey there were a small typo on the `SlippageLabel` that always show DAI as preview message.

Also I notice there is a Slippage form for ANT but there is no ANT functionality yet. Is it necessary?