### PR TITLE
docs: warn dev when starting mainnet locally to use a different ETH node

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -7,6 +7,31 @@ const execute = require('child_process').execSync
 
 const clientPort = process.env.ARAGON_PORT || process.env.REACT_APP_PORT || 3000
 
+if (
+  process.env.ARAGON_ETH_NETWORK_TYPE === 'main' &&
+  !process.env.ARAGON_DEFAULT_ETH_NODE
+) {
+  console.log(
+    '⚠️  You are connecting the Aragon client to mainnet but have not specified an Ethereum node.'
+  )
+  console.log(
+    '    Connecting to the default node (wss://mainnet.eth.aragon.network/ws) in a local'
+  )
+  console.log(
+    '    environment may result in severe slowdowns when trying to fetch Ethereum events or state.'
+  )
+  console.log()
+  console.log(
+    "➡️  During development, it is recommended to override the 'ARAGON_DEFAULT_ETH_NODE' environment"
+  )
+  console.log(
+    '    variable with an Infura (infura.io) mainnet node to accelerate loading Ethereum events and state.'
+  )
+  console.log(
+    '    You may do so by directly setting an environment variable or by using a .env file.'
+  )
+}
+
 execute(`copy-aragon-ui-assets -n aragon-ui ./public`, {
   stdio: 'inherit',
 })


### PR DESCRIPTION
We have degraded `wss://mainnet.eth.aragon.network/ws` connections on non-whitelisted domains, so it is very likely that developers connecting to mainnet will experience very slow loading.

In lieu of a better immediate fix, this provides some warning to the developer that they should override these configs via environment variables.

cc @Evalir 

![Screen Shot 2020-02-19 at 2 34 26 AM](https://user-images.githubusercontent.com/4166642/74793355-603c8980-52c0-11ea-84fb-ce173575fed1.png)
