### PR TITLE
Signing modals: Generic multiple screen modal

### DIFF
--- a/src/components/SigningModals/MultiScreenModal.js
+++ b/src/components/SigningModals/MultiScreenModal.js
@@ -1,33 +1,37 @@
 import React, { useCallback, useState } from 'react'
-import { Spring, Transition, animated } from 'react-spring'
 import PropTypes from 'prop-types'
 import {
-  GU,
   Modal,
   Viewport,
   springs,
   textStyle,
   useViewport,
+  GU,
 } from '@aragon/ui'
+import { Spring, Transition, animated } from 'react-spring'
 import { useSteps } from '../../hooks'
 
 const AnimatedDiv = animated.div
 
+const DEFAULT_MODAL_WIDTH = 700
+
 function MultiScreenModal({ visible, screens, onClose }) {
   const steps = screens.length
   const { prev, step, next, direction } = useSteps(steps)
+
   const [measuredHeight, setMeasuredHeight] = useState(false)
   const [height, setHeight] = useState(null)
   const [firstStart, setFirstStart] = useState(true)
   const { below } = useViewport()
 
   const smallMode = below('medium')
-  const { canClose = true, width = 680 } = screens[step]
+  const { disableClose, width } = screens[step]
+
+  const modalWidth = width || DEFAULT_MODAL_WIDTH
 
   const renderScreen = useCallback(
     step => {
-      const currentScreen = screens[step]
-      const { title } = currentScreen
+      const { title, content } = screens[step]
 
       return (
         <React.Fragment>
@@ -35,13 +39,13 @@ function MultiScreenModal({ visible, screens, onClose }) {
             css={`
               ${smallMode ? textStyle('title4') : textStyle('title3')};
 
-              line-height: 1.2;
-              margin-bottom: ${3 * GU}px;
+              margin-top: -${1 * GU}px;
+              margin-bottom: ${2 * GU}px;
             `}
           >
             {title}
           </h1>
-          {currentScreen.content({
+          {content({
             prevScreen: prev,
             nextScreen: next,
             closeModal: onClose,
@@ -64,69 +68,70 @@ function MultiScreenModal({ visible, screens, onClose }) {
   }, [firstStart])
 
   const handleModalClose = useCallback(() => {
-    if (canClose) {
+    if (!disableClose) {
       onClose()
     }
-  }, [canClose, onClose])
+  }, [disableClose, onClose])
 
   return (
     <Viewport>
       {({ width: viewportWidth }) => {
         const gutter = 30
-        const containWidth = viewportWidth < width + gutter
+        const containWidth = viewportWidth < modalWidth + gutter
 
         return (
           <Modal
             padding={0}
-            width={containWidth ? viewportWidth - gutter : width}
+            width={containWidth ? viewportWidth - gutter : modalWidth}
             onClose={handleModalClose}
             visible={visible}
-            closeButton={canClose}
+            closeButton={!disableClose}
           >
-            <div
-              css={`
-                padding: ${smallMode ? 3 * GU : 5 * GU}px;
-              `}
+            <Spring
+              config={springs.swift}
+              to={{ height }}
+              immediate={firstStart}
+              native
             >
-              <Spring
-                config={springs.smooth}
-                to={{ height }}
-                immediate={firstStart}
-                native
-              >
-                {({ height }) => (
-                  <AnimatedDiv
-                    style={{
-                      position: 'relative',
-                      height: measuredHeight ? height : 'auto',
+              {({ height }) => (
+                <AnimatedDiv
+                  style={{
+                    position: 'relative',
+                    height: measuredHeight ? height : 'auto',
+                  }}
+                >
+                  <Transition
+                    config={(_, state) =>
+                      state === 'leave' ? springs.instant : springs.smooth
+                    }
+                    items={step}
+                    immediate={firstStart}
+                    from={{
+                      opacity: 0,
+                      transform: `translate3d(${5 * GU * direction}px, 0, 0)`,
                     }}
+                    enter={{
+                      opacity: 1,
+                      transform: 'translate3d(0, 0, 0)',
+                    }}
+                    leave={{
+                      opacity: 0,
+                      transform: `translate3d(${5 * GU * -direction}px, 0, 0)`,
+                    }}
+                    onRest={(_, status) => {
+                      if (status === 'update') {
+                        setMeasuredHeight(false)
+                      }
+                    }}
+                    onStart={onStart}
+                    native
                   >
-                    <Transition
-                      config={springs.smooth}
-                      items={step}
-                      immediate={firstStart}
-                      from={{
-                        opacity: 0,
-                        transform: `translate3d(${20 *
-                          GU *
-                          direction}px, 0, 0)`,
-                      }}
-                      enter={{ opacity: 1, transform: 'translate3d(0, 0, 0)' }}
-                      leave={{
-                        opacity: 0,
-                        transform: `translate3d(${20 *
-                          GU *
-                          -direction}px, 0, 0)`,
-                      }}
-                      onRest={(_, status) => {
-                        if (status === 'update') {
-                          setMeasuredHeight(false)
-                        }
-                      }}
-                      onStart={onStart}
-                      native
-                    >
-                      {currentStep => ({ opacity, transform }) => (
+                    {currentStep => ({ opacity, transform }) => {
+                      // For better performance we avoid reflows between screen changes by matching the screen width with the modal width
+                      const screenWidth =
+                        screens[currentStep].width || DEFAULT_MODAL_WIDTH
+
+                      return (
                         <AnimatedDiv
                           ref={elt => {
                             if (elt) {
@@ -138,16 +143,20 @@ function MultiScreenModal({ visible, screens, onClose }) {
                               currentStep === step ? 'static' : 'absolute',
                             transform: transform,
                             opacity: opacity,
+                            width: containWidth
+                              ? viewportWidth - gutter
+                              : screenWidth,
+                            padding: smallMode ? 3 * GU : 5 * GU,
                           }}
                         >
                           {renderScreen(currentStep)}
                         </AnimatedDiv>
-                      )}
-                    </Transition>
-                  </AnimatedDiv>
-                )}
-              </Spring>
-            </div>
+                      )
+                    }}
+                  </Transition>
+                </AnimatedDiv>
+              )}
+            </Spring>
           </Modal>
         )
       }}
@@ -161,11 +170,11 @@ MultiScreenModal.propTypes = {
     PropTypes.shape({
       title: PropTypes.string,
       content: PropTypes.func,
-      canClose: PropTypes.bool,
+      disableClose: PropTypes.bool,
       width: PropTypes.number,
     })
   ),
   onClose: PropTypes.func,
 }
 
-export default MultiScreenModal
+export default React.memo(MultiScreenModal)

--- a/src/components/SigningModals/MultiScreenModal.js
+++ b/src/components/SigningModals/MultiScreenModal.js
@@ -1,0 +1,171 @@
+import React, { useCallback, useState } from 'react'
+import { Spring, Transition, animated } from 'react-spring'
+import PropTypes from 'prop-types'
+import {
+  GU,
+  Modal,
+  Viewport,
+  springs,
+  textStyle,
+  useViewport,
+} from '@aragon/ui'
+import { useSteps } from '../../hooks'
+
+const AnimatedDiv = animated.div
+
+function MultiScreenModal({ visible, screens, onClose }) {
+  const steps = screens.length
+  const { prev, step, next, direction } = useSteps(steps)
+  const [measuredHeight, setMeasuredHeight] = useState(false)
+  const [height, setHeight] = useState(null)
+  const [firstStart, setFirstStart] = useState(true)
+  const { below } = useViewport()
+
+  const smallMode = below('medium')
+  const { canClose = true, width = 680 } = screens[step]
+
+  const renderScreen = useCallback(
+    step => {
+      const currentScreen = screens[step]
+      const { title } = currentScreen
+
+      return (
+        <React.Fragment>
+          <h1
+            css={`
+              ${smallMode ? textStyle('title4') : textStyle('title3')};
+
+              line-height: 1.2;
+              margin-bottom: ${3 * GU}px;
+            `}
+          >
+            {title}
+          </h1>
+          {currentScreen.content({
+            prevScreen: prev,
+            nextScreen: next,
+            closeModal: onClose,
+          })}
+        </React.Fragment>
+      )
+    },
+    [prev, next, onClose, screens, smallMode]
+  )
+
+  const onStart = useCallback(() => {
+    // Don’t animate or set the static height when the modal first opens
+    if (firstStart) {
+      setFirstStart(false)
+
+      return
+    }
+
+    setMeasuredHeight(true)
+  }, [firstStart])
+
+  const handleModalClose = useCallback(() => {
+    if (canClose) {
+      onClose()
+    }
+  }, [canClose, onClose])
+
+  return (
+    <Viewport>
+      {({ width: viewportWidth }) => {
+        const gutter = 30
+        const containWidth = viewportWidth < width + gutter
+
+        return (
+          <Modal
+            padding={0}
+            width={containWidth ? viewportWidth - gutter : width}
+            onClose={handleModalClose}
+            visible={visible}
+            closeButton={canClose}
+          >
+            <div
+              css={`
+                padding: ${smallMode ? 3 * GU : 5 * GU}px;
+              `}
+            >
+              <Spring
+                config={springs.smooth}
+                to={{ height }}
+                immediate={firstStart}
+                native
+              >
+                {({ height }) => (
+                  <AnimatedDiv
+                    style={{
+                      position: 'relative',
+                      height: measuredHeight ? height : 'auto',
+                    }}
+                  >
+                    <Transition
+                      config={springs.smooth}
+                      items={step}
+                      immediate={firstStart}
+                      from={{
+                        opacity: 0,
+                        transform: `translate3d(${20 *
+                          GU *
+                          direction}px, 0, 0)`,
+                      }}
+                      enter={{ opacity: 1, transform: 'translate3d(0, 0, 0)' }}
+                      leave={{
+                        opacity: 0,
+                        transform: `translate3d(${20 *
+                          GU *
+                          -direction}px, 0, 0)`,
+                      }}
+                      onRest={(_, status) => {
+                        if (status === 'update') {
+                          setMeasuredHeight(false)
+                        }
+                      }}
+                      onStart={onStart}
+                      native
+                    >
+                      {currentStep => ({ opacity, transform }) => (
+                        <AnimatedDiv
+                          ref={elt => {
+                            if (elt) {
+                              setHeight(elt.clientHeight)
+                            }
+                          }}
+                          style={{
+                            position:
+                              currentStep === step ? 'static' : 'absolute',
+                            transform: transform,
+                            opacity: opacity,
+                          }}
+                        >
+                          {renderScreen(currentStep)}
+                        </AnimatedDiv>
+                      )}
+                    </Transition>
+                  </AnimatedDiv>
+                )}
+              </Spring>
+            </div>
+          </Modal>
+        )
+      }}
+    </Viewport>
+  )
+}
+
+MultiScreenModal.propTypes = {
+  visible: PropTypes.bool,
+  screens: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      content: PropTypes.func,
+      canClose: PropTypes.bool,
+      width: PropTypes.number,
+    })
+  ),
+  onClose: PropTypes.func,
+}
+
+export default MultiScreenModal

--- a/src/components/SigningModals/prop-types.js
+++ b/src/components/SigningModals/prop-types.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types'
+
+export const ModalProps = PropTypes.shape({
+  prevScreen: PropTypes.func,
+  nextScreen: PropTypes.func,
+  closeModal: PropTypes.func,
+})


### PR DESCRIPTION
Provide basic configuration for each step via an array of objects. Each screen component gains access to `prevScreen` `nextScreen` and `closeModal` via render prop to manage navigation. Can optionally provide a `width` or use the `disableClose` flag to disable closing behaviour for a specific screen.

```
const screens = [
  {
    title: 'Screen 1',
    content: props => <Screen1 modalProps={props} />,
  },
  {
    title: 'Screen 2',
    content: props => <Screen2 modalProps={props} />,
    disableClose: true
  },
  ......
]
```

![ezgif-2-f32fe989b3c1](https://user-images.githubusercontent.com/11708259/86348834-2315da00-bc58-11ea-9823-d78c365cb085.gif)
