### PR TITLE
Onboarding: make minimum vote duration be 1 minute instead of 10

### DIFF
--- a/src/templates/kit/screens/VotingScreen.js
+++ b/src/templates/kit/screens/VotingScreen.js
@@ -17,8 +17,8 @@ const DEFAULT_QUORUM = 15
 const DEFAULT_DURATION = DAY_IN_SECONDS
 
 function validationError(duration) {
-  if (duration < 10 * MINUTE_IN_SECONDS) {
-    return 'Please ensure the vote duration is equal to or longer than 10 minutes.'
+  if (duration < 1 * MINUTE_IN_SECONDS) {
+    return 'Please ensure the vote duration is equal to or longer than 1 minute.'
   }
   return null
 }


### PR DESCRIPTION
Reduces the minimum vote duration to be 1 minute. Closes #1093 .

Here's the new error copy when you try to submit a duration lower than one minute (🏎 voting!)

<img width="1680" alt="Screen Shot 2020-04-08 at 8 43 48 PM" src="https://user-images.githubusercontent.com/26014927/78846445-cb116380-79d9-11ea-8cf2-ec45ed93aefe.png">
