### PR TITLE
Permissions: add permission warning and menu enhancements for burn and unassign

### DIFF
--- a/src/apps/Permissions/AssignPermissionPanel.js
+++ b/src/apps/Permissions/AssignPermissionPanel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, DropDown, Info, Field, SidePanel, GU } from '@aragon/ui'
-import { ANY_ENTITY } from '../../permissions'
+import { isAnyEntity } from '../../permissions'
 import { PermissionsConsumer } from '../../contexts/PermissionsContext'
 import { AppType, AragonType } from '../../prop-types'
 import { isAddress, isEmptyAddress } from '../../web3-utils'
@@ -197,7 +197,7 @@ class AssignPermissionPanel extends React.PureComponent {
             {'Add permission'}
           </Button>
 
-          {this.state.assignEntityAddress === ANY_ENTITY && (
+          {isAnyEntity(this.state.assignEntityAddress) && (
             <Info
               mode="warning"
               css={`

--- a/src/apps/Permissions/EntitySelector.js
+++ b/src/apps/Permissions/EntitySelector.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { DropDown, Field } from '@aragon/ui'
-import { getAnyEntity } from '../../permissions'
+import {
+  getAnyEntity,
+  getBurnEntity,
+  getUnassignedEntity,
+} from '../../permissions'
 import { AppType, AragonType } from '../../prop-types'
 import { getEmptyAddress } from '../../web3-utils'
 import AppInstanceLabel from '../../components/AppInstanceLabel'
@@ -11,6 +15,8 @@ class EntitySelector extends React.Component {
   static propTypes = {
     apps: PropTypes.arrayOf(AppType).isRequired,
     includeAnyEntity: PropTypes.bool,
+    includeBurnEntity: PropTypes.bool,
+    includeUnassignedEntity: PropTypes.bool,
     label: PropTypes.string.isRequired,
     labelCustomAddress: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -46,7 +52,7 @@ class EntitySelector extends React.Component {
   }
   getAddress(index) {
     if (index === -1 || index === 0) {
-      return getEmptyAddress()
+      return ''
     }
 
     const items = this.getItems()
@@ -55,15 +61,30 @@ class EntitySelector extends React.Component {
       return this.state.customAddress
     }
 
-    if (this.props.includeAnyEntity && index === items.length - 2) {
+    if (this.props.includeAnyEntity && items[index] === 'Any account') {
       return getAnyEntity()
+    }
+
+    if (this.props.includeBurnEntity && items[index] === 'Burn role') {
+      return getBurnEntity()
+    }
+
+    if (
+      this.props.includeUnassignedEntity &&
+      items[index] === 'Unassign role'
+    ) {
+      return getUnassignedEntity()
     }
 
     const app = this.getApps()[index - 1]
     return (app && app.proxyAddress) || getEmptyAddress()
   }
   getItems() {
-    const { includeAnyEntity } = this.props
+    const {
+      includeAnyEntity,
+      includeBurnEntity,
+      includeUnassignedEntity,
+    } = this.props
 
     const items = [
       'Select an entity',
@@ -73,6 +94,14 @@ class EntitySelector extends React.Component {
     if (includeAnyEntity) {
       // Add immediately before last item
       items.splice(-1, 0, 'Any account')
+    }
+
+    if (includeBurnEntity) {
+      items.splice(-1, 0, 'Burn role')
+    }
+
+    if (includeUnassignedEntity) {
+      items.splice(-1, 0, 'Unassign role')
     }
 
     return items

--- a/src/apps/Permissions/ManageRolePanel.js
+++ b/src/apps/Permissions/ManageRolePanel.js
@@ -415,7 +415,7 @@ class ManageRolePanel extends React.PureComponent {
               `}
             >
               Be aware that granting the manager role to this address will
-              remove the currently assigned one. the permission can only be
+              remove the currently assigned one. The permission can only be
               granted or revoked if it is initialized again (requiring the
               “Create permission” action on the ACL app).
             </Info>

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -6,7 +6,7 @@ import { addressesEqual } from './web3-utils'
 //               that permission
 //   Burn entity: If a role's permission manager is set as "burn entity", then it is assumed to be a
 //               discarded and frozen role
-export const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
+const ANY_ENTITY = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 const BURN_ENTITY = '0x0000000000000000000000000000000000000001'
 const UNASSIGNED_ENTITY = '0x0000000000000000000000000000000000000000'
 const KERNEL_ROLES = [


### PR DESCRIPTION
> [Just sayin'](https://github.com/aragon/aragon/pull/1384#issuecomment-610558443) 🌸⚔️

Adds improvements to the warnings for the "special" ACL addresses, as well as exposing the "Burn" and "unassign" options to the user depending on the menu. A few screenshots:

Potentially damage democracy by unassigning this role: 
<img width="1680" alt="Screen Shot 2020-04-09 at 6 33 40 PM" src="https://user-images.githubusercontent.com/26014927/78946428-b0e68c80-7a90-11ea-8287-769e741c3030.png">

Protect democracy by burning the role:
<img width="1680" alt="Screen Shot 2020-04-09 at 5 58 30 PM" src="https://user-images.githubusercontent.com/26014927/78946456-c491f300-7a90-11ea-9ffd-fbb936bb8c0e.png">

Everyone is the manager of this role! We all know what this is.
<img width="1680" alt="Screen Shot 2020-04-09 at 6 35 16 PM" src="https://user-images.githubusercontent.com/26014927/78946507-e2f7ee80-7a90-11ea-9101-14766659a928.png">

Everyone can execute payments now! Everyone is good-willed! (note the difference in the copy)
<img width="1680" alt="Screen Shot 2020-04-09 at 6 36 53 PM" src="https://user-images.githubusercontent.com/26014927/78946591-294d4d80-7a91-11ea-87aa-64dda9cbaead.png">


