### PR TITLE
Permissions: fix prop types errors with not controlling the page in AppPermissions

### DIFF
--- a/src/apps/Permissions/AppPermissions.js
+++ b/src/apps/Permissions/AppPermissions.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { BackButton, Bar, textStyle } from '@aragon/ui'
 import { AppType } from '../../prop-types'
@@ -13,6 +13,8 @@ function AppPermissions({
   onBack,
   onManageRole,
 }) {
+  const [page, setPage] = useState(0)
+
   const permissions = usePermissionsByRole()
 
   const appProxyAddress = app ? app.proxyAddress : null
@@ -27,6 +29,14 @@ function AppPermissions({
         : [],
     [permissions, appProxyAddress]
   )
+
+  const permissionsKey = appPermissions
+    .map(permission => `${permission.app.proxyAddress}-${permission.role.id}`)
+    .join(',')
+
+  useEffect(() => {
+    setPage(0)
+  }, [permissionsKey])
 
   if (loading || !appProxyAddress) {
     return <EmptyBlock>Loading permissions…</EmptyBlock>
@@ -60,6 +70,8 @@ function AppPermissions({
         }
         onAssignPermission={onAssignPermission}
         onManageRole={onManageRole}
+        onPageChange={setPage}
+        page={page}
         permissions={appPermissions}
         showApps={false}
       />

--- a/src/apps/Permissions/Home/AllPermissions.js
+++ b/src/apps/Permissions/Home/AllPermissions.js
@@ -17,9 +17,9 @@ const ENTITY_TYPES = ['All entities', 'Accounts', 'Apps']
 
 function AllPermissions({
   loading,
-  permissions,
   onAssignPermission,
   onManageRole,
+  permissions,
 }) {
   const [selectedEntityType, setSelectedEntityType] = useState(-1)
   const [searchTerms, setSearchTerms] = useState('')

--- a/src/apps/Permissions/Home/Home.js
+++ b/src/apps/Permissions/Home/Home.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Tabs } from '@aragon/ui'
 import { AppType } from '../../../prop-types'
@@ -25,12 +25,16 @@ function Home({
     app => Boolean(app.isAragonOsInternalApp) === internalAppsOnly
   )
 
-  const permissionsFiltered = permissions.filter(
-    permission =>
-      permission.app &&
-      (permission.entities.length > 0 ||
-        permission.manager.type !== 'unassigned') &&
-      Boolean(permission.app.isAragonOsInternalApp) === internalAppsOnly
+  const permissionsFiltered = useMemo(
+    () =>
+      permissions.filter(
+        permission =>
+          permission.app &&
+          (permission.entities.length > 0 ||
+            permission.manager.type !== 'unassigned') &&
+          Boolean(permission.app.isAragonOsInternalApp) === internalAppsOnly
+      ),
+    [permissions, internalAppsOnly]
   )
 
   return (


### PR DESCRIPTION
Fixes some prop types errors caused by https://github.com/aragon/aragon/pull/1385 missing required changes for `AppPermissions`.