### PR TITLE
Connect modal: let users close the modal and use the account module

### DIFF
--- a/src/components/ConnectModal/ConnectModal.js
+++ b/src/components/ConnectModal/ConnectModal.js
@@ -3,21 +3,18 @@ import PropTypes from 'prop-types'
 import {
   Button,
   GU,
-  IconConnect,
   Link,
   Modal,
   textStyle,
   useTheme,
   useViewport,
 } from '@aragon/ui'
-import { useWallet } from '../../wallet'
 import providersImage from './assets/providers.png'
 
 function ConnectModal({ account, onClose, onConnect, visible }) {
   const theme = useTheme()
   const { below } = useViewport()
   const smallMode = below('medium')
-  const wallet = useWallet()
 
   const modalWidth = useCallback(
     ({ width }) => Math.min(55 * GU, width - 4 * GU),
@@ -92,13 +89,7 @@ function ConnectModal({ account, onClose, onConnect, visible }) {
             `}
           />
         </div>
-        <Button
-          icon={<IconConnect />}
-          label="Connect account"
-          mode="strong"
-          onClick={() => wallet.activate()}
-          wide
-        />
+        <Button label="Close" mode="strong" onClick={onClose} wide />
       </section>
     </Modal>
   )


### PR DESCRIPTION
The connect modal was only connecting to the injected provider, and not intercepting errors.

This change removes any connection attempt from the modal, and invite users to close it so they can use the account module instead.

![image](https://user-images.githubusercontent.com/36158/75176147-85e7e980-572b-11ea-8041-a189dc6e8515.png)
