### PR TITLE
Onboarding: Rename configure screen

### DIFF
--- a/src/onboarding/Configure/Setup.js
+++ b/src/onboarding/Configure/Setup.js
@@ -10,7 +10,7 @@ import { OrgTemplateType } from '../../prop-types'
 export const CONFIGURE_MODE_SELECT = Symbol('CONFIGURE_MODE_SELECT')
 export const CONFIGURE_MODE_CONFIGURE = Symbol('CONFIGURE_MODE_CONFIGURE')
 
-function Configure({
+function Setup({
   TemplateScreen,
   mode,
   onNextTemplateScreen,
@@ -75,7 +75,7 @@ function Configure({
   )
 }
 
-Configure.propTypes = {
+Setup.propTypes = {
   TemplateScreen: PropTypes.func.isRequired,
   mode: PropTypes.oneOf([CONFIGURE_MODE_SELECT, CONFIGURE_MODE_CONFIGURE])
     .isRequired,
@@ -91,4 +91,4 @@ Configure.propTypes = {
   templates: PropTypes.arrayOf(OrgTemplateType).isRequired,
 }
 
-export default Configure
+export default Setup

--- a/src/onboarding/Create/Create.js
+++ b/src/onboarding/Create/Create.js
@@ -19,10 +19,10 @@ import {
   saveTemplateState,
   prepareTransactionCreatorFromAbi,
 } from '../create-utils'
-import Configure, {
+import Setup, {
   CONFIGURE_MODE_SELECT,
   CONFIGURE_MODE_CONFIGURE,
-} from '../Configure/Configure'
+} from '../Configure/Setup'
 import Deployment from '../Deployment/Deployment'
 import ErrorModal from '../../components/ErrorModal/ErrorModal'
 import {
@@ -466,7 +466,7 @@ const Create = React.memo(function Create({
           transactionsStatus={transactionsStatus}
         />
       ) : (
-        <Configure
+        <Setup
           mode={
             status === STATUS_SELECT_TEMPLATE
               ? CONFIGURE_MODE_SELECT


### PR DESCRIPTION
This PR closes #1297 

From a convo with @bpierre we thought that since the `<ConfigureTemplateScreens>` and `<Templates>` shares lot of styes from the Parent screen doesn't make much sense to remove the `ConfigureTemplateScreens` from there, so we thought about  a better naming for the `Configure` screen