### PR TITLE
Environment: Allow ENS_REGISTRY_ADDRESS customization for buidler-aragon

### DIFF
--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -64,7 +64,9 @@ const CONFIGURATION_VARS = [
     ...acc,
     [option]: {
       storageKey: `${option}_KEY`,
-      envValue: envValues.reduce((prevVal, envValue) => prevVal || envValue),
+      envValue: envValues.reduce(
+        (prevVal, envValue) => prevVal || envValue || null
+      ),
     },
   }),
   {}

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -26,6 +26,7 @@ const CONFIGURATION_VARS = [
   ],
   [
     ENS_REGISTRY_ADDRESS,
+    getUrlParam('ens'),
     process.env.ARAGON_ENS_REGISTRY_ADDRESS,
     process.env.REACT_APP_ENS_REGISTRY_ADDRESS,
   ],
@@ -59,15 +60,20 @@ const CONFIGURATION_VARS = [
   [PORTIS_DAPP_ID, process.env.ARAGON_PORTIS_DAPP_ID],
   [FORTMATIC_API_KEY, process.env.ARAGON_FORTMATIC_API_KEY],
 ].reduce(
-  (acc, [option, envValue, envValueCompat]) => ({
+  (acc, [option, ...envValues]) => ({
     ...acc,
     [option]: {
       storageKey: `${option}_KEY`,
-      envValue: envValue || envValueCompat || null,
+      envValue: envValues.reduce((prevVal, envValue) => prevVal || envValue),
     },
   }),
   {}
 )
+
+// Get a search param from the location's hash
+function getUrlParam(paramName) {
+  return new URLSearchParams(window.location.hash.split('?')[1]).get(paramName)
+}
 
 // Get a setting from localStorage
 function getLocalStorageSetting(confKey) {


### PR DESCRIPTION
Allows customization of the `ENS_REGISTRY_ADDRESS`  with search params

This feature is necessary for the buidler-aragon plugin which may set up a different ENS address from the one that came prebuilt with aragen.

http://localhost:3000/#/hive?ens=0xc5De217D29A8B970d7Bd9BDb779948b9B01361F6

- I've picked the search param name `ens` for shortness but it could be changed if necessary.
- I've added a second reduce function to allow an arbitrary number of possible values instead of just two.


