### PR TITLE
chore: add @andyhook to reviewers list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,10 +6,11 @@ addAssignees: false
 reviewers:
   - bpierre
   - evalir
+  - andyhook
 
 skipKeywords:
   - wip
   - draft
 
 # Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 0
+numberOfReviewers: 2


### PR DESCRIPTION
Adding @andy-hook to the default list of reviewers 🙌.

The bot will randomly pick two from the list on each PR :).