### PR TITLE
CI: update deploy workflow

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12
-    - name: npm install
-      run: npm install
-    - name: npm test
-      run: npm run test
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Run tests
+      run: yarn test
     - name: now
       run: >
         now

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,19 +5,19 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Build Aragon
-        run: yarn build
-      - name: Run BundleWatch
-        run: yarn bundlewatch
-      - name: Run tests
-        run: yarn test
+    - uses: actions/checkout@v1
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Build Aragon
+      run: yarn build
+    - name: Run BundleWatch
+      run: yarn bundlewatch
+    - name: Run tests
+      run: yarn test
     env:
       CI: true
       BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the deploy workflow to use yarn instead of npm.

Also fixes the `steps` indentation for the `tests` workflow; this isn't technically wrong (yaml treats the `-` already as an indent), but it does align this workflow to the style shown in Github's Actions documentation.