### PR TITLE
GlobalPreferences: remove focus outline

### DIFF
--- a/src/components/GlobalPreferences/GlobalPreferences.js
+++ b/src/components/GlobalPreferences/GlobalPreferences.js
@@ -89,7 +89,7 @@ function GlobalPreferences({
   }, [])
 
   return (
-    <div ref={container} tabIndex="0">
+    <div ref={container} tabIndex="0" css="outline: 0">
       <Layout css="z-index: 2">
         <Close
           compact={compact}


### PR DESCRIPTION
At least on Chrome browsers, the GlobalPreferences modal would show the default native focus outline if it was short enough (e.g. on an unpopulated local labels tab).