### PR TITLE
GlobalPreferences: clean up search handlers for local identities

### DIFF
--- a/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
+++ b/src/components/GlobalPreferences/CustomLabels/CustomLabels.js
@@ -17,7 +17,6 @@ function CustomLabels({ wrapper, dao, locator }) {
   const {
     filteredIdentities,
     handleSearchTermChange,
-    onSearchTerm,
     searchTerm,
   } = useFilterIdentities(identities)
   const {
@@ -77,7 +76,6 @@ function CustomLabels({ wrapper, dao, locator }) {
           onImport={handleImport}
           onRemove={handleRemoveModalOpen}
           onSearchChange={handleSearchTermChange}
-          onSearchTerm={onSearchTerm}
           onShare={handleShareModalOpen}
           onToggleAll={handleToggleAll}
           onToggleIdentity={handleToggleIdentity}

--- a/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/LocalIdentities.js
@@ -35,7 +35,6 @@ const LocalIdentities = React.memo(function LocalIdentities({
   onImport,
   onRemove,
   onSearchChange,
-  onSearchTerm,
   onShare,
   onShowLocalIdentityModal,
   onToggleAll,
@@ -69,7 +68,6 @@ const LocalIdentities = React.memo(function LocalIdentities({
           <Filters
             searchTerm={searchTerm}
             onSearchChange={onSearchChange}
-            onSearchTerm={onSearchTerm}
             onImport={onImport}
             onShare={onShare}
             onExport={onExport}
@@ -175,7 +173,6 @@ LocalIdentities.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
-  onSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   onShowLocalIdentityModal: PropTypes.func.isRequired,
   onToggleAll: PropTypes.func.isRequired,
@@ -191,7 +188,6 @@ const Filters = React.memo(function Filters({
   onImport,
   onRemove,
   onSearchChange,
-  onSearchTerm,
   onShare,
   searchTerm,
   someSelected,
@@ -238,7 +234,6 @@ Filters.propTypes = {
   onImport: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func.isRequired,
-  onSearchTerm: PropTypes.func.isRequired,
   onShare: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   someSelected: PropTypes.bool.isRequired,

--- a/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
+++ b/src/components/GlobalPreferences/CustomLabels/useFilterIdentities.js
@@ -19,7 +19,6 @@ function useFilterIdentities(identities) {
     filteredIdentities,
     handleSearchTermChange: setSearchTerm,
     searchTerm,
-    onSearchTerm: setSearchTerm,
   }
 }
 


### PR DESCRIPTION
This seems like something the linter would pick up as an unused variable, but maybe it doesn't do that for unused props.

We had duplicated the export of `setSearchTerm` as `handleSearchTermChange` previously expected an event object.