### PR TITLE
Routing: use URLSearchParams

### DIFF
--- a/src/routing.js
+++ b/src/routing.js
@@ -119,15 +119,16 @@ export function getAppPath({
 }
 
 // Preferences
-const GLOBAL_PREFERENCES_QUERY_PARAM = '?preferences=/'
+const GLOBAL_PREFERENCES_QUERY_PARAM = '?preferences='
 const GLOBAL_PREFERENCES_SHARE_LINK_QUERY_VAR = '&labels='
 
 function parsePreferences(search = '') {
-  const [, raw = ''] = search.split(GLOBAL_PREFERENCES_QUERY_PARAM)
   const params = new Map()
-  const [path = null, labels = null] = raw.split(
-    GLOBAL_PREFERENCES_SHARE_LINK_QUERY_VAR
-  )
+  const searchParams = new URLSearchParams(search)
+
+  const path = searchParams.get('preferences')
+  const labels = searchParams.get('labels')
+
   if (labels) {
     params.set('labels', labels)
   }

--- a/src/routing.js
+++ b/src/routing.js
@@ -126,7 +126,7 @@ function parsePreferences(search = '') {
   const params = new Map()
   const searchParams = new URLSearchParams(search)
 
-  const path = searchParams.get('preferences')
+  const path = searchParams.get('preferences') || ''
   const labels = searchParams.get('labels')
 
   if (labels) {

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -80,29 +80,29 @@ describe('parsePath()', () => {
   })
 
   test('handles preferences paths', () => {
-    expect(parsePath('/open', '?preferences=/network')).toEqual(
+    expect(parsePath('/open', '?preferences=network')).toEqual(
       locator({
-        path: '/open?preferences=/network',
+        path: '/open?preferences=network',
         pathname: '/open',
         action: 'open',
         mode: APP_MODE_START,
         preferences: { params: new Map(), path: 'network' },
-        search: '?preferences=/network',
+        search: '?preferences=network',
       })
     )
   })
 
   test('handles an app path with a preference path', () => {
-    expect(parsePath(`/p/${ADDRESS}/test`, '?preferences=/network')).toEqual(
+    expect(parsePath(`/p/${ADDRESS}/test`, '?preferences=network')).toEqual(
       locator({
-        path: `/p/${ADDRESS}/test?preferences=/network`,
+        path: `/p/${ADDRESS}/test?preferences=network`,
         pathname: `/p/${ADDRESS}/test`,
         dao: 'p.aragonid.eth',
         instanceId: ADDRESS,
         instancePath: '/test',
         mode: APP_MODE_ORG,
         preferences: { params: new Map(), path: 'network' },
-        search: '?preferences=/network',
+        search: '?preferences=network',
       })
     )
   })


### PR DESCRIPTION
Couple of comments:

Removed the `/` from `GLOBAL_PREFERENCES_QUERY_PARAM = '?preferences='`
And not sure why are we using the `const params = new Map()` do we need that way for some reason?