### PR TITLE
Signing modal: Add retry and stepper info message

### DIFF
--- a/src/components/SigningModal/TransactionStepper/Step/StatusVisual.js
+++ b/src/components/SigningModal/TransactionStepper/Step/StatusVisual.js
@@ -97,7 +97,7 @@ function StatusVisual({ status, color, number, className }) {
           >
             <Transition
               config={(_, state) =>
-                state === 'enter' ? springs.smooth : springs.swift
+                state === 'enter' ? springs.smooth : springs.instant
               }
               items={statusIcon}
               onStart={onAnimationStart}
@@ -112,7 +112,6 @@ function StatusVisual({ status, color, number, className }) {
               leave={{
                 position: 'absolute',
                 opacity: 0,
-                transform: 'scale3d(0.8, 0.8, 1)',
               }}
               native
             >
@@ -130,7 +129,7 @@ function StatusVisual({ status, color, number, className }) {
                       color: ${color};
                       border: 1px solid currentColor;
                       bottom: 0;
-                      left: 0;
+                      right: 0;
                     `}
                     style={animProps}
                   >

--- a/src/components/SigningModal/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModal/TransactionStepper/Step/Step.js
@@ -13,8 +13,6 @@ import {
 import { useDeferredAnimation } from '../../../../hooks'
 import StatusVisual from './StatusVisual'
 
-const BADGE_OFFSET = 4.5 * GU
-
 const AnimatedSpan = animated.span
 
 function Step({
@@ -70,8 +68,6 @@ function Step({
           flex-direction: column;
           align-items: center;
 
-          padding-top: ${BADGE_OFFSET}px;
-
           width: ${23 * GU}px;
         `}
       >
@@ -108,7 +104,7 @@ function Step({
             config={springs.smooth}
             items={desc}
             onStart={onAnimationStart}
-            immediate={status === STEP_PROMPTING || immediateAnimation}
+            immediate={immediateAnimation}
             from={{
               opacity: 0,
               transform: `translate3d(0, ${2 * GU}px, 0)`,
@@ -152,7 +148,7 @@ function Step({
             width: 100%;
 
             /* Avoid visual jump when showing tx by pre-filling space */
-            height: ${BADGE_OFFSET}px;
+            height: ${4.5 * GU}px;
           `}
         >
           {transactionHash && (
@@ -212,7 +208,7 @@ function Step({
           color={visualColor}
           css={`
             position: relative;
-            top: ${BADGE_OFFSET + 6 * GU}px;
+            top: ${6 * GU}px;
           `}
         />
       )}

--- a/src/components/SigningModal/TransactionStepper/TransactionStepper.js
+++ b/src/components/SigningModal/TransactionStepper/TransactionStepper.js
@@ -2,14 +2,15 @@ import React, { useCallback, useEffect, useReducer, useState } from 'react'
 import { PropTypes } from 'prop-types'
 import { Transition, animated } from 'react-spring'
 import {
-  noop,
-  useTheme,
-  Info,
   Button,
-  springs,
   IconRotateRight,
+  Info,
+  noop,
+  springs,
+  useTheme,
   GU,
 } from '@aragon/ui'
+import Step from './Step/Step'
 import {
   STEP_ERROR,
   STEP_PROMPTING,
@@ -22,7 +23,6 @@ import {
 } from './stepper-statuses'
 import { useDetectIsMounted, useDeferredAnimation } from '../../../hooks'
 import useStepperLayout from './useStepperLayout'
-import Step from './Step/Step'
 
 const AnimatedDiv = animated.div
 
@@ -55,7 +55,12 @@ function reduceSteps(steps, [action, stepIndex, value]) {
   return steps
 }
 
-function TransactionStepper({ steps, onComplete, info, className }) {
+function TransactionStepper({
+  steps,
+  onComplete,
+  infoDescriptions,
+  className,
+}) {
   const theme = useTheme()
   const isMounted = useDetectIsMounted()
   const [immediateAnimation, onAnimationStart] = useDeferredAnimation()
@@ -69,7 +74,8 @@ function TransactionStepper({ steps, onComplete, info, className }) {
 
   const stepsCount = steps.length - 1
 
-  const infoMessage = (info && info[stepperStatus]) || ''
+  const infoMessage =
+    (infoDescriptions && infoDescriptions[stepperStatus]) || ''
 
   const renderStep = useCallback(
     (stepIndex, showDivider) => {
@@ -255,7 +261,6 @@ function TransactionStepper({ steps, onComplete, info, className }) {
             margin-top: ${4 * GU}px;
           `}
         >
-          {' '}
           {infoMessage}
         </Info>
       )}
@@ -290,7 +295,7 @@ TransactionStepper.propTypes = {
       }),
     })
   ).isRequired,
-  info: PropTypes.shape({
+  infoDescriptions: PropTypes.shape({
     [STEPPER_WORKING]: PropTypes.string,
     [STEPPER_SUCCESS]: PropTypes.string,
     [STEPPER_ERROR]: PropTypes.string,

--- a/src/components/SigningModal/TransactionStepper/stepper-statuses.js
+++ b/src/components/SigningModal/TransactionStepper/stepper-statuses.js
@@ -1,3 +1,8 @@
+// Stepper states
+export const STEPPER_WORKING = Symbol('STEPPER_WORKING')
+export const STEPPER_SUCCESS = Symbol('STEPPER_SUCCESS')
+export const STEPPER_ERROR = Symbol('STEPPER_ERROR')
+
 // Individual step states
 export const STEP_PROMPTING = Symbol('STEP_PROMPTING')
 export const STEP_WAITING = Symbol('STEP_WAITING')


### PR DESCRIPTION
The stepper is going to handle these info messages and retry function for now, in the future it should probably be hoisted out and managed separately depending on how complex things get.

![image](https://user-images.githubusercontent.com/11708259/87966957-f534f000-cab5-11ea-99c7-f2f041c668ba.png)
