### PR TITLE
Signing Modal: Add desc prop to step with defaults

### DIFF
--- a/src/components/SigningModal/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModal/TransactionStepper/Step/Step.js
@@ -19,6 +19,7 @@ const AnimatedSpan = animated.span
 
 function Step({
   title,
+  desc,
   status,
   number,
   className,
@@ -28,39 +29,33 @@ function Step({
   const theme = useTheme()
   const [immediateAnimation, onAnimationStart] = useDeferredAnimation()
 
-  const { desc, visualColor, descColor } = useMemo(() => {
+  const { visualColor, descColor } = useMemo(() => {
     const appearance = {
       [STEP_WAITING]: {
-        desc: 'Waiting for signature',
         visualColor: theme.accent,
         descColor: theme.contentSecondary,
       },
       [STEP_PROMPTING]: {
-        desc: 'Waiting for signature',
         visualColor: theme.accent,
         descColor: theme.contentSecondary,
       },
       [STEP_WORKING]: {
-        desc: 'Transaction being mined',
         visualColor: theme.accent,
         descColor: theme.accent,
       },
       [STEP_SUCCESS]: {
-        desc: 'Transaction confirmed',
         visualColor: theme.positive,
         descColor: theme.positive,
       },
       [STEP_ERROR]: {
-        desc: 'An error has occured',
         visualColor: theme.negative,
         descColor: theme.negative,
       },
     }
 
-    const { desc, descColor, visualColor } = appearance[status]
+    const { descColor, visualColor } = appearance[status]
 
     return {
-      desc,
       visualColor: `${visualColor}`,
       descColor: `${descColor}`,
     }
@@ -227,6 +222,7 @@ function Step({
 
 Step.propTypes = {
   title: PropTypes.string,
+  desc: PropTypes.string,
   transactionHash: PropTypes.string,
   className: PropTypes.string,
   number: PropTypes.number,

--- a/src/components/SigningModal/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModal/TransactionStepper/TransactionStepper.js
@@ -61,19 +61,7 @@ function TransactionStepper({ steps, onComplete, className }) {
     (stepIndex, showDivider) => {
       const { title, descriptions } = steps[stepIndex]
       const { status, hash } = stepState[stepIndex]
-
-      const { waiting, prompting, working, success, error } =
-        descriptions || DEFAULT_DESC
-
-      const descWithDefault = {
-        [STEP_WAITING]: waiting || DEFAULT_DESC['waiting'],
-        [STEP_PROMPTING]: prompting || DEFAULT_DESC['prompting'],
-        [STEP_WORKING]: working || DEFAULT_DESC['working'],
-        [STEP_SUCCESS]: success || DEFAULT_DESC['success'],
-        [STEP_ERROR]: error || DEFAULT_DESC['error'],
-      }
-
-      const desc = descWithDefault[status]
+      const desc = descriptions[status] || DEFAULT_DESC[status]
 
       return (
         <li
@@ -239,11 +227,11 @@ TransactionStepper.propTypes = {
       title: PropTypes.string.isRequired,
       handleSign: PropTypes.func.isRequired,
       descriptions: PropTypes.shape({
-        waiting: PropTypes.string,
-        prompting: PropTypes.string,
-        working: PropTypes.string,
-        success: PropTypes.string,
-        error: PropTypes.string,
+        [STEP_WAITING]: PropTypes.string,
+        [STEP_PROMPTING]: PropTypes.string,
+        [STEP_WORKING]: PropTypes.string,
+        [STEP_SUCCESS]: PropTypes.string,
+        [STEP_ERROR]: PropTypes.string,
       }),
     })
   ).isRequired,


### PR DESCRIPTION
Address https://github.com/aragon/aragon/pull/1473#discussion_r451032237

```javascript
const descs = {
  waiting: 'waiting desc',
  prompting: 'prompting desc',
  error: 'error desc',
  working: 'working desc',
  success: 'success desc',
}

const steps = [
  {
    title: 'First transaction',
    descriptions: descs,
    handleSign: handleSign,
  },
  {
    title: 'Second transaction',
    descriptions: descs,
    handleSign: handleSign,
  },
]
```