### PR TITLE
Ethereum: add built-in delay for received events on real networks

### DIFF
--- a/now-mainnet.json
+++ b/now-mainnet.json
@@ -8,7 +8,8 @@
       "ARAGON_ETH_NETWORK_TYPE": "main",
       "ARAGON_FORTMATIC_API_KEY": "@aragon-client-fortmatic-api-key",
       "ARAGON_PORTIS_DAPP_ID": "@aragon-client-portis-dapp-id",
-      "ARAGON_SENTRY_DSN": "@aragon-client-sentry-dsn"
+      "ARAGON_SENTRY_DSN": "@aragon-client-sentry-dsn",
+      "ARAGON_ETH_SUBSCRIPTION_EVENT_DELAY": "5000"
     }
   }
 }

--- a/now.json
+++ b/now.json
@@ -10,7 +10,8 @@
     "env": {
       "ARAGON_FORTMATIC_API_KEY": "@aragon-client-fortmatic-testnet-api-key",
       "ARAGON_PORTIS_DAPP_ID": "@aragon-client-portis-dapp-id",
-      "ARAGON_SENTRY_DSN": "@aragon-client-sentry-dsn"
+      "ARAGON_SENTRY_DSN": "@aragon-client-sentry-dsn",
+      "ARAGON_ETH_SUBSCRIPTION_EVENT_DELAY": "3000"
     }
   }
 }

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -112,7 +112,8 @@ export function getEthNetworkType() {
 }
 
 export function getEthSubscriptionEventDelay() {
-  return getLocalSetting(ETH_SUBSCRIPTION_EVENT_DELAY) || 0
+  const delay = parseInt(getLocalSetting(ETH_SUBSCRIPTION_EVENT_DELAY), 10)
+  return Number.isFinite(delay) ? delay : 0
 }
 
 export function getIpfsGateway() {


### PR DESCRIPTION
Re-applies the change in https://github.com/aragon/aragon/pull/887 and https://github.com/aragon/aragon/pull/890.

Unfortunately, we are still seeing race conditions in our ETH nodes, and this "hotfix" looks like it will have to stay for a while.

The problem manifests itself as:

1. Ethereum event is sent
2. `eth_call`s to fetch state on this event fail
3. An indeterminate amount of time passes before these `eth_call`s work

In an app, like Voting, this usually results in state not being updated correctly because it couldn't find the required information through `eth_call`s.

We have built-in retry logic into our apps to help catch these, but they look like they're still not enough :(.