### PR TITLE
Signing Modals: Support dynamic updates to screens count

### DIFF
--- a/src/components/SigningModals/MultiScreenModal.js
+++ b/src/components/SigningModals/MultiScreenModal.js
@@ -168,6 +168,23 @@ function MultiScreenModal({ visible, screens, onClose }) {
   )
 }
 
+MultiScreenModal.defaultProps = {
+  onClose: noop,
+}
+
+MultiScreenModal.propTypes = {
+  visible: PropTypes.bool,
+  screens: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      content: PropTypes.func,
+      disableClose: PropTypes.bool,
+      width: PropTypes.number,
+    })
+  ).isRequired,
+  onClose: PropTypes.func,
+}
+
 function useScreens(screens) {
   const { direction, next, prev, step } = useSteps(screens.length)
   const [screensState, setScreensState] = useState(screens)
@@ -188,23 +205,6 @@ function useScreens(screens) {
     prev,
     step,
   }
-}
-
-MultiScreenModal.defaultProps = {
-  onClose: noop,
-}
-
-MultiScreenModal.propTypes = {
-  visible: PropTypes.bool,
-  screens: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      content: PropTypes.func,
-      disableClose: PropTypes.bool,
-      width: PropTypes.number,
-    })
-  ).isRequired,
-  onClose: PropTypes.func,
 }
 
 export default React.memo(MultiScreenModal)

--- a/src/components/SigningModals/MultiScreenModal.js
+++ b/src/components/SigningModals/MultiScreenModal.js
@@ -169,7 +169,7 @@ function MultiScreenModal({ visible, screens, onClose }) {
 }
 
 function useScreens(screens) {
-  const { prev, step, next, direction } = useSteps(screens.length)
+  const { direction, next, prev, step } = useSteps(screens.length)
   const [screensState, setScreensState] = useState(screens)
 
   useEffect(() => {
@@ -181,12 +181,12 @@ function useScreens(screens) {
   const currentScreen = getScreen(step)
 
   return {
-    prev,
-    step,
-    next,
+    currentScreen,
     direction,
     getScreen,
-    currentScreen,
+    next,
+    prev,
+    step,
   }
 }
 


### PR DESCRIPTION
Previously, updates to `screens` might throw if the new length was less than the current step.

Persistence of current `step` addressed here https://github.com/aragon/aragon/pull/1480
