### PR TITLE
Console: update and align copy, refactor internals

### DIFF
--- a/src/apps/Console/Console.js
+++ b/src/apps/Console/Console.js
@@ -13,7 +13,7 @@ import {
 } from '@aragon/ui'
 import { performTransactionPaths } from '../../aragonjs-wrapper'
 import ConsoleFeedback from './ConsoleFeedback'
-import { parseCommand } from './console-utils'
+import { buildCommand, parseCommand } from './console-utils'
 import handlers from './handlers'
 import IconPrompt from './IconPrompt'
 import KEYCODES from '../../keycodes'
@@ -60,7 +60,7 @@ function Console({ apps, wrapper }) {
   // Handle command clicks
   const handleCommandClick = useCallback(
     clickedCommand => {
-      const newCommand = `${command}${clickedCommand.toLowerCase()}/`
+      const newCommand = buildCommand(command, clickedCommand)
       const parsingResult = parseCommand(newCommand)
       setParsedState(parsingResult)
       setCommand(newCommand)

--- a/src/apps/Console/Console.js
+++ b/src/apps/Console/Console.js
@@ -108,7 +108,7 @@ function Console({ apps, wrapper }) {
           <ConsoleFeedback
             apps={apps}
             currentParsedCommand={parsedState}
-            handleCommandClick={handleCommandClick}
+            onCommandClick={handleCommandClick}
             loading={loading}
           />
         </Info>

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -5,9 +5,9 @@ import { AppType } from '../../prop-types'
 import { shortenAddress } from '../../web3-utils'
 
 export default function ConsoleFeedback({
+  apps,
   currentParsedCommand,
   handleCommandClick,
-  apps,
   loading,
 }) {
   if (loading) {
@@ -343,8 +343,8 @@ export default function ConsoleFeedback({
 }
 
 ConsoleFeedback.propTypes = {
+  apps: PropTypes.arrayOf(AppType).isRequired,
   currentParsedCommand: PropTypes.array,
   handleCommandClick: PropTypes.func,
-  apps: PropTypes.arrayOf(AppType).isRequired,
   loading: PropTypes.bool,
 }

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -10,9 +10,6 @@ export default function ConsoleFeedback({
   apps,
   loading,
 }) {
-  function handleClick(command) {
-    handleCommandClick(command)
-  }
   if (loading) {
     return (
       <div
@@ -36,6 +33,7 @@ export default function ConsoleFeedback({
       </div>
     )
   }
+
   if (currentParsedCommand.length < 2) {
     return (
       <>
@@ -61,7 +59,7 @@ export default function ConsoleFeedback({
                 display: block;
                 margin-bottom: ${1 * GU}px;
               `}
-              onClick={() => handleClick(command)}
+              onClick={() => handleCommandClick(command)}
             >
               {command}
             </Link>
@@ -69,10 +67,43 @@ export default function ConsoleFeedback({
         </div>
       </>
     )
-  } else if (
-    currentParsedCommand[0] === 'install' &&
-    currentParsedCommand.length < 3
-  ) {
+  }
+
+  if (currentParsedCommand[0] === 'install') {
+    if (currentParsedCommand.length < 3) {
+      return (
+        <>
+          <p
+            css={`
+              ${textStyle('body2')}
+            `}
+          >
+            You can install the following apps:
+          </p>
+          <div
+            css={`
+              width: 100%;
+              margin-top: ${1 * GU}px;
+            `}
+          >
+            {['Agent', 'Finance', 'Tokens', 'Vault', 'Voting'].map(command => (
+              <Link
+                key={command}
+                css={`
+                  ${textStyle('address1')}
+                  display: block;
+                  margin-bottom: ${1 * GU}px;
+                `}
+                onClick={() => handleCommandClick(command.toLowerCase())}
+              >
+                {command}
+              </Link>
+            ))}
+          </div>
+        </>
+      )
+    }
+
     return (
       <>
         <p
@@ -80,43 +111,8 @@ export default function ConsoleFeedback({
             ${textStyle('body2')}
           `}
         >
-          You can install the following apps:
-        </p>
-        <div
-          css={`
-            width: 100%;
-            margin-top: ${1 * GU}px;
-          `}
-        >
-          {['Tokens', 'Voting', 'Finance', 'Vault', 'Agent'].map(command => (
-            <Link
-              key={command}
-              css={`
-                ${textStyle('address1')}
-                display: block;
-                margin-bottom: ${1 * GU}px;
-              `}
-              onClick={() => handleClick(command.toLowerCase())}
-            >
-              {command}
-            </Link>
-          ))}
-        </div>
-      </>
-    )
-  } else if (
-    currentParsedCommand[0] === 'install' &&
-    currentParsedCommand.length >= 3
-  ) {
-    return (
-      <>
-        <p
-          css={`
-            ${textStyle('body2')}
-          `}
-        >
-          Please enter the corresponding parameters &amp; permissions needed for
-          installing the app, ex:
+          Please enter the corresponding parameters and permissions needed for
+          installing the app, in this format:
         </p>
         <div
           css={`
@@ -130,8 +126,7 @@ export default function ConsoleFeedback({
               ${textStyle('address1')}
             `}
           >
-            install/app/
-            {`(...initparams)/...PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE`}
+            install/appName/(...initparams)/...PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE
           </p>
         </div>
         <p
@@ -143,7 +138,9 @@ export default function ConsoleFeedback({
         </p>
       </>
     )
-  } else if (currentParsedCommand[0] === 'exec') {
+  }
+
+  if (currentParsedCommand[0] === 'exec') {
     if (currentParsedCommand.length < 3) {
       return (
         <>
@@ -170,7 +167,7 @@ export default function ConsoleFeedback({
                   display: block;
                   margin-bottom: ${1 * GU}px;
                 `}
-                onClick={() => handleClick(app.proxyAddress)}
+                onClick={() => handleCommandClick(app.proxyAddress)}
               >
                 <span>{app.name}</span> (
                 <span title={app.proxyAddress}>
@@ -182,36 +179,38 @@ export default function ConsoleFeedback({
           </div>
         </>
       )
-    } else {
-      return (
-        <>
+    }
+
+    return (
+      <>
+        <p
+          css={`
+            ${textStyle('body2')}
+          `}
+        >
+          Please enter the corresponding method and parameters needed for
+          interacting with the app, like so:
+        </p>
+        <div
+          css={`
+            width: 100%;
+            margin-top: ${1 * GU}px;
+            margin-bottom: ${1 * GU}px;
+          `}
+        >
           <p
             css={`
-              ${textStyle('body2')}
+              ${textStyle('address1')}
             `}
           >
-            Please enter the corresponding method and parameters needed for
-            interacting with the app, like so:
+            exec/appAddress/methodName(...args)
           </p>
-          <div
-            css={`
-              width: 100%;
-              margin-top: ${1 * GU}px;
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            <p
-              css={`
-                ${textStyle('address1')}
-              `}
-            >
-              exec/appAddress/methodName(...args)
-            </p>
-          </div>
-        </>
-      )
-    }
-  } else if (currentParsedCommand[0] === 'act') {
+        </div>
+      </>
+    )
+  }
+
+  if (currentParsedCommand[0] === 'act') {
     if (currentParsedCommand.length < 3) {
       const agentInstalled =
         apps.filter(app => app.name.toLowerCase() === 'agent').length > 0
@@ -269,68 +268,69 @@ export default function ConsoleFeedback({
                   display: block;
                   margin-bottom: ${1 * GU}px;
                 `}
-                onClick={() => handleClick(agentApp.proxyAddress)}
+                onClick={() => handleCommandClick(agentApp.proxyAddress)}
               >
                 Agent #{index + 1} ({shortenAddress(agentApp.proxyAddress)})
               </Link>
             ))}
         </>
       )
-    } else {
-      return (
-        <>
-          <p
-            css={`
-              ${textStyle('body2')}
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            Pass the parameters required for the Agent's execute function, in
-            the following format:
-          </p>
-          <div
-            css={`
-              width: 100%;
-              margin-top: ${1 * GU}px;
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            <p
-              css={`
-                ${textStyle('address1')}
-              `}
-            >
-              act/agentAddress/targetAddress/methodName(type: arg)
-            </p>
-          </div>
-          <p
-            css={`
-              ${textStyle('body2')}
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            Where:
-          </p>
-          <ul
-            css={`
-              ${textStyle('body2')}
-              margin-bottom: ${1 * GU}px;
-              list-style-position: inside;
-            `}
-          >
-            <li>
-              the target address, which is the address of the contract to
-              interact with.
-            </li>{' '}
-            <li>
-              the human-readable function call, which is the name of the method
-              you want to call, along with its types and parameters.
-            </li>
-          </ul>
-        </>
-      )
     }
+
+    return (
+      <>
+        <p
+          css={`
+            ${textStyle('body2')}
+            margin-bottom: ${1 * GU}px;
+          `}
+        >
+          Pass the parameters required for the Agent's execute function, in the
+          following format:
+        </p>
+        <div
+          css={`
+            width: 100%;
+            margin-top: ${1 * GU}px;
+            margin-bottom: ${1 * GU}px;
+          `}
+        >
+          <p
+            css={`
+              ${textStyle('address1')}
+            `}
+          >
+            act/agentAddress/targetAddress/methodName(type: arg)
+          </p>
+        </div>
+        <p
+          css={`
+            ${textStyle('body2')}
+            margin-bottom: ${1 * GU}px;
+          `}
+        >
+          Where:
+        </p>
+        <ul
+          css={`
+            ${textStyle('body2')}
+            margin-bottom: ${1 * GU}px;
+            list-style-position: inside;
+          `}
+        >
+          <li>
+            the target address, which is the address of the contract to interact
+            with.
+          </li>{' '}
+          <li>
+            the human-readable function call, which is the name of the method
+            you want to call, along with its types and parameters.
+          </li>
+        </ul>
+      </>
+    )
   }
+
   return (
     <p
       css={`

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -21,7 +21,7 @@ export default function ConsoleFeedback({
           display: flex;
           align-items: center;
           justify-content: center;
-          padding: ${GU * 6}px 0 ${GU * 6}px 0;
+          padding: ${6 * GU}px 0 ${6 * GU}px 0;
         `}
       >
         <LoadingRing />
@@ -50,7 +50,7 @@ export default function ConsoleFeedback({
         <div
           css={`
             width: 100%;
-            margin-top: ${GU}px;
+            margin-top: ${1 * GU}px;
           `}
         >
           {['Exec', 'Act'].map(command => (
@@ -59,7 +59,7 @@ export default function ConsoleFeedback({
               css={`
                 ${textStyle('address1')}
                 display: block;
-                margin-bottom: ${GU}px;
+                margin-bottom: ${1 * GU}px;
               `}
               onClick={() => handleClick(command)}
             >
@@ -85,7 +85,7 @@ export default function ConsoleFeedback({
         <div
           css={`
             width: 100%;
-            margin-top: ${GU}px;
+            margin-top: ${1 * GU}px;
           `}
         >
           {['Tokens', 'Voting', 'Finance', 'Vault', 'Agent'].map(command => (
@@ -94,7 +94,7 @@ export default function ConsoleFeedback({
               css={`
                 ${textStyle('address1')}
                 display: block;
-                margin-bottom: ${GU}px;
+                margin-bottom: ${1 * GU}px;
               `}
               onClick={() => handleClick(command.toLowerCase())}
             >
@@ -121,8 +121,8 @@ export default function ConsoleFeedback({
         <div
           css={`
             width: 100%;
-            margin-top: ${GU}px;
-            margin-bottom: ${GU}px;
+            margin-top: ${1 * GU}px;
+            margin-bottom: ${1 * GU}px;
           `}
         >
           <p
@@ -157,7 +157,7 @@ export default function ConsoleFeedback({
           <div
             css={`
               width: 100%;
-              margin-top: ${GU}px;
+              margin-top: ${1 * GU}px;
               overflow: hidden;
               text-overflow: ellipsis;
             `}
@@ -168,7 +168,7 @@ export default function ConsoleFeedback({
                 css={`
                   ${textStyle('address1')}
                   display: block;
-                  margin-bottom: ${GU}px;
+                  margin-bottom: ${1 * GU}px;
                 `}
                 onClick={() => handleClick(app.proxyAddress)}
               >
@@ -196,8 +196,8 @@ export default function ConsoleFeedback({
           <div
             css={`
               width: 100%;
-              margin-top: ${GU}px;
-              margin-bottom: ${GU}px;
+              margin-top: ${1 * GU}px;
+              margin-bottom: ${1 * GU}px;
             `}
           >
             <p
@@ -222,11 +222,18 @@ export default function ConsoleFeedback({
             <p
               css={`
                 ${textStyle('body2')}
-                margin: 0 0 ${GU}px 0;
               `}
             >
               There are no Agent instances installed in this organization.
-              Please read{' '}
+            </p>
+            <p
+              css={`
+                ${textStyle('body2')}
+                margin-top: ${1 * GU}px;
+                margin-bottom: ${1 * GU}px;
+              `}
+            >
+              If you would like to install an Agent, please read{' '}
               <Link
                 external
                 href="https://hack.aragon.org/docs/cli-dao-commands#dao-install"
@@ -248,7 +255,7 @@ export default function ConsoleFeedback({
           <p
             css={`
               ${textStyle('body2')}
-              margin: 0 0 ${GU}px 0;
+              margin-bottom: ${1 * GU}px;
             `}
           >
             Please select the corresponding agent instance you want to interact
@@ -262,7 +269,7 @@ export default function ConsoleFeedback({
                 css={`
                   ${textStyle('address1')}
                   display: block;
-                  margin-bottom: ${GU}px;
+                  margin-bottom: ${1 * GU}px;
                 `}
                 onClick={() => handleClick(agentApp.proxyAddress)}
               >
@@ -277,7 +284,7 @@ export default function ConsoleFeedback({
           <p
             css={`
               ${textStyle('body2')}
-              margin: 0 0 ${GU}px 0;
+              margin-bottom: ${1 * GU}px;
             `}
           >
             Pass the paremeters required for the Agent's execute function:
@@ -285,7 +292,7 @@ export default function ConsoleFeedback({
           <ul
             css={`
               ${textStyle('body2')}
-              margin: 0 0 ${GU}px 0;
+              margin-bottom: ${1 * GU}px;
               list-style-position: inside;
             `}
           >
@@ -301,7 +308,7 @@ export default function ConsoleFeedback({
           <p
             css={`
               ${textStyle('body2')}
-              margin: 0 0 ${GU}px 0;
+              margin-bottom: ${1 * GU}px;
             `}
           >
             The format required looks as follows:
@@ -309,8 +316,8 @@ export default function ConsoleFeedback({
           <div
             css={`
               width: 100%;
-              margin-top: ${GU}px;
-              margin-bottom: ${GU}px;
+              margin-top: ${1 * GU}px;
+              margin-bottom: ${1 * GU}px;
             `}
           >
             <p

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -5,6 +5,15 @@ import { Link, textStyle, GU, LoadingRing } from '@aragon/ui'
 import { AppType } from '../../prop-types'
 import { shortenAddress } from '../../web3-utils'
 
+// Tuple of [display name, app name]
+const INSTALLABLE_APPS = [
+  ['Agent', 'agent'],
+  ['Finance', 'finance'],
+  ['Tokens', 'token-manager'],
+  ['Vault', 'vault'],
+  ['Voting', 'voting'],
+]
+
 function ConsoleFeedback({
   apps,
   currentParsedCommand,
@@ -73,15 +82,15 @@ function ConsoleFeedback({
               overflow: auto;
             `}
           >
-            {['Agent', 'Finance', 'Tokens', 'Vault', 'Voting'].map(command => (
+            {INSTALLABLE_APPS.map(([displayName, appName]) => (
               <InteractiveCommand
-                key={command}
+                key={appName}
                 css={`
                   display: block;
                 `}
-                onClick={() => onCommandClick(command.toLowerCase())}
+                onClick={() => onCommandClick(appName)}
               >
-                {command}
+                {displayName}
               </InteractiveCommand>
             ))}
           </div>

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { AppType } from '../../prop-types'
 import { shortenAddress } from '../../web3-utils'
 
-export default function ConsoleFeedback({
+function ConsoleFeedback({
   apps,
   currentParsedCommand,
   handleCommandClick,
@@ -348,3 +348,5 @@ ConsoleFeedback.propTypes = {
   handleCommandClick: PropTypes.func,
   loading: PropTypes.bool,
 }
+
+export default ConsoleFeedback

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -44,7 +44,7 @@ export default function ConsoleFeedback({
             ${textStyle('body2')}
           `}
         >
-          You can interact with this organization by using the following CLI
+          You can interact with this organization by using the following console
           commands:
         </p>
         <div
@@ -190,7 +190,7 @@ export default function ConsoleFeedback({
               ${textStyle('body2')}
             `}
           >
-            Please enter the corresponding method and arguments needed for
+            Please enter the corresponding method and parameters needed for
             interacting with the app, like so:
           </p>
           <div
@@ -205,8 +205,7 @@ export default function ConsoleFeedback({
                 ${textStyle('address1')}
               `}
             >
-              exec/appAddress/
-              {`methodName(...args)`}
+              exec/appAddress/methodName(...args)
             </p>
           </div>
         </>
@@ -240,11 +239,11 @@ export default function ConsoleFeedback({
               >
                 the documentation
               </Link>{' '}
-              on how to install an Agent using the CLI, or go to our{' '}
+              or ask our{' '}
               <Link external href="https://spectrum.chat/aragon">
-                Discord
+                Spectrum community
               </Link>{' '}
-              server to help you install it.
+              for help.
             </p>
           </>
         )
@@ -258,8 +257,7 @@ export default function ConsoleFeedback({
               margin-bottom: ${1 * GU}px;
             `}
           >
-            Please select the corresponding agent instance you want to interact
-            with:
+            Please select the corresponding Agent instance to interact with:
           </p>
           {apps
             .filter(app => app.name.toLowerCase() === 'agent')
@@ -287,7 +285,31 @@ export default function ConsoleFeedback({
               margin-bottom: ${1 * GU}px;
             `}
           >
-            Pass the paremeters required for the Agent's execute function:
+            Pass the parameters required for the Agent's execute function, in
+            the following format:
+          </p>
+          <div
+            css={`
+              width: 100%;
+              margin-top: ${1 * GU}px;
+              margin-bottom: ${1 * GU}px;
+            `}
+          >
+            <p
+              css={`
+                ${textStyle('address1')}
+              `}
+            >
+              act/agentAddress/targetAddress/methodName(type: arg)
+            </p>
+          </div>
+          <p
+            css={`
+              ${textStyle('body2')}
+              margin-bottom: ${1 * GU}px;
+            `}
+          >
+            Where:
           </p>
           <ul
             css={`
@@ -305,30 +327,6 @@ export default function ConsoleFeedback({
               you want to call, along with its types and parameters.
             </li>
           </ul>
-          <p
-            css={`
-              ${textStyle('body2')}
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            The format required looks as follows:
-          </p>
-          <div
-            css={`
-              width: 100%;
-              margin-top: ${1 * GU}px;
-              margin-bottom: ${1 * GU}px;
-            `}
-          >
-            <p
-              css={`
-                ${textStyle('address1')}
-              `}
-            >
-              act/{'<agentProxyAddress>'}/{'targetAddress'}/
-              {`methodName(type: arg)`}
-            </p>
-          </div>
         </>
       )
     }

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Link, textStyle, GU, LoadingRing } from '@aragon/ui'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Link, textStyle, GU, LoadingRing } from '@aragon/ui'
 import { AppType } from '../../prop-types'
 import { shortenAddress } from '../../web3-utils'
 
@@ -25,10 +26,10 @@ function ConsoleFeedback({
         <span
           css={`
             margin-left: ${1 * GU}px;
-            ${textStyle('body2')}
+            ${textStyle('body2')};
           `}
         >
-          Executing Command...
+          Executing command...
         </span>
       </div>
     )
@@ -37,32 +38,25 @@ function ConsoleFeedback({
   if (currentParsedCommand.length < 2) {
     return (
       <>
-        <p
-          css={`
-            ${textStyle('body2')}
-          `}
-        >
+        <Paragraph>
           You can interact with this organization by using the following console
           commands:
-        </p>
+        </Paragraph>
         <div
           css={`
-            width: 100%;
-            margin-top: ${1 * GU}px;
+            overflow: auto;
           `}
         >
           {['Exec', 'Act'].map(command => (
-            <Link
+            <InteractiveCommand
               key={command}
               css={`
-                ${textStyle('address1')}
                 display: block;
-                margin-bottom: ${1 * GU}px;
               `}
               onClick={() => handleCommandClick(command)}
             >
               {command}
-            </Link>
+            </InteractiveCommand>
           ))}
         </div>
       </>
@@ -73,31 +67,22 @@ function ConsoleFeedback({
     if (currentParsedCommand.length < 3) {
       return (
         <>
-          <p
-            css={`
-              ${textStyle('body2')}
-            `}
-          >
-            You can install the following apps:
-          </p>
+          <Paragraph>You can install the following apps:</Paragraph>
           <div
             css={`
-              width: 100%;
-              margin-top: ${1 * GU}px;
+              overflow: auto;
             `}
           >
             {['Agent', 'Finance', 'Tokens', 'Vault', 'Voting'].map(command => (
-              <Link
+              <InteractiveCommand
                 key={command}
                 css={`
-                  ${textStyle('address1')}
                   display: block;
-                  margin-bottom: ${1 * GU}px;
                 `}
                 onClick={() => handleCommandClick(command.toLowerCase())}
               >
                 {command}
-              </Link>
+              </InteractiveCommand>
             ))}
           </div>
         </>
@@ -106,36 +91,20 @@ function ConsoleFeedback({
 
     return (
       <>
-        <p
-          css={`
-            ${textStyle('body2')}
-          `}
-        >
+        <Paragraph>
           Please enter the corresponding parameters and permissions needed for
           installing the app, in this format:
-        </p>
-        <div
+        </Paragraph>
+        <Command
           css={`
-            width: 100%;
-            margin-top: ${1 * GU}px;
-            margin-bottom: ${1 * GU}px;
+            margin-left: ${1 * GU}px;
           `}
         >
-          <p
-            css={`
-              ${textStyle('address1')}
-            `}
-          >
-            install/appName/(...initparams)/...PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE
-          </p>
-        </div>
-        <p
-          css={`
-            ${textStyle('body2')}
-          `}
-        >
+          install/appName/(...initparams)/...PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE
+        </Command>
+        <Paragraph>
           You can set multiple permissions by separating them with a comma.
-        </p>
+        </Paragraph>
       </>
     )
   }
@@ -144,28 +113,17 @@ function ConsoleFeedback({
     if (currentParsedCommand.length < 3) {
       return (
         <>
-          <p
-            css={`
-              ${textStyle('body2')}
-            `}
-          >
-            You can interact with the following apps:
-          </p>
+          <Paragraph>You can interact with the following apps:</Paragraph>
           <div
             css={`
-              width: 100%;
-              margin-top: ${1 * GU}px;
-              overflow: hidden;
-              text-overflow: ellipsis;
+              overflow: auto;
             `}
           >
             {apps.map(app => (
-              <Link
+              <InteractiveCommand
                 key={app.proxyAddress}
                 css={`
-                  ${textStyle('address1')}
                   display: block;
-                  margin-bottom: ${1 * GU}px;
                 `}
                 onClick={() => handleCommandClick(app.proxyAddress)}
               >
@@ -174,7 +132,7 @@ function ConsoleFeedback({
                   {shortenAddress(app.proxyAddress)}
                 </span>
                 )
-              </Link>
+              </InteractiveCommand>
             ))}
           </div>
         </>
@@ -183,29 +141,17 @@ function ConsoleFeedback({
 
     return (
       <>
-        <p
-          css={`
-            ${textStyle('body2')}
-          `}
-        >
+        <Paragraph>
           Please enter the corresponding method and parameters needed for
-          interacting with the app, like so:
-        </p>
-        <div
+          interacting with the app, in this format:
+        </Paragraph>
+        <Command
           css={`
-            width: 100%;
-            margin-top: ${1 * GU}px;
-            margin-bottom: ${1 * GU}px;
+            margin-left: ${1 * GU}px;
           `}
         >
-          <p
-            css={`
-              ${textStyle('address1')}
-            `}
-          >
-            exec/appAddress/methodName(...args)
-          </p>
-        </div>
+          exec/appAddress/methodName(...args)
+        </Command>
       </>
     )
   }
@@ -217,20 +163,10 @@ function ConsoleFeedback({
       if (!agentInstalled) {
         return (
           <>
-            <p
-              css={`
-                ${textStyle('body2')}
-              `}
-            >
+            <Paragraph>
               There are no Agent instances installed in this organization.
-            </p>
-            <p
-              css={`
-                ${textStyle('body2')}
-                margin-top: ${1 * GU}px;
-                margin-bottom: ${1 * GU}px;
-              `}
-            >
+            </Paragraph>
+            <Paragraph>
               If you would like to install an Agent, please read{' '}
               <Link
                 external
@@ -243,79 +179,62 @@ function ConsoleFeedback({
                 Spectrum community
               </Link>{' '}
               for help.
-            </p>
+            </Paragraph>
           </>
         )
       }
 
       return (
         <>
-          <p
+          <Paragraph>
+            Please select the corresponding Agent instance to interact with:
+          </Paragraph>
+          <div
             css={`
-              ${textStyle('body2')}
-              margin-bottom: ${1 * GU}px;
+              overflow: auto;
             `}
           >
-            Please select the corresponding Agent instance to interact with:
-          </p>
-          {apps
-            .filter(app => app.name.toLowerCase() === 'agent')
-            .map((agentApp, index) => (
-              <Link
-                key={agentApp.proxyAddress}
-                css={`
-                  ${textStyle('address1')}
-                  display: block;
-                  margin-bottom: ${1 * GU}px;
-                `}
-                onClick={() => handleCommandClick(agentApp.proxyAddress)}
-              >
-                Agent #{index + 1} ({shortenAddress(agentApp.proxyAddress)})
-              </Link>
-            ))}
+            {apps
+              .filter(app => app.name.toLowerCase() === 'agent')
+              .map((agentApp, index) => (
+                <InteractiveCommand
+                  key={agentApp.proxyAddress}
+                  css={`
+                    display: block;
+                  `}
+                  onClick={() => handleCommandClick(agentApp.proxyAddress)}
+                >
+                  Agent #{index + 1} ({shortenAddress(agentApp.proxyAddress)})
+                </InteractiveCommand>
+              ))}
+          </div>
         </>
       )
     }
 
     return (
       <>
-        <p
+        <Paragraph>
+          Pass the parameters required for the Agent's execute function, in this
+          format:
+        </Paragraph>
+        <Command
           css={`
-            ${textStyle('body2')}
-            margin-bottom: ${1 * GU}px;
+            margin-left: ${1 * GU}px;
           `}
         >
-          Pass the parameters required for the Agent's execute function, in the
-          following format:
-        </p>
-        <div
-          css={`
-            width: 100%;
-            margin-top: ${1 * GU}px;
-            margin-bottom: ${1 * GU}px;
-          `}
-        >
-          <p
-            css={`
-              ${textStyle('address1')}
-            `}
-          >
-            act/agentAddress/targetAddress/methodName(type: arg)
-          </p>
-        </div>
-        <p
-          css={`
-            ${textStyle('body2')}
-            margin-bottom: ${1 * GU}px;
-          `}
-        >
-          Where:
-        </p>
+          act/agentAddress/targetAddress/methodName(type: arg)
+        </Command>
+        <Paragraph>Where:</Paragraph>
         <ul
           css={`
-            ${textStyle('body2')}
             margin-bottom: ${1 * GU}px;
             list-style-position: inside;
+            ${textStyle('body2')};
+
+            > li {
+              margin-left: ${1 * GU}px;
+            }
           `}
         >
           <li>
@@ -331,15 +250,7 @@ function ConsoleFeedback({
     )
   }
 
-  return (
-    <p
-      css={`
-        ${textStyle('address1')}
-      `}
-    >
-      Unrecognized Command
-    </p>
-  )
+  return <Command css="margin: 0">Unrecognized command</Command>
 }
 
 ConsoleFeedback.propTypes = {
@@ -348,5 +259,17 @@ ConsoleFeedback.propTypes = {
   handleCommandClick: PropTypes.func,
   loading: PropTypes.bool,
 }
+
+const Command = styled.p`
+  margin-bottom: ${1 * GU}px;
+  ${textStyle('address1')};
+`
+
+const InteractiveCommand = props => <Command as={Link} {...props} />
+
+const Paragraph = styled.p`
+  margin-bottom: ${1 * GU}px;
+  ${textStyle('body2')};
+`
 
 export default ConsoleFeedback

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -144,7 +144,7 @@ export default function ConsoleFeedback({
       </>
     )
   } else if (currentParsedCommand[0] === 'exec') {
-    if (currentParsedCommand.length <= 2) {
+    if (currentParsedCommand.length < 3) {
       return (
         <>
           <p
@@ -212,7 +212,7 @@ export default function ConsoleFeedback({
       )
     }
   } else if (currentParsedCommand[0] === 'act') {
-    if (currentParsedCommand.length <= 2) {
+    if (currentParsedCommand.length < 3) {
       const agentInstalled =
         apps.filter(app => app.name.toLowerCase() === 'agent').length > 0
       if (!agentInstalled) {

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -8,8 +8,8 @@ import { shortenAddress } from '../../web3-utils'
 function ConsoleFeedback({
   apps,
   currentParsedCommand,
-  handleCommandClick,
   loading,
+  onCommandClick,
 }) {
   if (loading) {
     return (
@@ -53,7 +53,7 @@ function ConsoleFeedback({
               css={`
                 display: block;
               `}
-              onClick={() => handleCommandClick(command)}
+              onClick={() => onCommandClick(command)}
             >
               {command}
             </InteractiveCommand>
@@ -79,7 +79,7 @@ function ConsoleFeedback({
                 css={`
                   display: block;
                 `}
-                onClick={() => handleCommandClick(command.toLowerCase())}
+                onClick={() => onCommandClick(command.toLowerCase())}
               >
                 {command}
               </InteractiveCommand>
@@ -125,7 +125,7 @@ function ConsoleFeedback({
                 css={`
                   display: block;
                 `}
-                onClick={() => handleCommandClick(app.proxyAddress)}
+                onClick={() => onCommandClick(app.proxyAddress)}
               >
                 <span>{app.name}</span> (
                 <span title={app.proxyAddress}>
@@ -202,7 +202,7 @@ function ConsoleFeedback({
                   css={`
                     display: block;
                   `}
-                  onClick={() => handleCommandClick(agentApp.proxyAddress)}
+                  onClick={() => onCommandClick(agentApp.proxyAddress)}
                 >
                   Agent #{index + 1} ({shortenAddress(agentApp.proxyAddress)})
                 </InteractiveCommand>
@@ -268,8 +268,8 @@ function ConsoleFeedback({
 ConsoleFeedback.propTypes = {
   apps: PropTypes.arrayOf(AppType).isRequired,
   currentParsedCommand: PropTypes.array,
-  handleCommandClick: PropTypes.func,
   loading: PropTypes.bool,
+  onCommandClick: PropTypes.func,
 }
 
 const Command = styled.p`

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -238,12 +238,24 @@ function ConsoleFeedback({
           `}
         >
           <li>
-            the target address, which is the address of the contract to interact
-            with.
-          </li>{' '}
+            <span
+              css={`
+                ${textStyle('address1')}
+              `}
+            >
+              targetAddress
+            </span>
+            : the address of the contract to interact with
+          </li>
           <li>
-            the human-readable function call, which is the name of the method
-            you want to call, along with its types and parameters.
+            <span
+              css={`
+                ${textStyle('address1')}
+              `}
+            >
+              methodName
+            </span>
+            : the function call, with its types and parameters
           </li>
         </ul>
       </>

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -13,6 +13,7 @@ const INSTALLABLE_APPS = [
   ['Vault', 'vault'],
   ['Voting', 'voting'],
 ]
+const SUGGESTED_COMMANDS = ['Exec', 'Act']
 
 function ConsoleFeedback({
   apps,
@@ -56,7 +57,7 @@ function ConsoleFeedback({
             overflow: auto;
           `}
         >
-          {['Exec', 'Act'].map(command => (
+          {SUGGESTED_COMMANDS.map(command => (
             <InteractiveCommand
               key={command}
               css={`

--- a/src/apps/Console/ConsoleFeedback.js
+++ b/src/apps/Console/ConsoleFeedback.js
@@ -38,7 +38,7 @@ function ConsoleFeedback({
             ${textStyle('body2')};
           `}
         >
-          Executing command...
+          Executing command…
         </span>
       </div>
     )
@@ -109,7 +109,7 @@ function ConsoleFeedback({
             margin-left: ${1 * GU}px;
           `}
         >
-          install/appName/(...initparams)/...PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE
+          install/appName/(…initparams)/…PERMISSION_ROLE:ADDRESS_MANAGER:ADDRESS_GRANTEE
         </Command>
         <Paragraph>
           You can set multiple permissions by separating them with a comma.
@@ -159,7 +159,7 @@ function ConsoleFeedback({
             margin-left: ${1 * GU}px;
           `}
         >
-          exec/appAddress/methodName(...args)
+          exec/appAddress/methodName(…args)
         </Command>
       </>
     )

--- a/src/apps/Console/console-utils.js
+++ b/src/apps/Console/console-utils.js
@@ -1,3 +1,25 @@
+import { appendTrailingSlash } from '../../utils'
+
+const SEPARATOR = '/'
+
+export function buildCommand(command, nextToken) {
+  if (typeof command !== 'string' || typeof nextToken !== 'string') {
+    throw new Error(
+      `Parsing command failed, reason: wrong type passed in. Expected string, got ${typeof method}`
+    )
+  }
+
+  return appendTrailingSlash(
+    command
+      .split(SEPARATOR)
+      // Remove the last item, which will be an empty string if the command was
+      // terminated correctly with a /
+      .slice(0, -1)
+      .concat(nextToken.toLowerCase())
+      .join('/')
+  )
+}
+
 export function parseCommand(command) {
   if (typeof command !== 'string') {
     throw new Error(
@@ -5,7 +27,7 @@ export function parseCommand(command) {
     )
   }
 
-  return command.split('/')
+  return command.split(SEPARATOR)
 }
 
 export function parseMethodCall(method) {
@@ -22,7 +44,7 @@ export function parseMethodCall(method) {
 
   if (methodName === '' || areParenthesisMalformed) {
     throw new Error(
-      'Parsing method failed, reason: Malformed method call. Please check if a parenthesis has been misplaced or if you are not passing the method name.'
+      'Parsing method failed, reason: malformed method call. Please check if a parenthesis has been misplaced or if you are not passing the method name.'
     )
   }
 

--- a/src/apps/Console/console-utils.test.js
+++ b/src/apps/Console/console-utils.test.js
@@ -1,9 +1,31 @@
 import {
+  buildCommand,
   parseMethodCall,
   parseCommand,
   parseInitParams,
   parsePermissions,
 } from './console-utils'
+
+describe('Build command tests', () => {
+  test('Builds from empty strings', () => {
+    expect(buildCommand('', 'command')).toEqual('command/')
+  })
+
+  test('Builds from existing tokens', () => {
+    expect(buildCommand('command/first/', 'second')).toEqual(
+      'command/first/second/'
+    )
+  })
+
+  test('Eliminates dangling characters from last token', () => {
+    expect(buildCommand('command/incomple', 'first')).toEqual('command/first/')
+  })
+
+  test('Errors out on wrong types', () => {
+    expect(() => buildCommand(null, 'first')).toThrow('wrong type')
+    expect(() => buildCommand('command/', null)).toThrow('wrong type')
+  })
+})
 
 describe('Parse command tests', () => {
   test('Handles empty strings', () => {
@@ -25,25 +47,13 @@ describe('Parse command tests', () => {
       '(0x,1)',
     ])
   })
+
+  test('Errors out on wrong types', () => {
+    expect(() => parseCommand(null)).toThrow('wrong type')
+  })
 })
 
 describe('parseMethodCall tests', () => {
-  test('Errors out on malformed calls', () => {
-    expect(() => parseMethodCall('')).toThrow('Malformed')
-    expect(() => parseMethodCall('  ')).toThrow('Malformed')
-    expect(() => parseMethodCall('y')).toThrow('Malformed')
-    expect(() => parseMethodCall('y(bool:true')).toThrow('Malformed')
-  })
-
-  test('Throws on parameters and arguments mismatch', () => {
-    expect(() =>
-      parseMethodCall('vote(uint256:,bool: true,bool: false')
-    ).toThrow('failed')
-    expect(() => parseMethodCall('vote(uint256: 1, bool: , bool:)')).toThrow(
-      'failed'
-    )
-  })
-
   test('Handles method calls without arguments', () => {
     expect(parseMethodCall('vote()')).toEqual(['vote'])
     expect(parseMethodCall('vote(uint256,bool,bool)')).toEqual([
@@ -61,9 +71,39 @@ describe('parseMethodCall tests', () => {
       parseMethodCall('vote(uint256: 7, bool: true, bool: false)')
     ).toEqual(['vote', ['uint256', 'bool', 'bool'], ['7', 'true', 'false']])
   })
+
+  test('Errors out on wrong types', () => {
+    expect(() => parseMethodCall(null)).toThrow('wrong type')
+  })
+
+  test('Errors out on malformed calls', () => {
+    expect(() => parseMethodCall('')).toThrow('malformed')
+    expect(() => parseMethodCall('  ')).toThrow('malformed')
+    expect(() => parseMethodCall('y')).toThrow('malformed')
+    expect(() => parseMethodCall('y(bool:true')).toThrow('malformed')
+  })
+
+  test('Throws on parameters and arguments mismatch', () => {
+    expect(() =>
+      parseMethodCall('vote(uint256:,bool: true,bool: false')
+    ).toThrow('failed')
+    expect(() => parseMethodCall('vote(uint256: 1, bool: , bool:)')).toThrow(
+      'failed'
+    )
+  })
 })
 
 describe('parseInitParams tests', () => {
+  test('Handles parsing correctly', () => {
+    expect(parseInitParams('(0x,true,1)')).toEqual(['0x', 'true', '1'])
+    expect(parseInitParams('(0x)')).toEqual(['0x'])
+    expect(parseInitParams('()')).toEqual([])
+  })
+
+  test('Errors out on wrong types', () => {
+    expect(() => parseInitParams(null)).toThrow('wrong type')
+  })
+
   test('Errors out on malformed calls', () => {
     expect(() => parseInitParams('0x(5,3)')).toThrow('malformed')
     expect(() => parseInitParams('0x,1,false)')).toThrow('malformed')
@@ -74,20 +114,9 @@ describe('parseInitParams tests', () => {
     expect(() => parseInitParams('( , , , true)')).toThrow('skipped')
     expect(() => parseInitParams('(, , true, )')).toThrow('skipped')
   })
-  test('Handles parsing correctly', () => {
-    expect(parseInitParams('(0x,true,1)')).toEqual(['0x', 'true', '1'])
-    expect(parseInitParams('(0x)')).toEqual(['0x'])
-    expect(parseInitParams('()')).toEqual([])
-  })
 })
 
 describe('parsePermissions tests', () => {
-  test('Errors out on malformed calls', () => {
-    expect(() => parsePermissions('0x:1')).toThrow('malformed')
-    expect(() => parsePermissions('0x')).toThrow('malformed')
-    expect(() => parsePermissions('0x,0x:1:2')).toThrow('malformed')
-  })
-
   test('Handles parsing correctly', () => {
     expect(parsePermissions('TRANSFER_ROLE:0x:0x')).toEqual([
       ['TRANSFER_ROLE', '0x', '0x'],
@@ -102,5 +131,15 @@ describe('parsePermissions tests', () => {
       ['EXECUTE_ACTIONS_ROLE', '0x', '0x'],
       ['VOTE_ROLE', '0x', '0x'],
     ])
+  })
+
+  test('Errors out on wrong types', () => {
+    expect(() => parsePermissions(null)).toThrow('wrong type')
+  })
+
+  test('Errors out on malformed calls', () => {
+    expect(() => parsePermissions('0x:1')).toThrow('malformed')
+    expect(() => parsePermissions('0x')).toThrow('malformed')
+    expect(() => parsePermissions('0x,0x:1:2')).toThrow('malformed')
   })
 })


### PR DESCRIPTION
Builds on https://github.com/aragon/aragon/pull/1382.

Primarily aligns the language and implementation of each command. May be easiest to review commit-by-commit.

Main changes:
- 1de2427: updates `CommandFeedback`'s rendering logic to not use `else` unless necessary
- 6db0396: consolidates `CommandFeedback`'s styling into internal components
- e5201e0, 55ed113, 9979441: several prop name or internal alignments with rest of codebase
- 8d4fa7f: fix install for apps with app names that differ from their display names
- 44facf6: UX enhancement: overwrite incomplete command arguments if user clicks on an interactive command

----------

How `act/` looks:

<img width="1069" alt="Screen Shot 2020-04-09 at 11 18 02 AM" src="https://user-images.githubusercontent.com/4166642/78879610-6810e280-7a54-11ea-8d03-07c232dadc3c.png">