### PR TITLE
SignerPanel: update quotes in radspec descriptions to be fancy quotes

### DIFF
--- a/src/components/SignerPanel/ActionPathsContent.js
+++ b/src/components/SignerPanel/ActionPathsContent.js
@@ -100,7 +100,7 @@ class ActionPathsContent extends React.Component {
                         font-style: italic;
                       `}
                     >
-                      {value.name}
+                      “{value.name}”
                     </span>
                   )
                 }


### PR DESCRIPTION
The signer panel only shows these for roles and kernel namespaces (which is pretty hard to do), but aligns it with the rest of the places where we're rendering descriptions to use the fancy quotes :).