### PR TITLE
AccountModule: Fix providers component display 

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
     "moduleNameMapper": {
       "\\.(svg|png)$": "<rootDir>/src/test/empty-string.js"
     },
-    "moduleDirectories": ["<rootDir>/node_modules"]
+    "moduleDirectories": [
+      "<rootDir>/node_modules"
+    ]
   }
 }

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -66,7 +66,7 @@ export const networkConfigs = {
       shortName: 'Ropsten',
       type: 'ropsten', // as returned by web3.eth.net.getNetworkType()
     },
-    providers: ['injected', 'frame'],
+    providers: [{ id: 'injected' }, { id: 'frame' }],
   },
   local: {
     addresses: {
@@ -80,7 +80,7 @@ export const networkConfigs = {
       shortName: 'Local',
       type: 'private',
     },
-    providers: ['injected', 'frame'],
+    providers: [{ id: 'injected' }, { id: 'frame' }],
   },
   unknown: {
     addresses: {
@@ -94,7 +94,7 @@ export const networkConfigs = {
       shortName: 'Unknown',
       type: 'unknown',
     },
-    providers: ['injected', 'frame'],
+    providers: [{ id: 'injected' }, { id: 'frame' }],
   },
 }
 


### PR DESCRIPTION
When run locally, the providers component didn't display the icons properly:

<img width="437" alt="Screen Shot 2020-03-19 at 8 32 22 PM" src="https://user-images.githubusercontent.com/642515/77130009-95a5d580-6a2c-11ea-9b9c-c09bb4d1a42c.png">


The problem was in the `networkConfigs` variable where providers have to be arrays of objects instead of arrays of strings.

Thanks @Evalir for the help! 🙌 