### PR TITLE
App Center: fix release date formats

### DIFF
--- a/src/apps/AppCenter/InstalledApps/RepoVersions.js
+++ b/src/apps/AppCenter/InstalledApps/RepoVersions.js
@@ -91,7 +91,7 @@ const RepoVersions = ({ animate, repo: { currentVersion, versions } }) => {
                   >
                     {timestamp ? (
                       <time
-                        dateTime={dateFormat(timestamp, 'iso')}
+                        dateTime={dateFormat(timestamp)}
                         title={dateFormat(timestamp, 'standard')}
                       >
                         {dateFormat(timestamp, 'onlyDate')}

--- a/src/date-utils.js
+++ b/src/date-utils.js
@@ -5,10 +5,12 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 dayjs.extend(relativeTime)
 
 const KNOWN_FORMATS = {
-  onlyDate: 'yyyy-MM-dd',
+  onlyDate: 'YYYY-MM-DD',
+  standard: 'ddd MMM YYYY, HH:mm:ss',
 }
 
 export function dateFormat(date, formatName) {
+  // dayjs.format() applies ISO format by default if no format is given
   return dayjs(date).format(KNOWN_FORMATS[formatName])
 }
 


### PR DESCRIPTION
Re-adds the `standard` date format that was used, and updates the format to be day.js' formats (rather than [TR35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)).