### PR TITLE
Permissions: Add "any account" warning when using safe address

### DIFF
--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, DropDown, Info, Field, SidePanel, GU } from '@aragon/ui'
+import { ANY_ENTITY } from '../../permissions'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
 import { AppType, AragonType } from '../../prop-types'
 import { isAddress, isEmptyAddress } from '../../web3-utils'
@@ -13,8 +14,6 @@ const DEFAULT_STATE = {
   appIndex: -1,
   roleIndex: -1,
 }
-
-const ANY_ACCOUNT_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 
 // The permission panel, wrapped in a PermissionsContext (see end of file)
 class AssignPermissionPanel extends React.PureComponent {
@@ -198,7 +197,7 @@ class AssignPermissionPanel extends React.PureComponent {
             {'Add permission'}
           </Button>
 
-          {this.state.assignEntityAddress === ANY_ACCOUNT_ADDRESS && (
+          {this.state.assignEntityAddress === ANY_ENTITY && (
             <Info
               mode="warning"
               css={`

--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -14,6 +14,8 @@ const DEFAULT_STATE = {
   roleIndex: -1,
 }
 
+const ANY_ACCOUNT_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+
 // The permission panel, wrapped in a PermissionsContext (see end of file)
 class AssignPermissionPanel extends React.PureComponent {
   static propTypes = {
@@ -195,6 +197,18 @@ class AssignPermissionPanel extends React.PureComponent {
           >
             {'Add permission'}
           </Button>
+
+          {this.state.assignEntityAddress === ANY_ACCOUNT_ADDRESS && (
+            <Info
+              mode="warning"
+              css={`
+                margin-top: ${3 * GU}px;
+              `}
+            >
+              Be aware that assigning the permission to this address will let
+              anyone perform this action.
+            </Info>
+          )}
 
           <Info
             title="Adding the permission might create a vote"

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -11,7 +11,7 @@ import {
   breakpoint,
 } from '@aragon/ui'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
-import { isBurnEntity } from '../../permissions'
+import { ANY_ENTITY, isBurnEntity } from '../../permissions'
 import { AppType, AragonType } from '../../prop-types'
 import { isAddress, isEmptyAddress } from '../../web3-utils'
 import LocalLabelAppBadge from '../../components/LocalLabelAppBadge/LocalLabelAppBadge'
@@ -23,8 +23,6 @@ const VIEW_PERMISSION = Symbol('VIEW_PERMISSION')
 const NO_UPDATE_ACTION = Symbol('NO_UPDATE_ACTION')
 const SET_PERMISSION_MANAGER = Symbol('SET_PERMISSION_MANAGER')
 const REMOVE_PERMISSION_MANAGER = Symbol('REMOVE_PERMISSION_MANAGER')
-
-const ANY_ACCOUNT_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 
 const UPDATE_ACTIONS = new Map([
   [NO_UPDATE_ACTION, { label: 'Select an update', message: null }],
@@ -269,7 +267,7 @@ class ManageRolePanel extends React.PureComponent {
     const action = this.getCurrentAction()
     const isUpdateAction = UPDATE_ACTIONS.has(action)
     const message = this.getMessage(action)
-    console.log(this.state.assignEntityAddress)
+
     return (
       <SidePanel
         title={
@@ -358,8 +356,8 @@ class ManageRolePanel extends React.PureComponent {
             </Button>
           )}
 
-          {(this.state.newRoleManagerValue === ANY_ACCOUNT_ADDRESS ||
-            this.state.assignEntityAddress === ANY_ACCOUNT_ADDRESS) && (
+          {(this.state.newRoleManagerValue === ANY_ENTITY ||
+            this.state.assignEntityAddress === ANY_ENTITY) && (
             <Info
               mode="warning"
               css={`

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -269,7 +269,7 @@ class ManageRolePanel extends React.PureComponent {
     const action = this.getCurrentAction()
     const isUpdateAction = UPDATE_ACTIONS.has(action)
     const message = this.getMessage(action)
-
+    console.log(this.state.assignEntityAddress)
     return (
       <SidePanel
         title={
@@ -358,14 +358,16 @@ class ManageRolePanel extends React.PureComponent {
             </Button>
           )}
 
-          {this.state.newRoleManagerValue === ANY_ACCOUNT_ADDRESS && (
+          {(this.state.newRoleManagerValue === ANY_ACCOUNT_ADDRESS ||
+            this.state.assignEntityAddress === ANY_ACCOUNT_ADDRESS) && (
             <Info
               mode="warning"
               css={`
                 margin-top: ${3 * GU}px;
               `}
             >
-              Be aware that using this address will let anyone manage this
+              Be aware that assigning the permission or manager role to this
+              address will let anyone perform this action or manage this
               permission.
             </Info>
           )}

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -24,6 +24,8 @@ const NO_UPDATE_ACTION = Symbol('NO_UPDATE_ACTION')
 const SET_PERMISSION_MANAGER = Symbol('SET_PERMISSION_MANAGER')
 const REMOVE_PERMISSION_MANAGER = Symbol('REMOVE_PERMISSION_MANAGER')
 
+const ANY_ACCOUNT_ADDRESS = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+
 const UPDATE_ACTIONS = new Map([
   [NO_UPDATE_ACTION, { label: 'Select an update', message: null }],
   [
@@ -354,6 +356,18 @@ class ManageRolePanel extends React.PureComponent {
             >
               {isUpdateAction ? 'Update permission' : 'Initialize permission'}
             </Button>
+          )}
+
+          {this.state.newRoleManagerValue === ANY_ACCOUNT_ADDRESS && (
+            <Info
+              mode="warning"
+              css={`
+                margin-top: ${3 * GU}px;
+              `}
+            >
+              Be aware that using this address will let anyone manage this
+              permission.
+            </Info>
           )}
 
           {message && (

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -6,7 +6,7 @@ import { addressesEqual } from './web3-utils'
 //               that permission
 //   Burn entity: If a role's permission manager is set as "burn entity", then it is assumed to be a
 //               discarded and frozen role
-const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+export const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 const BURN_ENTITY = '0x0000000000000000000000000000000000000001'
 const UNASSIGNED_ENTITY = '0x0000000000000000000000000000000000000000'
 const KERNEL_ROLES = [


### PR DESCRIPTION
Spring cleaning 🌸, closing #969 .

> ...And you will their engineer, your code will be their shield and your PR... their sword. You will remain... online... for your fight... is eternal.

Adds a warning when using the "safe address" `0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF`, in the permission panels. Screenshots:

<img width="1680" alt="Screen Shot 2020-04-03 at 4 49 04 PM" src="https://user-images.githubusercontent.com/26014927/78404232-f1936100-75cb-11ea-928f-be558d4f45ae.png">

<img width="1680" alt="Screen Shot 2020-04-03 at 4 39 43 PM" src="https://user-images.githubusercontent.com/26014927/78404240-f6581500-75cb-11ea-99cd-1c767ea59231.png">

<img width="1680" alt="Screen Shot 2020-04-03 at 4 39 26 PM" src="https://user-images.githubusercontent.com/26014927/78404281-0d970280-75cc-11ea-98cc-23c3ff1483af.png">
