### PR TITLE
Preferences: add organization name to share labels link

### DIFF
--- a/src/components/GlobalPreferences/CustomLabels/useIdentitiesActions.js
+++ b/src/components/GlobalPreferences/CustomLabels/useIdentitiesActions.js
@@ -29,14 +29,16 @@ function useIdentitiesActions({
     )
     try {
       const labels = utoa(JSON.stringify(identitiesToShare))
-      return `${window.location.origin}/#${routing.path({
+      // Embed the organization address as saving labels (on the receipient's side) requires an
+      // wrapper context (that is only created on an organization path)
+      return `${window.location.origin}/#${orgAddress}${routing.path({
         preferences: { section: 'custom-labels', data: { labels } },
       })}`
     } catch (err) {
       log('Error while creating the identities sharing link:', err)
       return ''
     }
-  }, [filteredIdentities, identitiesSelected, routing])
+  }, [filteredIdentities, identitiesSelected, orgAddress, routing])
 
   // import
   const handleImport = useCallback(


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon/issues/1492.

I think this was changed during the routing update (#1272), and although I would agree we shouldn't need an organization context to have this link work, unfortunately we only create a `wrapper` instance when inside of an organization at the moment.