### PR TITLE
Worker: delay object URL clean up

### DIFF
--- a/src/worker/SandboxedWorker.js
+++ b/src/worker/SandboxedWorker.js
@@ -111,8 +111,13 @@ class SandboxedWorker extends EventTarget {
             }
           })
 
-          // Clean up the url we created to spawn the worker
-          URL.revokeObjectURL(workerUrl)
+          window.addEventListener('unload', () => {
+            // Clean up the url we created to spawn the worker when the iframe is unloaded
+            // Note that we **NEED** to do this late, as Chrome 83+ appears to have
+            // introduced a race condition with starting workers using object URLs,
+            // preventing us from synchronously revoking this object URL immediately.
+            URL.revokeObjectURL(workerUrl)
+          })
         }
 
         init()


### PR DESCRIPTION
Chrome 83+ appears to have made starting workers reliant on an object URL being available.

This must be an asynchronous race condition with the web worker now being starting asynchronously and sharing memory for the object URL. Revoking the object URL synchronously results in an 100% failure rate; using a `setTimeout(0)` results in it only failing some times.