### PR TITLE
useSteps: Remember current step when count changes

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -69,7 +69,7 @@ function stepsReducer(state, { type, value, steps }) {
   if (type === 'prev' && step > 0) {
     newStep = step - 1
   }
-  if (type === 'remember') {
+  if (type === 'adjustSize') {
     newStep = step <= stepsCount ? step : stepsCount
   }
 
@@ -90,10 +90,10 @@ export function useSteps(steps) {
     direction: 0,
   })
 
-  // If the number of steps change, we remember the current step
+  // If the number of steps change, we need to remember the current step
   // or use the closest value available
   useEffect(() => {
-    updateStep({ type: 'remember', steps })
+    updateStep({ type: 'adjustSize', steps })
   }, [steps])
 
   const setStep = useCallback(

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -57,16 +57,21 @@ export function useArrows({ onUp, onLeft, onDown, onRight } = {}) {
 function stepsReducer(state, { type, value, steps }) {
   const { step } = state
 
+  const stepsCount = steps - 1
+
   let newStep = null
 
   if (type === 'set') {
     newStep = value
   }
-  if (type === 'next' && step < steps - 1) {
+  if (type === 'next' && step < stepsCount) {
     newStep = step + 1
   }
   if (type === 'prev' && step > 0) {
     newStep = step - 1
+  }
+  if (type === 'remember') {
+    newStep = step <= stepsCount ? step : stepsCount
   }
 
   if (newStep !== null && step !== newStep) {
@@ -86,9 +91,10 @@ export function useSteps(steps) {
     direction: 0,
   })
 
-  // If the number of steps change, we reset the current step
+  // If the number of steps change, we remember the current step
+  // or use the closest value available
   useEffect(() => {
-    updateStep({ type: 'set', value: 0, steps })
+    updateStep({ type: 'remember', steps })
   }, [steps])
 
   const setStep = useCallback(

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -56,7 +56,6 @@ export function useArrows({ onUp, onLeft, onDown, onRight } = {}) {
 
 function stepsReducer(state, { type, value, steps }) {
   const { step } = state
-
   const stepsCount = steps - 1
 
   let newStep = null


### PR DESCRIPTION
Previously `useSteps` would always revert to first position causing problems in consumers that want to dynamically update collection lengths without disrupting the user experience.