### PR TITLE
Documentation: Add console documentation link

### DIFF
--- a/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
+++ b/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
@@ -112,10 +112,12 @@ function HelpAndFeedback({ historyPush, locator, onClose }) {
           <Info>
             The embedded console lets you interact with your organization as you
             would with aragonCLI, but inside the frontend client. Please note
-            that this feature is highly experimental. Documentation about the
-            console is available{' '}
-            <Link href="https://github.com/aragon/aragon/blob/master/docs/CONSOLE.md">
-              here
+            that this feature is highly experimental. Please read the{' '}
+            <Link
+              external
+              href="https://github.com/aragon/aragon/blob/master/docs/CONSOLE.md"
+            >
+              documentation
             </Link>
             .
           </Info>

--- a/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
+++ b/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
@@ -110,16 +110,24 @@ function HelpAndFeedback({ historyPush, locator, onClose }) {
             </span>
           </label>
           <Info>
-            The embedded console lets you interact with your organization as you
-            would with aragonCLI, but inside the frontend client. Please note
-            that this feature is highly experimental. Please read the{' '}
-            <Link
-              external
-              href="https://github.com/aragon/aragon/blob/master/docs/CONSOLE.md"
+            <p>
+              The embedded console lets you interact with your organization as
+              you would with aragonCLI, but inside the frontend client.
+            </p>
+            <p
+              css={`
+                margin-top: ${1 * GU}px;
+              `}
             >
-              documentation
-            </Link>
-            .
+              Note that this feature is currently experimental. Please read the{' '}
+              <Link
+                external
+                href="https://github.com/aragon/aragon/blob/master/docs/CONSOLE.md"
+              >
+                documentation
+              </Link>
+              .
+            </p>
           </Info>
         </div>
       </Box>

--- a/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
+++ b/src/components/GlobalPreferences/HelpAndFeedback/HelpAndFeedback.js
@@ -112,7 +112,12 @@ function HelpAndFeedback({ historyPush, locator, onClose }) {
           <Info>
             The embedded console lets you interact with your organization as you
             would with aragonCLI, but inside the frontend client. Please note
-            that this feature is highly experimental.
+            that this feature is highly experimental. Documentation about the
+            console is available{' '}
+            <Link href="https://github.com/aragon/aragon/blob/master/docs/CONSOLE.md">
+              here
+            </Link>
+            .
           </Info>
         </div>
       </Box>


### PR DESCRIPTION
Spring Cleaning 🌸, closing #1332 

We probably may want to quickly check up with @dizzypaty on this, but, I believe a good place to link to the documentation, is where you "activate" the console itself. Let me know what you think!