### PR TITLE
Signing modals: Tx stepper

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -1,6 +1,6 @@
-Hacks
-=====
+# Hacks
 
 We've had to do some not so nice things to make things work, or work better :cry:.
 
 - Cloned the `window.ethereum` object to another place before the app loads so [web3 can't mutate it](https://github.com/aragon/aragon/pull/1463/files): [web3 has side-effects](https://github.com/ethereum/web3.js/issues/3374)
+- Polyfilled [ResizeObserver](https://github.com/juggle/resize-observer) for backwards compatibility when measuring our [Transaction Stepper](https://github.com/aragon/aragon/pull/1473#discussion_r451529607)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-helmet": "^5.2.1",
     "react-spring": "^7.2.10",
     "react-use-gesture": "^5.2.4",
+    "react-use-measure": "^2.0.1",
     "regenerator-runtime": "^0.13.3",
     "resolve-pathname": "^3.0.0",
     "styled-components": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@aragon/templates-tokens": "^1.2.1",
     "@aragon/ui": "^1.4.2",
     "@aragon/wrapper": "^5.0.0-rc.28",
+    "@juggle/resize-observer": "^3.2.0",
     "@sentry/browser": "^5.17.0",
     "@ungap/event-target": "^0.1.0",
     "clipboard-polyfill": "^2.8.6",

--- a/src/components/SigningModals/TransactionStepper/Step/Divider.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Divider.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+function Divider({ className, color }) {
+  return (
+    <svg
+      width="75.75"
+      height="9.53"
+      viewBox="0 0 75.75 9.53"
+      className={className}
+    >
+      <path d="M3.75,4.76,0,9.53V0Z" fill={color} opacity="0.3" />
+      <path d="M11.75,4.76,8,9.53V0Z" fill={color} opacity="0.4" />
+      <path d="M19.75,4.76,16,9.53V0Z" fill={color} opacity="0.5" />
+      <path d="M27.75,4.76,24,9.53V0Z" fill={color} opacity="0.6" />
+      <path d="M35.75,4.76,32,9.53V0Z" fill={color} opacity="0.7" />
+      <path d="M43.75,4.76,40,9.53V0Z" fill={color} opacity="0.8" />
+      <path d="M51.75,4.76,48,9.53V0Z" fill={color} />
+      <path d="M59.75,4.76,56,9.53V0Z" fill={color} />
+      <path d="M67.75,4.76,64,9.53V0Z" fill={color} />
+      <path d="M75.75,4.76,72,9.53V0Z" fill={color} />
+    </svg>
+  )
+}
+
+Divider.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+}
+
+export default Divider

--- a/src/components/SigningModals/TransactionStepper/Step/Illustration.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Illustration.js
@@ -1,0 +1,101 @@
+import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
+import { STEP_ERROR, STEP_SUCCESS, STEP_WORKING } from '../stepper-statuses'
+
+const gradients = {
+  [STEP_WORKING]: [
+    ['#98f9ff', '#00c2ff'],
+    ['#01e8f7', '#00c2ff'],
+  ],
+  [STEP_SUCCESS]: [
+    ['#9fe8d2', '#00c2ff'],
+    ['#73d8ce', '#18b9a0'],
+  ],
+  [STEP_ERROR]: [
+    ['#ffa48e', '#f8baab'],
+    ['#fa8e75', '#ef7757'],
+  ],
+}
+
+function Illustration({ status }) {
+  const [backgroundFrom, backgroundTo] = gradients[status][0]
+  const [foregroundFrom, foregroundTo] = gradients[status][1]
+
+  const gradientId = useCallback(id => `${status.description}-${id}`, [status])
+
+  return (
+    <svg
+      viewBox="0 0 70 70"
+      css={`
+        display: block;
+      `}
+    >
+      <defs>
+        <linearGradient
+          id={gradientId('a')}
+          x1="86.03"
+          y1="-2.54"
+          x2="-184.81"
+          y2="207.33"
+          gradientTransform="matrix(1, 0, 0, -1, 0, 72)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor={backgroundFrom} />
+          <stop offset="1" stopColor={backgroundTo} />
+        </linearGradient>
+        <linearGradient
+          id={gradientId('b')}
+          x1="59.34"
+          y1="15.79"
+          x2="38.41"
+          y2="19.85"
+          gradientTransform="matrix(1, 0, 0, -1, 0, 72)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor={foregroundFrom} />
+          <stop offset="1" stopColor={foregroundTo} />
+        </linearGradient>
+        <linearGradient
+          id={gradientId('c')}
+          x1="54.24"
+          y1="46.24"
+          x2="16.48"
+          y2="60.87"
+          xlinkHref={`#${gradientId('b')}`}
+        />
+        <linearGradient
+          id={gradientId('d')}
+          x1="31.91"
+          y1="21.06"
+          x2="10.98"
+          y2="25.11"
+          xlinkHref={`#${gradientId('b')}`}
+        />
+      </defs>
+      <path
+        d="M64.18,48.77V21.23a5.48,5.48,0,0,0-2.72-4.73L37.72,2.73a5.45,5.45,0,0,0-5.44,0L8.54,16.5a5.48,5.48,0,0,0-2.72,4.73V48.77A5.48,5.48,0,0,0,8.54,53.5L32.28,67.27a5.45,5.45,0,0,0,5.44,0L61.46,53.5A5.48,5.48,0,0,0,64.18,48.77Z"
+        fill={`url(#${gradientId('a')})`}
+      />
+      <path
+        d="M61.46,53.5a5.48,5.48,0,0,0,2-2L35,35V68a5.39,5.39,0,0,0,2.72-.73Z"
+        fill={`url(#${gradientId('b')})`}
+        opacity="0.6"
+      />
+      <path
+        d="M35,35,63.44,18.5a5.35,5.35,0,0,0-2-2L37.71,2.73a5.43,5.43,0,0,0-5.43,0L8.54,16.5a5.45,5.45,0,0,0-2,2Z"
+        fill={`url(#${gradientId('c')})`}
+      />
+      <path
+        d="M8.54,53.5a5.48,5.48,0,0,1-2-2L35,35V68a5.35,5.35,0,0,1-2.71-.73Z"
+        opacity="0.4"
+        fill={`url(#${gradientId('d')})`}
+      />
+    </svg>
+  )
+}
+
+Illustration.propTypes = {
+  status: PropTypes.oneOf([STEP_WORKING, STEP_SUCCESS, STEP_ERROR]),
+}
+
+export default Illustration

--- a/src/components/SigningModals/TransactionStepper/Step/Illustration.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Illustration.js
@@ -17,11 +17,15 @@ const gradients = {
   ],
 }
 
-function Illustration({ status }) {
+function Illustration({ status, index }) {
   const [backgroundFrom, backgroundTo] = gradients[status][0]
   const [foregroundFrom, foregroundTo] = gradients[status][1]
 
-  const gradientId = useCallback(id => `${status.description}-${id}`, [status])
+  // Inline SVGs don't scope their defs so we have to provide unique ids
+  const gradientId = useCallback(id => `${status.description}-${index}-${id}`, [
+    status,
+    index,
+  ])
 
   return (
     <svg
@@ -96,6 +100,7 @@ function Illustration({ status }) {
 
 Illustration.propTypes = {
   status: PropTypes.oneOf([STEP_WORKING, STEP_SUCCESS, STEP_ERROR]),
+  index: PropTypes.number,
 }
 
 export default Illustration

--- a/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
@@ -197,7 +197,7 @@ function StepIllustration({ number, status }) {
       `}
     >
       {renderIllustration ? (
-        <Illustration status={status} />
+        <Illustration status={status} index={number} />
       ) : (
         <div
           css={`

--- a/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { css, keyframes } from 'styled-components'
@@ -10,6 +10,7 @@ import {
   textStyle,
   useTheme,
 } from '@aragon/ui'
+import Illustration from './Illustration'
 import {
   STEP_ERROR,
   STEP_PROMPTING,
@@ -17,7 +18,7 @@ import {
   STEP_WAITING,
   STEP_WORKING,
 } from '../stepper-statuses'
-import Illustration from './Illustration'
+import { useDeferredAnimation } from '../../../../hooks'
 
 const STATUS_ICONS = {
   [STEP_ERROR]: IconCross,
@@ -53,14 +54,7 @@ const pulseAnimation = css`
 
 function StatusVisual({ status, color, number, className }) {
   const theme = useTheme()
-  const [firstStart, setFirstStart] = useState(true)
-
-  const onStart = useCallback(() => {
-    // Don’t animate on first render
-    if (firstStart) {
-      setFirstStart(false)
-    }
-  }, [firstStart])
+  const [immediateAnimation, onAnimationStart] = useDeferredAnimation()
 
   const [statusIcon, illustration] = useMemo(() => {
     const Icon = STATUS_ICONS[status]
@@ -106,8 +100,8 @@ function StatusVisual({ status, color, number, className }) {
                 state === 'enter' ? springs.smooth : springs.swift
               }
               items={statusIcon}
-              onStart={onStart}
-              immediate={firstStart}
+              onStart={onAnimationStart}
+              immediate={immediateAnimation}
               from={{
                 transform: 'scale3d(1.25, 1.25, 1)',
               }}

--- a/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { css, keyframes } from 'styled-components'
 import {
@@ -18,15 +19,6 @@ import {
 } from '../stepper-statuses'
 
 import Illustration from './Illustration'
-import PropTypes from 'prop-types'
-
-const ABSOLUTE_FILL = `
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-`
 
 const STATUS_ICONS = {
   [STEP_ERROR]: IconCross,
@@ -79,6 +71,7 @@ function StatusVisual({ status, color, number, className }) {
     <div
       className={className}
       css={`
+        display: flex;
         position: relative;
         width: ${13.5 * GU}px;
         height: ${13.5 * GU}px;
@@ -86,10 +79,8 @@ function StatusVisual({ status, color, number, className }) {
     >
       <div
         css={`
-          ${ABSOLUTE_FILL}
-
           display: flex;
-
+          flex: 1;
           align-items: center;
           justify-content: center;
         `}
@@ -182,15 +173,18 @@ function StatusVisual({ status, color, number, className }) {
         </div>
         <div
           css={`
-            ${ABSOLUTE_FILL}
-            ${status === STEP_PROMPTING && pulseAnimation}
-            ${status === STEP_WORKING && spinAnimation}
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
 
             border-radius: 100%;
+            border: 2px solid ${status === STEP_WAITING ? 'transparent' : color};
 
-            border: 2px solid
-            ${status === STEP_WAITING ? 'transparent' : color};
-        `}
+            ${status === STEP_PROMPTING && pulseAnimation}
+            ${status === STEP_WORKING && spinAnimation}
+          `}
         />
       </div>
     </div>
@@ -204,9 +198,9 @@ StatusVisual.propTypes = {
     STEP_WORKING,
     STEP_SUCCESS,
     STEP_ERROR,
-  ]),
-  color: PropTypes.string,
-  number: PropTypes.number,
+  ]).isRequired,
+  color: PropTypes.string.isRequired,
+  number: PropTypes.number.isRequired,
   className: PropTypes.string,
 }
 

--- a/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { css, keyframes } from 'styled-components'
@@ -17,7 +17,6 @@ import {
   STEP_WAITING,
   STEP_WORKING,
 } from '../stepper-statuses'
-
 import Illustration from './Illustration'
 
 const STATUS_ICONS = {
@@ -55,7 +54,6 @@ const pulseAnimation = css`
 function StatusVisual({ status, color, number, className }) {
   const theme = useTheme()
   const [firstStart, setFirstStart] = useState(true)
-  const StatusIcon = STATUS_ICONS[status]
 
   const onStart = useCallback(() => {
     // Don’t animate on first render
@@ -64,8 +62,14 @@ function StatusVisual({ status, color, number, className }) {
     }
   }, [firstStart])
 
-  const renderIllustration =
-    status === STEP_WORKING || status === STEP_ERROR || status === STEP_SUCCESS
+  const [statusIcon, illustration] = useMemo(() => {
+    const Icon = STATUS_ICONS[status]
+
+    return [
+      Icon && <Icon />,
+      <StepIllustration number={number} status={status} />,
+    ]
+  }, [status, number])
 
   return (
     <div
@@ -101,7 +105,7 @@ function StatusVisual({ status, color, number, className }) {
               config={(_, state) =>
                 state === 'enter' ? springs.smooth : springs.swift
               }
-              items={StatusIcon}
+              items={statusIcon}
               onStart={onStart}
               immediate={firstStart}
               from={{
@@ -118,58 +122,32 @@ function StatusVisual({ status, color, number, className }) {
               }}
               native
             >
-              {CurrentStatusIcon =>
-                CurrentStatusIcon &&
+              {currentStatusIcon =>
+                currentStatusIcon &&
                 (animProps => (
                   <AnimatedDiv
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                      borderRadius: '100%',
-                      padding: `${0.25 * GU}px`,
-                      backgroundColor: theme.surface,
-                      border: '1px solid currentColor',
-                      bottom: 0,
-                      right: 0,
-                      color,
-                      ...animProps,
-                    }}
+                    css={`
+                      display: flex;
+                      justify-content: center;
+                      align-items: center;
+                      border-radius: 100%;
+                      padding: ${0.25 * GU}px;
+                      background-color: ${theme.surface};
+                      color: ${color};
+                      border: 1px solid currentColor;
+                      bottom: 0;
+                      left: 0;
+                    `}
+                    style={animProps}
                   >
-                    <CurrentStatusIcon />
+                    {currentStatusIcon}
                   </AnimatedDiv>
                 ))
               }
             </Transition>
           </div>
 
-          <div
-            css={`
-              width: ${8.5 * GU}px;
-              height: ${8.5 * GU}px;
-            `}
-          >
-            {renderIllustration ? (
-              <Illustration status={status} />
-            ) : (
-              <div
-                css={`
-                  display: flex;
-                  align-items: center;
-                  justify-content: center;
-                  background-color: ${theme.surfaceOpened};
-                  height: 100%;
-                  border-radius: 100%;
-                  color: ${theme.accentContent};
-
-                  ${textStyle('title3')}
-                  font-weight: 600;
-                `}
-              >
-                {number}
-              </div>
-            )}
-          </div>
+          {illustration}
         </div>
         <div
           css={`
@@ -203,5 +181,44 @@ StatusVisual.propTypes = {
   number: PropTypes.number.isRequired,
   className: PropTypes.string,
 }
+
+/* eslint-disable react/prop-types */
+function StepIllustration({ number, status }) {
+  const theme = useTheme()
+
+  const renderIllustration =
+    status === STEP_WORKING || status === STEP_ERROR || status === STEP_SUCCESS
+
+  return (
+    <div
+      css={`
+        width: ${8.5 * GU}px;
+        height: ${8.5 * GU}px;
+      `}
+    >
+      {renderIllustration ? (
+        <Illustration status={status} />
+      ) : (
+        <div
+          css={`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: ${theme.surfaceOpened};
+            height: 100%;
+            border-radius: 100%;
+            color: ${theme.accentContent};
+
+            ${textStyle('title3')}
+            font-weight: 600;
+          `}
+        >
+          {number}
+        </div>
+      )}
+    </div>
+  )
+}
+/* eslint-enable react/prop-types */
 
 export default StatusVisual

--- a/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModals/TransactionStepper/Step/StatusVisual.js
@@ -1,0 +1,213 @@
+import React, { useCallback, useState } from 'react'
+import { Transition, animated } from 'react-spring'
+import { css, keyframes } from 'styled-components'
+import {
+  GU,
+  IconCheck,
+  IconCross,
+  springs,
+  textStyle,
+  useTheme,
+} from '@aragon/ui'
+import {
+  STEP_ERROR,
+  STEP_PROMPTING,
+  STEP_SUCCESS,
+  STEP_WAITING,
+  STEP_WORKING,
+} from '../stepper-statuses'
+
+import Illustration from './Illustration'
+import PropTypes from 'prop-types'
+
+const ABSOLUTE_FILL = `
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`
+
+const STATUS_ICONS = {
+  [STEP_ERROR]: IconCross,
+  [STEP_SUCCESS]: IconCheck,
+}
+
+const AnimatedDiv = animated.div
+
+const spinAnimation = css`
+  mask-image: linear-gradient(35deg, transparent 15%, rgba(0, 0, 0, 1));
+  animation: ${keyframes`
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  `} 1.5s linear infinite;
+`
+
+const pulseAnimation = css`
+  animation: ${keyframes`
+    from {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0.2;
+    }
+  `} 0.75s linear alternate infinite;
+`
+
+function StatusVisual({ status, color, number, className }) {
+  const theme = useTheme()
+  const [firstStart, setFirstStart] = useState(true)
+  const StatusIcon = STATUS_ICONS[status]
+
+  const onStart = useCallback(() => {
+    // Don’t animate on first render
+    if (firstStart) {
+      setFirstStart(false)
+    }
+  }, [firstStart])
+
+  const renderIllustration =
+    status === STEP_WORKING || status === STEP_ERROR || status === STEP_SUCCESS
+
+  return (
+    <div
+      className={className}
+      css={`
+        position: relative;
+        width: ${13.5 * GU}px;
+        height: ${13.5 * GU}px;
+      `}
+    >
+      <div
+        css={`
+          ${ABSOLUTE_FILL}
+
+          display: flex;
+
+          align-items: center;
+          justify-content: center;
+        `}
+      >
+        <div
+          css={`
+            position: relative;
+          `}
+        >
+          <div
+            css={`
+              position: absolute;
+              bottom: ${0.5 * GU}px;
+              right: 0;
+            `}
+          >
+            <Transition
+              config={(_, state) =>
+                state === 'enter' ? springs.smooth : springs.swift
+              }
+              items={StatusIcon}
+              onStart={onStart}
+              immediate={firstStart}
+              from={{
+                transform: 'scale3d(1.25, 1.25, 1)',
+              }}
+              enter={{
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1)',
+              }}
+              leave={{
+                position: 'absolute',
+                opacity: 0,
+                transform: 'scale3d(0.8, 0.8, 1)',
+              }}
+              native
+            >
+              {CurrentStatusIcon =>
+                CurrentStatusIcon &&
+                (animProps => (
+                  <AnimatedDiv
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      borderRadius: '100%',
+                      padding: `${0.25 * GU}px`,
+                      backgroundColor: theme.surface,
+                      border: '1px solid currentColor',
+                      bottom: 0,
+                      right: 0,
+                      color,
+                      ...animProps,
+                    }}
+                  >
+                    <CurrentStatusIcon />
+                  </AnimatedDiv>
+                ))
+              }
+            </Transition>
+          </div>
+
+          <div
+            css={`
+              width: ${8.5 * GU}px;
+              height: ${8.5 * GU}px;
+            `}
+          >
+            {renderIllustration ? (
+              <Illustration status={status} />
+            ) : (
+              <div
+                css={`
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  background-color: ${theme.surfaceOpened};
+                  height: 100%;
+                  border-radius: 100%;
+                  color: ${theme.accentContent};
+
+                  ${textStyle('title3')}
+                  font-weight: 600;
+                `}
+              >
+                {number}
+              </div>
+            )}
+          </div>
+        </div>
+        <div
+          css={`
+            ${ABSOLUTE_FILL}
+            ${status === STEP_PROMPTING && pulseAnimation}
+            ${status === STEP_WORKING && spinAnimation}
+
+            border-radius: 100%;
+
+            border: 2px solid
+            ${status === STEP_WAITING ? 'transparent' : color};
+        `}
+        />
+      </div>
+    </div>
+  )
+}
+
+StatusVisual.propTypes = {
+  status: PropTypes.oneOf([
+    STEP_WAITING,
+    STEP_PROMPTING,
+    STEP_WORKING,
+    STEP_SUCCESS,
+    STEP_ERROR,
+  ]),
+  color: PropTypes.string,
+  number: PropTypes.number,
+  className: PropTypes.string,
+}
+
+export default StatusVisual

--- a/src/components/SigningModals/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Step.js
@@ -1,4 +1,5 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useMemo } from 'react'
+import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { GU, TransactionBadge, springs, textStyle, useTheme } from '@aragon/ui'
 import {
@@ -10,48 +11,9 @@ import {
 } from '../stepper-statuses'
 
 import Divider from './Divider'
-import PropTypes from 'prop-types'
 import StatusVisual from './StatusVisual'
 
 const BADGE_OFFSET = 4.5 * GU
-
-const getStepAppearance = (status, theme) => {
-  const appearance = {
-    [STEP_WAITING]: {
-      desc: 'Waiting for signature',
-      visualColor: theme.accent,
-      descColor: theme.contentSecondary,
-    },
-    [STEP_PROMPTING]: {
-      desc: 'Waiting for signature',
-      visualColor: theme.accent,
-      descColor: theme.contentSecondary,
-    },
-    [STEP_WORKING]: {
-      desc: 'Transaction being mined',
-      visualColor: theme.accent,
-      descColor: theme.accent,
-    },
-    [STEP_SUCCESS]: {
-      desc: 'Transaction confirmed',
-      visualColor: theme.positive,
-      descColor: theme.positive,
-    },
-    [STEP_ERROR]: {
-      desc: 'An error has occured',
-      visualColor: theme.negative,
-      descColor: theme.negative,
-    },
-  }
-
-  const { desc, descColor, visualColor } = appearance[status]
-
-  return {
-    desc,
-    visualColor: `${visualColor}`,
-    descColor: `${descColor}`,
-  }
-}
 
 const AnimatedSpan = animated.span
 
@@ -66,7 +28,43 @@ function Step({
   const theme = useTheme()
   const [firstStart, setFirstStart] = useState(true)
 
-  const { desc, visualColor, descColor } = getStepAppearance(status, theme)
+  const { desc, visualColor, descColor } = useMemo(() => {
+    const appearance = {
+      [STEP_WAITING]: {
+        desc: 'Waiting for signature',
+        visualColor: theme.accent,
+        descColor: theme.contentSecondary,
+      },
+      [STEP_PROMPTING]: {
+        desc: 'Waiting for signature',
+        visualColor: theme.accent,
+        descColor: theme.contentSecondary,
+      },
+      [STEP_WORKING]: {
+        desc: 'Transaction being mined',
+        visualColor: theme.accent,
+        descColor: theme.accent,
+      },
+      [STEP_SUCCESS]: {
+        desc: 'Transaction confirmed',
+        visualColor: theme.positive,
+        descColor: theme.positive,
+      },
+      [STEP_ERROR]: {
+        desc: 'An error has occured',
+        visualColor: theme.negative,
+        descColor: theme.negative,
+      },
+    }
+
+    const { desc, descColor, visualColor } = appearance[status]
+
+    return {
+      desc,
+      visualColor: `${visualColor}`,
+      descColor: `${descColor}`,
+    }
+  }, [status, theme])
 
   const onStart = useCallback(() => {
     // Don’t animate on first render
@@ -139,8 +137,8 @@ function Step({
             }}
             native
           >
-            {currentAppearance =>
-              currentAppearance &&
+            {description =>
+              description &&
               (props => (
                 <AnimatedSpan
                   style={{
@@ -152,7 +150,7 @@ function Step({
                     ...props,
                   }}
                 >
-                  {currentAppearance}
+                  {description}
                 </AnimatedSpan>
               ))
             }
@@ -160,6 +158,7 @@ function Step({
         </p>
         <div
           css={`
+            display: flex;
             position: relative;
 
             width: 100%;
@@ -171,18 +170,14 @@ function Step({
           {transactionHash && (
             <div
               css={`
-                position: absolute;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-
-                width: 100%;
-
                 display: flex;
+
+                flex: 1;
                 align-items: center;
                 justify-content: flex-end;
                 flex-direction: column;
+
+                width: 100%;
               `}
             >
               <Transition

--- a/src/components/SigningModals/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Step.js
@@ -1,7 +1,8 @@
-import React, { useCallback, useState, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import { GU, TransactionBadge, springs, textStyle, useTheme } from '@aragon/ui'
+import Divider from './Divider'
 import {
   STEP_ERROR,
   STEP_PROMPTING,
@@ -9,8 +10,7 @@ import {
   STEP_WAITING,
   STEP_WORKING,
 } from '../stepper-statuses'
-
-import Divider from './Divider'
+import { useDeferredAnimation } from '../../../../hooks'
 import StatusVisual from './StatusVisual'
 
 const BADGE_OFFSET = 4.5 * GU
@@ -26,7 +26,7 @@ function Step({
   showDivider,
 }) {
   const theme = useTheme()
-  const [firstStart, setFirstStart] = useState(true)
+  const [immediateAnimation, onAnimationStart] = useDeferredAnimation()
 
   const { desc, visualColor, descColor } = useMemo(() => {
     const appearance = {
@@ -65,13 +65,6 @@ function Step({
       descColor: `${descColor}`,
     }
   }, [status, theme])
-
-  const onStart = useCallback(() => {
-    // Don’t animate on first render
-    if (firstStart) {
-      setFirstStart(false)
-    }
-  }, [firstStart])
 
   return (
     <React.Fragment>
@@ -119,8 +112,8 @@ function Step({
           <Transition
             config={springs.smooth}
             items={desc}
-            onStart={onStart}
-            immediate={status === STEP_PROMPTING || firstStart}
+            onStart={onAnimationStart}
+            immediate={status === STEP_PROMPTING || immediateAnimation}
             from={{
               opacity: 0,
               transform: `translate3d(0, ${2 * GU}px, 0)`,
@@ -183,8 +176,8 @@ function Step({
               <Transition
                 config={springs.smooth}
                 items={transactionHash}
-                onStart={onStart}
-                immediate={firstStart}
+                onStart={onAnimationStart}
+                immediate={immediateAnimation}
                 from={{
                   opacity: 0,
                   transform: `translate3d(0, ${1 * GU}px, 0)`,

--- a/src/components/SigningModals/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModals/TransactionStepper/Step/Step.js
@@ -1,0 +1,255 @@
+import React, { useCallback, useState } from 'react'
+import { Transition, animated } from 'react-spring'
+import { GU, TransactionBadge, springs, textStyle, useTheme } from '@aragon/ui'
+import {
+  STEP_ERROR,
+  STEP_PROMPTING,
+  STEP_SUCCESS,
+  STEP_WAITING,
+  STEP_WORKING,
+} from '../stepper-statuses'
+
+import Divider from './Divider'
+import PropTypes from 'prop-types'
+import StatusVisual from './StatusVisual'
+
+const BADGE_OFFSET = 4.5 * GU
+
+const getStepAppearance = (status, theme) => {
+  const appearance = {
+    [STEP_WAITING]: {
+      desc: 'Waiting for signature',
+      visualColor: theme.accent,
+      descColor: theme.contentSecondary,
+    },
+    [STEP_PROMPTING]: {
+      desc: 'Waiting for signature',
+      visualColor: theme.accent,
+      descColor: theme.contentSecondary,
+    },
+    [STEP_WORKING]: {
+      desc: 'Transaction being mined',
+      visualColor: theme.accent,
+      descColor: theme.accent,
+    },
+    [STEP_SUCCESS]: {
+      desc: 'Transaction confirmed',
+      visualColor: theme.positive,
+      descColor: theme.positive,
+    },
+    [STEP_ERROR]: {
+      desc: 'An error has occured',
+      visualColor: theme.negative,
+      descColor: theme.negative,
+    },
+  }
+
+  const { desc, descColor, visualColor } = appearance[status]
+
+  return {
+    desc,
+    visualColor: `${visualColor}`,
+    descColor: `${descColor}`,
+  }
+}
+
+const AnimatedSpan = animated.span
+
+function Step({
+  title,
+  status,
+  number,
+  className,
+  transactionHash,
+  showDivider,
+}) {
+  const theme = useTheme()
+  const [firstStart, setFirstStart] = useState(true)
+
+  const { desc, visualColor, descColor } = getStepAppearance(status, theme)
+
+  const onStart = useCallback(() => {
+    // Don’t animate on first render
+    if (firstStart) {
+      setFirstStart(false)
+    }
+  }, [firstStart])
+
+  return (
+    <React.Fragment>
+      <div
+        className={className}
+        css={`
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+
+          padding-top: ${BADGE_OFFSET}px;
+
+          width: ${23 * GU}px;
+        `}
+      >
+        <StatusVisual
+          status={status}
+          color={visualColor}
+          number={number}
+          css={`
+            margin-bottom: ${3 * GU}px;
+          `}
+        />
+        <h2
+          css={`
+            ${textStyle('title4')}
+
+            line-height: 1.2;
+            text-align: center;
+            margin-bottom: ${1 * GU}px;
+          `}
+        >
+          {status === STEP_ERROR ? 'Transaction failed' : title}
+        </h2>
+
+        <p
+          css={`
+            width: 100%;
+            position: relative;
+            text-align: center;
+            color: ${theme.contentSecondary};
+            line-height: 1.2;
+          `}
+        >
+          <Transition
+            config={springs.smooth}
+            items={desc}
+            onStart={onStart}
+            immediate={status === STEP_PROMPTING || firstStart}
+            from={{
+              opacity: 0,
+              transform: `translate3d(0, ${2 * GU}px, 0)`,
+            }}
+            enter={{
+              opacity: 1,
+              transform: 'translate3d(0, 0, 0)',
+              color: descColor,
+            }}
+            leave={{
+              position: 'absolute',
+              opacity: 0,
+              transform: `translate3d(0, -${2 * GU}px, 0)`,
+            }}
+            native
+          >
+            {currentAppearance =>
+              currentAppearance &&
+              (props => (
+                <AnimatedSpan
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    left: 0,
+                    top: 0,
+                    width: '100%',
+                    ...props,
+                  }}
+                >
+                  {currentAppearance}
+                </AnimatedSpan>
+              ))
+            }
+          </Transition>
+        </p>
+        <div
+          css={`
+            position: relative;
+
+            width: 100%;
+
+            /* Avoid visual jump when showing tx by pre-filling space */
+            height: ${BADGE_OFFSET}px;
+          `}
+        >
+          {transactionHash && (
+            <div
+              css={`
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+
+                width: 100%;
+
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                flex-direction: column;
+              `}
+            >
+              <Transition
+                config={springs.smooth}
+                items={transactionHash}
+                onStart={onStart}
+                immediate={firstStart}
+                from={{
+                  opacity: 0,
+                  transform: `translate3d(0, ${1 * GU}px, 0)`,
+                }}
+                enter={{
+                  opacity: 1,
+                  transform: 'translate3d(0, 0, 0)',
+                }}
+                leave={{
+                  opacity: 0,
+                  transform: `translate3d(0, -${1 * GU}px, 0)`,
+                }}
+                native
+              >
+                {currentHash => animProps => (
+                  <AnimatedSpan
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      bottom: 0,
+                      display: 'flex',
+                      justifyContent: 'center',
+                      width: '100%',
+                      ...animProps,
+                    }}
+                  >
+                    <TransactionBadge transaction={currentHash} />
+                  </AnimatedSpan>
+                )}
+              </Transition>
+            </div>
+          )}
+        </div>
+      </div>
+      {showDivider && (
+        <Divider
+          color={visualColor}
+          css={`
+            position: relative;
+            top: ${BADGE_OFFSET + 6 * GU}px;
+          `}
+        />
+      )}
+    </React.Fragment>
+  )
+}
+
+Step.propTypes = {
+  title: PropTypes.string,
+  transactionHash: PropTypes.string,
+  className: PropTypes.string,
+  number: PropTypes.number,
+  status: PropTypes.oneOf([
+    STEP_WAITING,
+    STEP_PROMPTING,
+    STEP_WORKING,
+    STEP_SUCCESS,
+    STEP_ERROR,
+  ]).isRequired,
+  showDivider: PropTypes.bool,
+}
+
+export default Step

--- a/src/components/SigningModals/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModals/TransactionStepper/TransactionStepper.js
@@ -1,0 +1,247 @@
+import React, {
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import { PropTypes } from 'prop-types'
+import { Transition, animated } from 'react-spring'
+import { noop, useTheme, springs, GU } from '@aragon/ui'
+import {
+  STEP_ERROR,
+  STEP_PROMPTING,
+  STEP_SUCCESS,
+  STEP_WAITING,
+  STEP_WORKING,
+} from './stepper-statuses'
+import useStepperLayout from './useStepperLayout'
+import Step from './Step/Step'
+
+const AnimatedDiv = animated.div
+
+function initialStepState(steps) {
+  return steps.map((_, i) => {
+    return {
+      status: i === 0 ? STEP_PROMPTING : STEP_WAITING,
+      hash: null,
+    }
+  })
+}
+
+function reduceSteps(steps, [action, stepIndex, value]) {
+  if (action === 'setHash') {
+    steps[stepIndex].hash = value
+    return [...steps]
+  }
+  if (action === 'setStatus') {
+    steps[stepIndex].status = value
+    return [...steps]
+  }
+  return steps
+}
+
+function TransactionStepper({ steps, onComplete, className }) {
+  const theme = useTheme()
+  const [stepperStage, setStepperStage] = useState(0)
+  const [stepState, updateStep] = useReducer(
+    reduceSteps,
+    initialStepState(steps)
+  )
+  const [firstStart, setFirstStart] = useState(true)
+
+  const {
+    outerBoundsRef,
+    innerBoundsRef,
+    layout,
+    measuring,
+  } = useStepperLayout()
+
+  const canPerformUpdate = useRef(true)
+
+  const stepsCount = steps.length - 1
+
+  const onStart = useCallback(() => {
+    // Don’t animate on first render
+    if (firstStart) {
+      setFirstStart(false)
+    }
+  }, [firstStart])
+
+  const renderStep = (stepIndex, showDivider) => {
+    const title = steps[stepIndex][0]
+    const { status, hash } = stepState[stepIndex]
+
+    return (
+      <li
+        key={stepIndex}
+        css={`
+          display: flex;
+        `}
+      >
+        <Step
+          title={title}
+          number={stepIndex + 1}
+          status={status}
+          showDivider={showDivider}
+          transactionHash={hash}
+        />
+      </li>
+    )
+  }
+
+  const renderSteps = () => {
+    return steps.map((_, index) => {
+      const showDivider = index < stepsCount
+
+      return renderStep(index, showDivider)
+    })
+  }
+
+  const updateStepStatus = useCallback(
+    status => {
+      if (canPerformUpdate.current) {
+        updateStep(['setStatus', stepperStage, status])
+      }
+    },
+    [stepperStage]
+  )
+
+  const updateHash = useCallback(
+    hash => {
+      if (canPerformUpdate.current) {
+        updateStep(['setHash', stepperStage, hash])
+      }
+    },
+    [stepperStage]
+  )
+
+  const handleSign = useCallback(() => {
+    const signProcess = steps[stepperStage][1]
+
+    // Always start new step in the "Prompting" state
+    updateStepStatus(STEP_PROMPTING)
+
+    // Pass state updates as render props to signProcess
+    signProcess({
+      setStepHash: hash => updateHash(hash),
+      setStepWorking: () => updateStepStatus(STEP_WORKING),
+      setStepError: () => updateStepStatus(STEP_ERROR),
+      setStepSuccess: () => {
+        updateStepStatus(STEP_SUCCESS)
+
+        // Advance to next step or fire complete callback
+        if (stepperStage !== stepsCount && canPerformUpdate.current) {
+          setStepperStage(stepperStage + 1)
+        }
+
+        if (stepperStage === stepsCount && canPerformUpdate.current) {
+          onComplete()
+        }
+      },
+    })
+  }, [
+    steps,
+    stepperStage,
+    updateStepStatus,
+    updateHash,
+    onComplete,
+    stepsCount,
+  ])
+
+  useEffect(handleSign, [stepperStage])
+
+  // Prevent async state updates after unmount
+  useEffect(() => {
+    return () => {
+      canPerformUpdate.current = false
+    }
+  }, [])
+
+  return (
+    <div className={className}>
+      <div
+        ref={outerBoundsRef}
+        css={`
+          display: flex;
+          justify-content: center;
+        `}
+      >
+        <ul
+          ref={innerBoundsRef}
+          css={`
+            padding: 0;
+            display: flex;
+            flex-direction: ${layout === 'single' ? 'column' : 'row'};
+            visibility: ${measuring ? 'hidden' : 'visible'};
+          `}
+        >
+          {layout === 'single' && (
+            <React.Fragment>
+              <p
+                css={`
+                  text-align: center;
+                  color: ${theme.contentSecondary};
+                `}
+              >
+                {stepperStage + 1} out of {steps.length} transactions
+              </p>
+
+              <div
+                css={`
+                  position: relative;
+                `}
+              >
+                <Transition
+                  config={springs.smooth}
+                  delay={300}
+                  items={stepperStage}
+                  immediate={firstStart}
+                  onStart={onStart}
+                  from={{
+                    opacity: 0,
+                    transform: `translate3d(${10 * GU}px, 0, 0)`,
+                  }}
+                  enter={{
+                    opacity: 1,
+                    transform: 'translate3d(0, 0, 0)',
+                  }}
+                  leave={{
+                    opacity: 0,
+                    transform: `translate3d(-${20 * GU}px, 0, 0)`,
+                  }}
+                  native
+                >
+                  {currentStage => animProps => (
+                    <AnimatedDiv
+                      style={{
+                        position:
+                          currentStage === stepperStage ? 'static' : 'absolute',
+                        ...animProps,
+                      }}
+                    >
+                      {renderStep(currentStage)}
+                    </AnimatedDiv>
+                  )}
+                </Transition>
+              </div>
+            </React.Fragment>
+          )}
+          {layout === 'multiple' && renderSteps()}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+TransactionStepper.defaultProps = {
+  onComplete: noop,
+}
+
+TransactionStepper.propTypes = {
+  steps: PropTypes.arrayOf(PropTypes.array),
+  onComplete: PropTypes.func,
+  className: PropTypes.string,
+}
+
+export default TransactionStepper

--- a/src/components/SigningModals/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModals/TransactionStepper/TransactionStepper.js
@@ -126,12 +126,10 @@ function TransactionStepper({ steps, onComplete, className }) {
         updateStepStatus(STEP_SUCCESS)
 
         // Advance to next step or fire complete callback
-        if (stepperStage !== stepsCount && canPerformUpdate.current) {
-          setStepperStage(stepperStage + 1)
-        }
-
-        if (stepperStage === stepsCount && canPerformUpdate.current) {
-          onComplete()
+        if (canPerformUpdate.current) {
+          stepperStage === stepsCount
+            ? onComplete()
+            : setStepperStage(stepperStage + 1)
         }
       },
     })
@@ -228,14 +226,14 @@ function TransactionStepper({ steps, onComplete, className }) {
   )
 }
 
-TransactionStepper.defaultProps = {
-  onComplete: noop,
-}
-
 TransactionStepper.propTypes = {
-  steps: PropTypes.arrayOf(PropTypes.array),
+  steps: PropTypes.arrayOf(PropTypes.array).isRequired,
   onComplete: PropTypes.func,
   className: PropTypes.string,
+}
+
+TransactionStepper.defaultProps = {
+  onComplete: noop,
 }
 
 export default TransactionStepper

--- a/src/components/SigningModals/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModals/TransactionStepper/TransactionStepper.js
@@ -49,9 +49,7 @@ function TransactionStepper({ steps, onComplete, className }) {
     initialStepState(steps)
   )
   const [firstStart, setFirstStart] = useState(true)
-
   const { outerBoundsRef, innerBoundsRef, layout } = useStepperLayout()
-
   const canPerformUpdate = useRef(true)
 
   const stepsCount = steps.length - 1
@@ -165,19 +163,21 @@ function TransactionStepper({ steps, onComplete, className }) {
           css={`
             padding: 0;
             display: flex;
-            flex-direction: ${layout === 'single' ? 'column' : 'row'};
+            flex-direction: ${layout === 'collapsed' ? 'column' : 'row'};
           `}
         >
-          {layout === 'single' && (
+          {layout === 'collapsed' && (
             <React.Fragment>
-              <p
-                css={`
-                  text-align: center;
-                  color: ${theme.contentSecondary};
-                `}
-              >
-                {stepperStage + 1} out of {steps.length} transactions
-              </p>
+              {steps.length > 1 && (
+                <p
+                  css={`
+                    text-align: center;
+                    color: ${theme.contentSecondary};
+                  `}
+                >
+                  {stepperStage + 1} out of {steps.length} transactions
+                </p>
+              )}
 
               <div
                 css={`
@@ -219,7 +219,7 @@ function TransactionStepper({ steps, onComplete, className }) {
               </div>
             </React.Fragment>
           )}
-          {layout === 'multiple' && renderSteps()}
+          {layout === 'expanded' && renderSteps()}
         </ul>
       </div>
     </div>

--- a/src/components/SigningModals/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModals/TransactionStepper/TransactionStepper.js
@@ -50,12 +50,7 @@ function TransactionStepper({ steps, onComplete, className }) {
   )
   const [firstStart, setFirstStart] = useState(true)
 
-  const {
-    outerBoundsRef,
-    innerBoundsRef,
-    layout,
-    measuring,
-  } = useStepperLayout()
+  const { outerBoundsRef, innerBoundsRef, layout } = useStepperLayout()
 
   const canPerformUpdate = useRef(true)
 
@@ -173,7 +168,6 @@ function TransactionStepper({ steps, onComplete, className }) {
             padding: 0;
             display: flex;
             flex-direction: ${layout === 'single' ? 'column' : 'row'};
-            visibility: ${measuring ? 'hidden' : 'visible'};
           `}
         >
           {layout === 'single' && (

--- a/src/components/SigningModals/TransactionStepper/stepper-statuses.js
+++ b/src/components/SigningModals/TransactionStepper/stepper-statuses.js
@@ -1,0 +1,6 @@
+// Individual step states
+export const STEP_PROMPTING = Symbol('STEP_PROMPTING')
+export const STEP_WAITING = Symbol('STEP_WAITING')
+export const STEP_WORKING = Symbol('STEP_WORKING')
+export const STEP_SUCCESS = Symbol('STEP_SUCCESS')
+export const STEP_ERROR = Symbol('STEP_ERROR')

--- a/src/components/SigningModals/TransactionStepper/useStepperLayout.js
+++ b/src/components/SigningModals/TransactionStepper/useStepperLayout.js
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState, useLayoutEffect } from 'react'
 import useMeasure from 'react-use-measure'
+import { ResizeObserver } from '@juggle/resize-observer'
 
 function useStepperLayout() {
-  const [outerBoundsRef, outerBounds] = useMeasure()
+  const [outerBoundsRef, outerBounds] = useMeasure({ polyfill: ResizeObserver })
   const innerBoundsRef = useRef()
   const [innerBounds, setInnerBounds] = useState(null)
 

--- a/src/components/SigningModals/TransactionStepper/useStepperLayout.js
+++ b/src/components/SigningModals/TransactionStepper/useStepperLayout.js
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from 'react'
+import useMeasure from 'react-use-measure'
+
+function useStepperLayout() {
+  const [outerBoundsRef, outerBounds] = useMeasure()
+  const innerBoundsRef = useRef()
+  const [innerBounds, setInnerBounds] = useState(null)
+  const [measuring, setMeasuring] = useState(true)
+
+  // First render must always be in "multiple" mode so that our measurement reference point is accurate
+  const [layout, setLayout] = useState('multiple')
+
+  useEffect(() => {
+    const outerMeasured = outerBounds.width && outerBounds.width > 0
+
+    if (!innerBounds) {
+      setInnerBounds(innerBoundsRef.current.offsetWidth)
+      setMeasuring(false)
+    }
+
+    if (outerMeasured && outerBounds.width < innerBounds) {
+      setLayout('single')
+    }
+
+    if (outerMeasured && outerBounds.width >= innerBounds) {
+      setLayout('multiple')
+    }
+  }, [outerBounds, innerBounds])
+
+  return { outerBoundsRef, innerBoundsRef, layout, measuring }
+}
+
+export default useStepperLayout

--- a/src/components/SigningModals/TransactionStepper/useStepperLayout.js
+++ b/src/components/SigningModals/TransactionStepper/useStepperLayout.js
@@ -1,22 +1,23 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useLayoutEffect } from 'react'
 import useMeasure from 'react-use-measure'
 
 function useStepperLayout() {
   const [outerBoundsRef, outerBounds] = useMeasure()
   const innerBoundsRef = useRef()
   const [innerBounds, setInnerBounds] = useState(null)
-  const [measuring, setMeasuring] = useState(true)
 
   // First render must always be in "multiple" mode so that our measurement reference point is accurate
   const [layout, setLayout] = useState('multiple')
 
-  useEffect(() => {
-    const outerMeasured = outerBounds.width && outerBounds.width > 0
-
+  // It's important that we only query for the inner offsetWidth once so that our reference width remains constant
+  useLayoutEffect(() => {
     if (!innerBounds) {
       setInnerBounds(innerBoundsRef.current.offsetWidth)
-      setMeasuring(false)
     }
+  }, [innerBounds])
+
+  useEffect(() => {
+    const outerMeasured = outerBounds.width > 0
 
     if (outerMeasured && outerBounds.width < innerBounds) {
       setLayout('single')
@@ -27,7 +28,7 @@ function useStepperLayout() {
     }
   }, [outerBounds, innerBounds])
 
-  return { outerBoundsRef, innerBoundsRef, layout, measuring }
+  return { outerBoundsRef, innerBoundsRef, layout }
 }
 
 export default useStepperLayout

--- a/src/components/SigningModals/TransactionStepper/useStepperLayout.js
+++ b/src/components/SigningModals/TransactionStepper/useStepperLayout.js
@@ -7,7 +7,7 @@ function useStepperLayout() {
   const innerBoundsRef = useRef()
   const [innerBounds, setInnerBounds] = useState(null)
 
-  // First render must always be in "multiple" mode so that our measurement reference point is accurate
+  // First render must always be in "expanded" mode so that our measurement reference point is accurate
   const [layout, setLayout] = useState('expanded')
 
   // It's important that we only query for the inner offsetWidth once so that our reference width remains constant

--- a/src/components/SigningModals/TransactionStepper/useStepperLayout.js
+++ b/src/components/SigningModals/TransactionStepper/useStepperLayout.js
@@ -8,7 +8,7 @@ function useStepperLayout() {
   const [innerBounds, setInnerBounds] = useState(null)
 
   // First render must always be in "multiple" mode so that our measurement reference point is accurate
-  const [layout, setLayout] = useState('multiple')
+  const [layout, setLayout] = useState('expanded')
 
   // It's important that we only query for the inner offsetWidth once so that our reference width remains constant
   useLayoutEffect(() => {
@@ -21,11 +21,11 @@ function useStepperLayout() {
     const outerMeasured = outerBounds.width > 0
 
     if (outerMeasured && outerBounds.width < innerBounds) {
-      setLayout('single')
+      setLayout('collapsed')
     }
 
     if (outerMeasured && outerBounds.width >= innerBounds) {
-      setLayout('multiple')
+      setLayout('expanded')
     }
   }, [outerBounds, innerBounds])
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -369,11 +369,11 @@ export function useDetectIsMounted() {
 
 // Simple hook for delaying Spring animations until after the first render
 export function useDeferredAnimation() {
-  const [immediateAnimation, setBlockAnimation] = useState(true)
+  const [immediateAnimation, setImmediateAnimation] = useState(true)
 
   const onAnimationStart = useCallback(() => {
     if (immediateAnimation) {
-      setBlockAnimation(false)
+      setImmediateAnimation(false)
     }
   }, [immediateAnimation])
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -354,3 +354,28 @@ export function useMatchMedia(query) {
 export function usePrefersDarkMode() {
   return useMatchMedia('(prefers-color-scheme: dark)')
 }
+
+export function useDetectIsMounted() {
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  return () => mounted.current
+}
+
+// Simple hook for delaying Spring animations until after the first render
+export function useDeferredAnimation() {
+  const [immediateAnimation, setBlockAnimation] = useState(true)
+
+  const onAnimationStart = useCallback(() => {
+    if (immediateAnimation) {
+      setBlockAnimation(false)
+    }
+  }, [immediateAnimation])
+
+  return [immediateAnimation, onAnimationStart]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,6 +4194,11 @@ deasync@^0.1.14:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"
 
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -10417,6 +10422,13 @@ react-use-gesture@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-5.2.4.tgz#c84ebe0d79703fd90cb26a220812c2f430d3e40d"
   integrity sha512-oay95IPKBTAIqsZWwPAXJVVlDCpXdg4y2kEKz8oGLSqewpmXsXC4vKlAZq/ZDwZa4djzWlK1pnSIJY2iylx4QQ==
+
+react-use-measure@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
+  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
+  dependencies:
+    debounce "^1.2.0"
 
 react@^16.8.6:
   version "16.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,6 +1290,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@juggle/resize-observer@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
+  integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Takes an array of items consisting of a `title` and async function:

```javascript
const steps = [
  ['First transaction', handleSign],
  ['Second transaction', handleSign],
  .....
]
```

This function is given access to several props for managing the status of a given step:
`setStepHash`
`setStepWorking`
`setStepError`
`setStepSuccess`

The initial status is always `prompting`:

```javascript
async function handleSign({
  setStepHash,
  setStepWorking,
  setStepError,
  setStepSuccess,
}) {
  try {
    await walletInteraction()

    setStepWorking()

    const transactionHash = await transactionHash()

    setStepHash(transactionHash)

    await transactionMining()

    setStepSuccess()
  } catch (err) {
    setStepError()
  }
}
```

You can provide an optional callback to the component which fires when all steps have succeeded. Success being defined as the last call to `setStepSuccess` in a given array of steps.

```javascript
<TransactionStepper steps={steps} onComplete={nextScreen} />
```

Happy path:
![ezgif-2-6a60ffc7f786](https://user-images.githubusercontent.com/11708259/86618765-630af300-bfb1-11ea-9ea7-52f67b370144.gif)

On error:
![ezgif-2-695b0024d9b3](https://user-images.githubusercontent.com/11708259/86618761-61d9c600-bfb1-11ea-8fea-48335befcbf7.gif)

When the full width of the stepper exceeds its container it will automatically collapse into a single step display mode:
![ezgif-2-0ed97f09152e](https://user-images.githubusercontent.com/11708259/86618753-5f776c00-bfb1-11ea-877c-8f89b1415b59.gif)
