### PR TITLE
docs: update instructions to be yarn-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
 
 ## Quick start
 
-`npm start` will launch the app, configured to connect to our Rinkeby deployment.
+Install with `yarn` and launch the app with `yarn start`. By default, the app is configured to connect to the Ethereum Rinkeby testnet.
 
 For connecting to other chains / deployments, a few useful npm scripts are provided:
 
-- Mainnet: `npm run start:mainnet` will launch the app, configured to connect to our mainnet deployment
-- Local development: `npm run start:local` will launch the app, configured to connect to our [aragen](https://github.com/aragon/aragen) local development environment. It will also use the local IPFS daemon, if it detects one exists. If you're using the [aragonCLI](http://github.com/aragon/aragon-cli), you'll want to run this to connect to its local chain.
+- Ethereum Mainnet: `yarn run start:mainnet` will launch the app, configured to connect to the Ethereum mainnet
+- Local development: `yarn run start:local` will launch the app, configured to connect to our [aragen](https://github.com/aragon/aragen) local development environment. It will also use the local IPFS daemon, if it detects one exists. If you're using the [aragonCLI](http://github.com/aragon/aragon-cli), you'll want to run this to connect to its local chain.
 
 **Note**: Windows users may need to install the [windows-build-tools](https://www.npmjs.com/package/windows-build-tools) before installing this project's dependencies.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Install with `yarn` and launch the app with `yarn start`. By default, the app is
 
 For connecting to other chains / deployments, a few useful npm scripts are provided:
 
-- Ethereum Mainnet: `yarn run start:mainnet` will launch the app, configured to connect to the Ethereum mainnet
-- Local development: `yarn run start:local` will launch the app, configured to connect to our [aragen](https://github.com/aragon/aragen) local development environment. It will also use the local IPFS daemon, if it detects one exists. If you're using the [aragonCLI](http://github.com/aragon/aragon-cli), you'll want to run this to connect to its local chain.
+- Ethereum Mainnet: `yarn start:mainnet` will launch the app, configured to connect to the Ethereum mainnet
+- Local development: `yarn start:local` will launch the app, configured to connect to our [aragen](https://github.com/aragon/aragen) local development environment. It will also use the local IPFS daemon, if it detects one exists. If you're using the [aragonCLI](http://github.com/aragon/aragon-cli), you'll want to run this to connect to its local chain.
 
 **Note**: Windows users may need to install the [windows-build-tools](https://www.npmjs.com/package/windows-build-tools) before installing this project's dependencies.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,31 +31,31 @@ Which source to load app frontend assets from. Can be one of `ipfs` (uses the co
 It is also possible to define how every app is loaded individually using a comma-separated list, which contains a series of locations defined as `<app ID>:<app location>`.
 
 ```console
-ARAGON_APP_LOCATOR=0xbf8491150dafc5dcaee5b861414dca922de09ccffa344964ae167212e8c673ae:http://localhost:1234,0xbf8491150dafc5dcaee5b861414dca922de09ccffa344964ae167212e8c673ae:http://localhost:3333 npm start
+ARAGON_APP_LOCATOR=0xbf8491150dafc5dcaee5b861414dca922de09ccffa344964ae167212e8c673ae:http://localhost:1234,0xbf8491150dafc5dcaee5b861414dca922de09ccffa344964ae167212e8c673ae:http://localhost:3333 yarn start
 ```
 
 Individual app locators can also use its “known name” if it exists. Known names are `Agent`, `Finance`, `Fundraising`, `Survey`, `TokenManager`, `Vault`, and `Voting`. When a known name is used without any location, they will be fetched from their [assigned local ports](src/known-app-ids.js), which are used by their respective development servers (see [aragon-apps](https://github.com/aragon/aragon-apps)).
 
 ```console
-ARAGON_APP_LOCATOR=Agent,Finance npm start
+ARAGON_APP_LOCATOR=Agent,Finance yarn start
 ```
 
 Another option is to use the ENS name of any app:
 
 ```console
-ARAGON_APP_LOCATOR=voting.aragonpm.eth:1234 npm start
+ARAGON_APP_LOCATOR=voting.aragonpm.eth:1234 yarn start
 ```
 
 Locations can also be a domain or an IP without the `http://` prefix, in which case it will get added:
 
 ```console
-ARAGON_APP_LOCATOR=Agent:localhost:1234,Finance:192.168.1.4 npm start
+ARAGON_APP_LOCATOR=Agent:localhost:1234,Finance:192.168.1.4 yarn start
 ```
 
 And they can also be a port, in which case `http://localhost` will get used:
 
 ```console
-ARAGON_APP_LOCATOR=Agent:3333,Finance:4444 npm start
+ARAGON_APP_LOCATOR=Agent:3333,Finance:4444 yarn start
 ```
 
 ## Ethereum Providers

--- a/docs/FRONTEND_SETUP.md
+++ b/docs/FRONTEND_SETUP.md
@@ -13,10 +13,10 @@ git clone git@github.com:aragon/aragon-ui.git
 cd aragon-ui
 yarn install
 yarn link
-yarn run dev
+yarn dev
 ```
 
-Note: `yarn run dev` is like `yarn run build`, but it rebuilds automtically when a file changes.
+Note: `yarn dev` is like `yarn build`, but it rebuilds automtically when a file changes.
 
 Install the devbox dependencies, link `@aragon/ui` to it, and start it:
 
@@ -46,7 +46,7 @@ If a change only impacts the Aragon client, the easiest is to run it connected t
 Run it:
 
 ```
-yarn run start:rinkeby
+yarn start:rinkeby
 ```
 
 The development server is now running on http://localhost:3000/, and file changes will trigger a rebuild and reload the page.
@@ -54,9 +54,9 @@ The development server is now running on http://localhost:3000/, and file change
 A few other commands are available to connect it to other networks:
 
 ```
-yarn run start:staging
-yarn run start:mainnet
-yarn run start:local # require a local node
+yarn start:staging
+yarn start:mainnet
+yarn start:local # require a local node
 ```
 
 If it requires the local version of aragonUI, link it:
@@ -106,7 +106,7 @@ Apps need to receive data from the client to run properly, and won’t work when
 
 ```
 cd aragon
-ARAGON_APP_LOCATOR=local yarn run start:rinkeby
+ARAGON_APP_LOCATOR=local yarn start:rinkeby
 ```
 
 Aragon client knows the local ports of every app, so loading any organization and trying to access e.g. the Token Manager will load it from the version running locally.

--- a/docs/FRONTEND_SETUP.md
+++ b/docs/FRONTEND_SETUP.md
@@ -11,23 +11,23 @@ Install the aragonUI dependencies, link it, and start building it:
 ```
 git clone git@github.com:aragon/aragon-ui.git
 cd aragon-ui
-npm install
-npm link
-npm run dev
+yarn install
+yarn link
+yarn run dev
 ```
 
-Note: `npm run dev` is like `npm run build`, but it rebuilds automtically when a file changes.
+Note: `yarn run dev` is like `yarn run build`, but it rebuilds automtically when a file changes.
 
 Install the devbox dependencies, link `@aragon/ui` to it, and start it:
 
 ```
 cd devbox
-npm install
-npm link @aragon/ui
-npm start
+yarn install
+yarn link @aragon/ui
+yarn start
 ```
 
-Note: linking `@aragon/ui` is not really needed with `npm` since we are declaring its version using  the [file protocol](https://github.com/aragon/aragon-ui/blob/8c60dffcd279e9ba640d91b3e7ce1a5d88b0ae64/devbox/package.json#L13) in the dependencies which creates a Unix link, but `yarn` has a different behavior and copies the parent directory, which prevent to live updates.
+Note: linking `@aragon/ui` is not really needed with `npm` since we are declaring its version using  the [file protocol](https://github.com/aragon/aragon-ui/blob/8c60dffcd279e9ba640d91b3e7ce1a5d88b0ae64/devbox/package.json#L13) in the dependencies which creates a Unix link, but `yarn` has a different behavior and copies the parent directory, which prevents live updates.
 
 To add a new demo, add a new file to `devbox/apps` and restart the server. The demo will appear on http://localhost:1234/.
 
@@ -38,7 +38,7 @@ Install it:
 ```
 git clone git@github.com:aragon/aragon.git
 cd aragon
-npm install
+yarn install
 ```
 
 If a change only impacts the Aragon client, the easiest is to run it connected to rinkeby, and create a testing organization. It requires an internet connection, but it doesn’t require to setup anything else (local Ethereum / IPFS nodes).
@@ -46,7 +46,7 @@ If a change only impacts the Aragon client, the easiest is to run it connected t
 Run it:
 
 ```
-npm run start:rinkeby
+yarn run start:rinkeby
 ```
 
 The development server is now running on http://localhost:3000/, and file changes will trigger a rebuild and reload the page.
@@ -54,15 +54,15 @@ The development server is now running on http://localhost:3000/, and file change
 A few other commands are available to connect it to other networks:
 
 ```
-npm run start:staging
-npm run start:mainnet
-npm run start:local # require a local node
+yarn run start:staging
+yarn run start:mainnet
+yarn run start:local # require a local node
 ```
 
 If it requires the local version of aragonUI, link it:
 
 ```
-npm link @aragon/ui
+yarn link @aragon/ui
 ```
 
 By running the client this way, the apps themselves will be loaded from IPFS. We’ll see how to override this behavior to run the apps frontend locally in the next section.
@@ -88,8 +88,8 @@ cd aragon-apps/apps/token-manager/app
 Install its dependencies and run it:
 
 ```
-npm install
-npm start
+yarn install
+yarn start
 ```
 
 The development server is now running on http://localhost:3003/, and file changes will trigger a rebuild and reload the page.
@@ -99,14 +99,14 @@ Note: each app in the `aragon-apps` project is having its own port number, so it
 If it requires the local version of aragonUI, link it:
 
 ```
-npm link @aragon/ui
+yarn link @aragon/ui
 ```
 
 Apps need to receive data from the client to run properly, and won’t work when being loaded directly. To run them in the Aragon client, run it by setting the `ARAGON_APP_LOCATOR` variable to `local`:
 
 ```
 cd aragon
-ARAGON_APP_LOCATOR=local npm run start:rinkeby
+ARAGON_APP_LOCATOR=local yarn run start:rinkeby
 ```
 
 Aragon client knows the local ports of every app, so loading any organization and trying to access e.g. the Token Manager will load it from the version running locally.


### PR DESCRIPTION
General search and replace for npm to yarn in the docs.

The only really important commands to update were any instructions with `npm install`, but I thought we might as well use yarn as much as possible.