### PR TITLE
Signing modal: 1 – Connect to signature and transaction bags

### DIFF
--- a/src/components/OrgView/OrgView.js
+++ b/src/components/OrgView/OrgView.js
@@ -29,6 +29,7 @@ import MenuPanel, { MENU_PANEL_WIDTH } from '../MenuPanel/MenuPanel'
 import OrgViewApp from './OrgViewApp'
 import OrganizationSwitcher from '../MenuPanel/OrganizationSwitcher/OrganizationSwitcher'
 import SignerPanel from '../SignerPanel/SignerPanel'
+import SigningModal from '../SigningModal/SigningModal'
 import UpgradeBanner from '../Upgrade/UpgradeBanner'
 import UpgradeModal from '../Upgrade/UpgradeModal'
 import UpgradeOrganizationPanel from '../Upgrade/UpgradeOrganizationPanel'
@@ -355,7 +356,14 @@ function OrgView({
                     wrapper={wrapper}
                   />
 
-                  <SignerPanel
+                  {/* <SignerPanel
+                    apps={apps}
+                    transactionBag={transactionBag}
+                    signatureBag={signatureBag}
+                    web3={web3}
+                  /> */}
+
+                  <SigningModal
                     apps={apps}
                     transactionBag={transactionBag}
                     signatureBag={signatureBag}

--- a/src/components/OrgView/OrgView.js
+++ b/src/components/OrgView/OrgView.js
@@ -28,7 +28,6 @@ import GlobalPreferencesButton from './GlobalPreferencesButton/GlobalPreferences
 import MenuPanel, { MENU_PANEL_WIDTH } from '../MenuPanel/MenuPanel'
 import OrgViewApp from './OrgViewApp'
 import OrganizationSwitcher from '../MenuPanel/OrganizationSwitcher/OrganizationSwitcher'
-import SignerPanel from '../SignerPanel/SignerPanel'
 import SigningModal from '../SigningModal/SigningModal'
 import UpgradeBanner from '../Upgrade/UpgradeBanner'
 import UpgradeModal from '../Upgrade/UpgradeModal'
@@ -355,13 +354,6 @@ function OrgView({
                     repos={repos}
                     wrapper={wrapper}
                   />
-
-                  {/* <SignerPanel
-                    apps={apps}
-                    transactionBag={transactionBag}
-                    signatureBag={signatureBag}
-                    web3={web3}
-                  /> */}
 
                   <SigningModal
                     apps={apps}

--- a/src/components/SignerPanel/SignerPanel.js
+++ b/src/components/SignerPanel/SignerPanel.js
@@ -200,7 +200,7 @@ class SignerPanel extends React.PureComponent {
             .then(({ nonce }) => setActivityNonce({ transactionHash, nonce }))
             .catch(console.error)
 
-          // Pretransactions are for so the app can get approval
+          // Pretransactions are handled separately from the intent itself, and are usually used to approve tokens for the intended action
           const description = isPretransaction
             ? getPretransactionDescription(intent)
             : intent.description

--- a/src/components/SigningModal/AddressLink.js
+++ b/src/components/SigningModal/AddressLink.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from '@aragon/ui'
+import { EthereumAddressType } from '../../prop-types'
+import EtherscanLink from '../Etherscan/EtherscanLink'
+
+function AddressLink({ children, to }) {
+  return to ? (
+    <EtherscanLink address={to}>
+      {url =>
+        url ? (
+          <Link href={url} focusRingSpacing={[3, 2]}>
+            {children || to}
+          </Link>
+        ) : (
+          to
+        )
+      }
+    </EtherscanLink>
+  ) : (
+    'an address or app'
+  )
+}
+
+AddressLink.propTypes = {
+  children: PropTypes.node,
+  to: EthereumAddressType,
+}
+
+export default AddressLink

--- a/src/components/SigningModal/DetailField.js
+++ b/src/components/SigningModal/DetailField.js
@@ -12,11 +12,11 @@ function DetailField({ title, children }) {
     >
       <h2
         css={`
-            ${textStyle('label2')}
-  
-            color: ${theme.surfaceContentSecondary};
-            margin-bottom: ${1 * GU}px;
-          `}
+          ${textStyle('label2')}
+
+          color: ${theme.surfaceContentSecondary};
+          margin-bottom: ${1 * GU}px;
+        `}
       >
         {title}
       </h2>

--- a/src/components/SigningModal/DetailField.js
+++ b/src/components/SigningModal/DetailField.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { textStyle, GU, useTheme } from '@aragon/ui'
+import { textStyle, useTheme, GU } from '@aragon/ui'
 
-function InfoField({ title, children }) {
+function DetailField({ title, children }) {
   const theme = useTheme()
   return (
     <div
       css={`
-        margin-bottom: ${3.5 * GU}px;
+        margin-bottom: ${3 * GU}px;
       `}
     >
       <h2
@@ -25,9 +25,9 @@ function InfoField({ title, children }) {
   )
 }
 
-InfoField.propTypes = {
+DetailField.propTypes = {
   title: PropTypes.string,
   children: PropTypes.node,
 }
 
-export default InfoField
+export default DetailField

--- a/src/components/SigningModal/InfoField.js
+++ b/src/components/SigningModal/InfoField.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { textStyle, GU, useTheme } from '@aragon/ui'
+
+function InfoField({ title, children }) {
+  const theme = useTheme()
+  return (
+    <div
+      css={`
+        margin-bottom: ${3.5 * GU}px;
+      `}
+    >
+      <h2
+        css={`
+            ${textStyle('label2')}
+  
+            color: ${theme.surfaceContentSecondary};
+            margin-bottom: ${1 * GU}px;
+          `}
+      >
+        {title}
+      </h2>
+      {children}
+    </div>
+  )
+}
+
+InfoField.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node,
+}
+
+export default InfoField

--- a/src/components/SigningModal/MultiScreenModal.js
+++ b/src/components/SigningModal/MultiScreenModal.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
+import { Spring, Transition, animated } from 'react-spring'
 import {
   Modal,
   noop,
@@ -9,7 +10,6 @@ import {
   useViewport,
   GU,
 } from '@aragon/ui'
-import { Spring, Transition, animated } from 'react-spring'
 import { useSteps, useDeferredAnimation } from '../../hooks'
 
 const AnimatedDiv = animated.div

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -1,0 +1,158 @@
+import React, { useMemo, useCallback, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Button, Info, IdentityBadge, textStyle, noop, GU } from '@aragon/ui'
+import { AppType } from '../../prop-types'
+import { getAppByProxyAddress, getErrorMessage } from './utils'
+import InfoField from './InfoField'
+import LocalLabelAppBadge from '../../components/LocalLabelAppBadge/LocalLabelAppBadge'
+import MultiScreenModal from './MultiScreenModal'
+import {
+  STEPPER_WORKING,
+  STEPPER_SUCCESS,
+  STEPPER_ERROR,
+  STEP_SUCCESS,
+} from './TransactionStepper/stepper-statuses'
+import TransactionStepper from './TransactionStepper/TransactionStepper'
+import { useWallet } from '../../wallet'
+
+function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
+  const [error, setError] = useState()
+  const { web3: walletWeb3, account } = useWallet()
+
+  const infoMessages = useMemo(() => {
+    return {
+      [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the message. Do not close the web browser window until the process is finished.`,
+      [STEPPER_SUCCESS]: `Success! The signature request was completed. You can close this window.`,
+      [STEPPER_ERROR]: getErrorMessage(`Your message wasn't signed.`, error),
+    }
+  }, [error])
+
+  const { message, requestingApp } = useMemo(() => {
+    const { requestingApp, message } = signatureBag
+    return {
+      message: message || '',
+      requestingApp: getAppByProxyAddress(requestingApp, apps),
+    }
+  }, [signatureBag, apps])
+
+  const handleMsgSign = useCallback(
+    async ({ setStepWorking, setStepSuccess, setStepError }) => {
+      try {
+        const signature = await walletWeb3.eth.personal.sign(
+          signatureBag.message,
+          account
+        )
+        setStepWorking()
+
+        signatureBag.resolve(signature)
+        setStepSuccess()
+      } catch (err) {
+        signatureBag.reject(err)
+        setError(err)
+        setStepError()
+      }
+    },
+    [signatureBag, account, walletWeb3]
+  )
+
+  const transactionSteps = useMemo(
+    () => [
+      {
+        title: 'Sign message',
+        handleSign: handleMsgSign,
+        descriptions: {
+          [STEP_SUCCESS]: 'Message signed',
+        },
+      },
+    ],
+    [handleMsgSign]
+  )
+
+  const modalScreens = useMemo(
+    () => [
+      {
+        title: 'Sign Message',
+        content: modalProps => (
+          <React.Fragment>
+            <p
+              css={`
+                margin-bottom: ${2 * GU}px;
+              `}
+            >
+              You are about to sign this message with enabled account{' '}
+              <IdentityBadge
+                entity={account}
+                connectedAccount
+                compact
+                labelStyle={`
+                  ${textStyle('body3')}
+                `}
+              />
+            </p>
+            <InfoField title="Signature requested by">
+              <LocalLabelAppBadge app={requestingApp} apps={[]} noIdentifier />
+            </InfoField>
+
+            <Info mode="description" title="Message to be signed">
+              {message}
+            </Info>
+
+            <Info
+              css={`
+                margin-top: ${2 * GU}px;
+              `}
+            >
+              By signing this message you confirm that have control over the
+              enabled account. Your Ethereum address will then be publicly
+              associated with the signed message. This won’t cost you any ETH.
+            </Info>
+            <Button
+              wide
+              mode="strong"
+              onClick={modalProps.nextScreen}
+              css={`
+                margin-top: ${2 * GU}px;
+              `}
+            >
+              Sign message
+            </Button>
+          </React.Fragment>
+        ),
+      },
+      {
+        title: 'Sign Message',
+        content: () => (
+          <div
+            css={`
+              padding-top: ${3 * GU}px;
+            `}
+          >
+            <TransactionStepper steps={transactionSteps} info={infoMessages} />
+          </div>
+        ),
+      },
+    ],
+    [transactionSteps, message, requestingApp, account, infoMessages]
+  )
+
+  return (
+    <MultiScreenModal
+      visible={visible}
+      screens={modalScreens}
+      onClose={onClose}
+    />
+  )
+}
+
+SignMessageFlow.propTypes = {
+  apps: PropTypes.arrayOf(AppType).isRequired,
+  signatureBag: PropTypes.object,
+  visible: PropTypes.bool,
+  onClose: PropTypes.func,
+}
+
+SignMessageFlow.defaultProps = {
+  onClose: noop,
+}
+
+export default SignMessageFlow

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -19,11 +19,14 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const [error, setError] = useState()
   const { web3: walletWeb3, account } = useWallet()
 
-  const infoMessages = useMemo(() => {
+  const infoDescriptions = useMemo(() => {
     return {
       [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the message. Do not close the web browser window until the process is finished.`,
       [STEPPER_SUCCESS]: `Success! The signature request was completed. You can close this window.`,
-      [STEPPER_ERROR]: getErrorMessage(`Your message wasn't signed.`, error),
+      [STEPPER_ERROR]: getErrorMessage(
+        `Your message wasn't signed.`,
+        error || ''
+      ),
     }
   }, [error])
 
@@ -53,19 +56,6 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
       }
     },
     [signatureBag, account, walletWeb3]
-  )
-
-  const transactionSteps = useMemo(
-    () => [
-      {
-        title: 'Sign message',
-        handleSign: handleMsgSign,
-        descriptions: {
-          [STEP_SUCCESS]: 'Message signed',
-        },
-      },
-    ],
-    [handleMsgSign]
   )
 
   const modalScreens = useMemo(
@@ -106,6 +96,7 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
               enabled account. Your Ethereum address will then be publicly
               associated with the signed message. This won’t cost you any ETH.
             </Info>
+
             <Button
               wide
               mode="strong"
@@ -127,12 +118,23 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
               padding-top: ${3 * GU}px;
             `}
           >
-            <TransactionStepper steps={transactionSteps} info={infoMessages} />
+            <TransactionStepper
+              steps={[
+                {
+                  title: 'Sign message',
+                  handleSign: handleMsgSign,
+                  descriptions: {
+                    [STEP_SUCCESS]: 'Message signed',
+                  },
+                },
+              ]}
+              infoDescriptions={infoDescriptions}
+            />
           </div>
         ),
       },
     ],
-    [transactionSteps, message, requestingApp, account, infoMessages]
+    [message, requestingApp, account, infoDescriptions, handleMsgSign]
   )
 
   return (

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -44,13 +44,12 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const walletError = useWalletError({ intent, isTransaction: false })
 
   const handleMsgSign = useCallback(
-    async ({ setStepWorking, setStepSuccess, setStepError }) => {
+    async ({ setStepSuccess, setStepError }) => {
       try {
         const signature = await walletWeb3.eth.personal.sign(
           signatureBag.message,
           account
         )
-        setStepWorking()
 
         signatureBag.resolve(signature)
         setStepSuccess()

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -1,11 +1,12 @@
 import React, { useMemo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
-import { Button, Info, IdentityBadge, textStyle, noop, GU } from '@aragon/ui'
+import { Info, IdentityBadge, textStyle, noop, GU } from '@aragon/ui'
 import { AppType } from '../../prop-types'
+import DetailField from './DetailField'
 import { getAppByProxyAddress, getErrorMessage } from './utils'
-import InfoField from './InfoField'
 import LocalLabelAppBadge from '../../components/LocalLabelAppBadge/LocalLabelAppBadge'
 import MultiScreenModal from './MultiScreenModal'
+import SignerButton from './SignerButton'
 import {
   STEPPER_WORKING,
   STEPPER_SUCCESS,
@@ -61,7 +62,7 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const modalScreens = useMemo(
     () => [
       {
-        title: 'Sign Message',
+        title: 'Sign message',
         content: modalProps => (
           <React.Fragment>
             <p
@@ -79,9 +80,9 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
                 `}
               />
             </p>
-            <InfoField title="Signature requested by">
+            <DetailField title="Signature requested by">
               <LocalLabelAppBadge app={requestingApp} apps={[]} noIdentifier />
-            </InfoField>
+            </DetailField>
 
             <Info mode="description" title="Message to be signed">
               {message}
@@ -97,21 +98,14 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
               associated with the signed message. This won’t cost you any ETH.
             </Info>
 
-            <Button
-              wide
-              mode="strong"
-              onClick={modalProps.nextScreen}
-              css={`
-                margin-top: ${2 * GU}px;
-              `}
-            >
+            <SignerButton onClick={modalProps.nextScreen}>
               Sign message
-            </Button>
+            </SignerButton>
           </React.Fragment>
         ),
       },
       {
-        title: 'Sign Message',
+        title: 'Sign message',
         content: () => (
           <div
             css={`

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -4,6 +4,7 @@ import { Info, IdentityBadge, textStyle, noop, GU } from '@aragon/ui'
 import { AppType } from '../../prop-types'
 import DetailField from './DetailField'
 import { getAppByProxyAddress, getErrorMessage } from './utils'
+import { getProviderString } from '../../ethereum-providers'
 import LocalLabelAppBadge from '../../components/LocalLabelAppBadge/LocalLabelAppBadge'
 import MultiScreenModal from './MultiScreenModal'
 import SignerButton from './SignerButton'
@@ -19,15 +20,18 @@ import useWalletError from './useWalletError'
 
 function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const [error, setError] = useState()
-  const { web3: walletWeb3, account } = useWallet()
+  const { web3: walletWeb3, account, providerInfo } = useWallet()
 
   const infoDescriptions = useMemo(() => {
     return {
-      [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the message. Do not close the web browser window until the process is finished.`,
+      [STEPPER_WORKING]: `Open ${getProviderString(
+        'your Ethereum wallet',
+        providerInfo.id
+      )} to sign the message. Do not close the web browser window until the process is finished.`,
       [STEPPER_SUCCESS]: `Success! The signature request was completed. You can close this window.`,
       [STEPPER_ERROR]: getErrorMessage(`Your message wasn't signed.`, error),
     }
-  }, [error])
+  }, [error, providerInfo])
 
   const intent = useMemo(() => {
     const { requestingApp, message } = signatureBag

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -15,6 +15,7 @@ import {
 } from './TransactionStepper/stepper-statuses'
 import TransactionStepper from './TransactionStepper/TransactionStepper'
 import { useWallet } from '../../wallet'
+import useWalletError from './useWalletError'
 
 function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const [error, setError] = useState()
@@ -31,13 +32,15 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
     }
   }, [error])
 
-  const { message, requestingApp } = useMemo(() => {
+  const intent = useMemo(() => {
     const { requestingApp, message } = signatureBag
     return {
       message: message || '',
       requestingApp: getAppByProxyAddress(requestingApp, apps),
     }
   }, [signatureBag, apps])
+
+  const walletError = useWalletError({ intent, isTransaction: false })
 
   const handleMsgSign = useCallback(
     async ({ setStepWorking, setStepSuccess, setStepError }) => {
@@ -59,10 +62,12 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
     [signatureBag, account, walletWeb3]
   )
 
-  const modalScreens = useMemo(
-    () => [
+  const modalScreens = useMemo(() => {
+    const title = 'Sign message'
+
+    const signMessage = [
       {
-        title: 'Sign message',
+        title,
         content: modalProps => (
           <React.Fragment>
             <p
@@ -81,11 +86,15 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
               />
             </p>
             <DetailField title="Signature requested by">
-              <LocalLabelAppBadge app={requestingApp} apps={[]} noIdentifier />
+              <LocalLabelAppBadge
+                app={intent.requestingApp}
+                apps={[]}
+                noIdentifier
+              />
             </DetailField>
 
             <Info mode="description" title="Message to be signed">
-              {message}
+              {intent.message}
             </Info>
 
             <Info
@@ -105,7 +114,7 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
         ),
       },
       {
-        title: 'Sign message',
+        title,
         content: () => (
           <div
             css={`
@@ -115,7 +124,7 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
             <TransactionStepper
               steps={[
                 {
-                  title: 'Sign message',
+                  title,
                   handleSign: handleMsgSign,
                   descriptions: {
                     [STEP_SUCCESS]: 'Message signed',
@@ -127,9 +136,14 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
           </div>
         ),
       },
-    ],
-    [message, requestingApp, account, infoDescriptions, handleMsgSign]
-  )
+    ]
+
+    if (walletError) {
+      return [{ title, content: walletError }]
+    }
+
+    return signMessage
+  }, [intent, account, infoDescriptions, handleMsgSign, walletError])
 
   return (
     <MultiScreenModal

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -25,10 +25,7 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
     return {
       [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the message. Do not close the web browser window until the process is finished.`,
       [STEPPER_SUCCESS]: `Success! The signature request was completed. You can close this window.`,
-      [STEPPER_ERROR]: getErrorMessage(
-        `Your message wasn't signed.`,
-        error || ''
-      ),
+      [STEPPER_ERROR]: getErrorMessage(`Your message wasn't signed.`, error),
     }
   }, [error])
 

--- a/src/components/SigningModal/SignMessageFlow.js
+++ b/src/components/SigningModal/SignMessageFlow.js
@@ -65,6 +65,10 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
   const modalScreens = useMemo(() => {
     const title = 'Sign message'
 
+    if (walletError) {
+      return [{ title, content: walletError }]
+    }
+
     const signMessage = [
       {
         title,
@@ -137,10 +141,6 @@ function SignMessageFlow({ signatureBag, visible, apps, onClose }) {
         ),
       },
     ]
-
-    if (walletError) {
-      return [{ title, content: walletError }]
-    }
 
     return signMessage
   }, [intent, account, infoDescriptions, handleMsgSign, walletError])

--- a/src/components/SigningModal/SignTransactionFlow/AnnotatedDescription.js
+++ b/src/components/SigningModal/SignTransactionFlow/AnnotatedDescription.js
@@ -1,0 +1,107 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { textStyle, Link, GU } from '@aragon/ui'
+import LocalIdentityBadge from '../../../components/IdentityBadge/LocalIdentityBadge'
+import { useRouting } from '../../../routing'
+
+function AnnotatedDescription({ intent }) {
+  const routing = useRouting()
+  const { description, annotatedDescription } = intent
+
+  return (
+    <React.Fragment>
+      {annotatedDescription
+        ? annotatedDescription.map(({ type, value }, index) => {
+            if (type === 'address' || type === 'any-account') {
+              return (
+                <span
+                  key={index}
+                  css={`
+                    position: relative;
+                    display: inline-flex;
+                    vertical-align: middle;
+                    margin-right: ${0.5 * GU}px;
+                  `}
+                >
+                  <LocalIdentityBadge
+                    entity={type === 'any-account' ? 'Any account' : value}
+                    labelStyle={`
+                            ${textStyle('body3')}
+                          `}
+                    compact
+                  />
+                </span>
+              )
+            }
+            if (type === 'app') {
+              return (
+                <Link
+                  key={index}
+                  href={`#${routing.path(({ mode }) => ({
+                    mode: {
+                      ...mode,
+                      name: 'org',
+                      instanceId: 'permissions',
+                      instancePath: `/app/${value.proxyAddress}`,
+                    },
+                  }))}`}
+                  focusRingSpacing={[3, 2]}
+                  css={`
+                    margin-right: ${0.25 * GU}px;
+                  `}
+                >
+                  {value.name}
+                </Link>
+              )
+            }
+            if (type === 'role' || type === 'kernelNamespace') {
+              return (
+                <span
+                  key={index}
+                  css={`
+                    margin-right: ${0.5 * GU}px;
+                    font-style: italic;
+                  `}
+                >
+                  “{value.name}”
+                </span>
+              )
+            }
+            if (type === 'apmPackage') {
+              return (
+                <span
+                  key={index}
+                  css={`
+                    display: inline-flex;
+                    vertical-align: middle;
+                    margin-right: ${0.5 * GU}px;
+                  `}
+                >
+                  <LocalIdentityBadge
+                    entity={value.name}
+                    labelStyle={`${textStyle('body3')}`}
+                  />
+                </span>
+              )
+            }
+            return (
+              <span
+                key={index}
+                css={`
+                  margin-right: ${0.5 * GU}px;
+                `}
+              >
+                {value}
+              </span>
+            )
+          })
+        : description || 'an action'}
+    </React.Fragment>
+  )
+}
+
+AnnotatedDescription.propTypes = {
+  intent: PropTypes.object.isRequired,
+}
+
+export default AnnotatedDescription

--- a/src/components/SigningModal/SignTransactionFlow/AnnotatedDescription.js
+++ b/src/components/SigningModal/SignTransactionFlow/AnnotatedDescription.js
@@ -26,8 +26,8 @@ function AnnotatedDescription({ intent }) {
                   <LocalIdentityBadge
                     entity={type === 'any-account' ? 'Any account' : value}
                     labelStyle={`
-                            ${textStyle('body3')}
-                          `}
+                      ${textStyle('body3')}
+                    `}
                     compact
                   />
                 </span>

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -1,0 +1,188 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { noop, GU } from '@aragon/ui'
+import { addressesEqual } from '../../../web3-utils'
+import { AppType } from '../../../prop-types'
+import { getErrorMessage } from '../utils'
+import MultiScreenModal from '../MultiScreenModal'
+import {
+  STEPPER_ERROR,
+  STEPPER_SUCCESS,
+  STEPPER_WORKING,
+  STEP_SUCCESS,
+} from '../TransactionStepper/stepper-statuses'
+import TransactionDetails from './TransactionDetails'
+import TransactionStepper from '../TransactionStepper/TransactionStepper'
+import useSignTransaction from './useSignTransaction'
+
+function getAppName(apps, proxyAddress) {
+  const app = apps.find(app => addressesEqual(app.proxyAddress, proxyAddress))
+  return (app && app.name) || ''
+}
+
+const STEP_DESC = {
+  [STEP_SUCCESS]: 'Transaction signed',
+}
+
+function transactionIntent(bag, apps) {
+  const { external, path, transaction = {} } = bag
+
+  // If the path includes forwarders, the intent is always the last node
+  // Otherwise, it's the direct transaction
+  const targetIntent = path.length > 1 ? path[path.length - 1] : transaction
+  const { annotatedDescription, description, to } = targetIntent
+  const name = getAppName(apps, to)
+  const installed = apps.some(
+    ({ proxyAddress }) => proxyAddress === transaction.to
+  )
+
+  return {
+    annotatedDescription,
+    description,
+    external,
+    installed,
+    name,
+    to,
+    transaction,
+  }
+}
+
+function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
+  const [error, setError] = useState()
+  const signTransaction = useSignTransaction(web3)
+
+  const infoMessages = useMemo(() => {
+    return {
+      [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the transactions. Do not close the web browser window until the process is finished.`,
+      [STEPPER_SUCCESS]: `Success! The transaction has been sent to the network for processing. You can close this window.`,
+      [STEPPER_ERROR]: getErrorMessage(
+        `Your transaction wasn't signed and no tokens were sent.`,
+        error
+      ),
+    }
+  }, [error])
+
+  // This is temporary to reshape the transaction bag
+  // to the future format we expect from Aragon.js
+  const reshapedBag = useMemo(() => {
+    const { path, transaction } = transactionBag
+    const decoratedPaths = path.map(path => ({
+      ...path,
+      name: getAppName(apps, path.to),
+    }))
+
+    return {
+      intent: (transaction && transactionIntent(transactionBag, apps)) || {},
+      directPath: decoratedPaths.length === 1,
+      actionPaths: decoratedPaths.length ? decoratedPaths : [],
+      pretransaction: (transaction && transaction.pretransaction) || null,
+    }
+  }, [transactionBag, apps])
+
+  const getSignHandler = useCallback(
+    (transaction, intent, isPretransaction) => async ({
+      setStepHash,
+      setStepSuccess,
+      setStepError,
+    }) => {
+      try {
+        const transactionHash = await signTransaction(
+          transaction,
+          intent,
+          isPretransaction
+        )
+
+        setStepHash(transactionHash)
+        setStepSuccess()
+
+        transactionBag.resolve(transactionHash)
+      } catch (err) {
+        transactionBag.reject(err)
+        setError(err)
+        setStepError()
+      }
+    },
+    [transactionBag, signTransaction]
+  )
+
+  const transactionSteps = useMemo(() => {
+    const { directPath, intent, actionPaths, pretransaction } = reshapedBag
+    const directTransaction = intent.transaction
+    const indirectTransaction = actionPaths && actionPaths[0]
+
+    const stepsToRender = [
+      {
+        title: 'Sign transaction',
+        descriptions: STEP_DESC,
+        handleSign: getSignHandler(
+          directPath ? directTransaction : indirectTransaction,
+          intent,
+          false
+        ),
+      },
+    ]
+
+    if (pretransaction) {
+      stepsToRender.unshift({
+        title: 'Sign transaction',
+        descriptions: STEP_DESC,
+        handleSign: getSignHandler(pretransaction, intent, true),
+      })
+    }
+
+    return stepsToRender
+  }, [getSignHandler, reshapedBag])
+
+  const modalScreens = useMemo(() => {
+    const { actionPaths, intent, directPath } = reshapedBag
+
+    return [
+      {
+        title: 'Create transaction',
+        content: modalProps => (
+          <TransactionDetails
+            actionPaths={actionPaths}
+            apps={apps}
+            directPath={directPath}
+            intent={intent}
+            modalProps={modalProps}
+          />
+        ),
+      },
+      {
+        title: 'Create transaction',
+        content: () => (
+          <div
+            css={`
+              padding-top: ${3 * GU}px;
+            `}
+          >
+            <TransactionStepper steps={transactionSteps} info={infoMessages} />
+          </div>
+        ),
+      },
+    ]
+  }, [transactionSteps, reshapedBag, apps, infoMessages])
+
+  return (
+    <MultiScreenModal
+      visible={visible}
+      screens={modalScreens}
+      onClose={onClose}
+    />
+  )
+}
+
+SignTransactionFlow.propTypes = {
+  transactionBag: PropTypes.object,
+  apps: PropTypes.arrayOf(AppType).isRequired,
+  web3: PropTypes.object.isRequired,
+  visible: PropTypes.bool,
+  onClose: PropTypes.func,
+}
+
+SignTransactionFlow.defaultProps = {
+  onClose: noop,
+}
+
+export default SignTransactionFlow

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -48,7 +48,7 @@ function shapeTransactionIntent(bag, apps) {
 }
 
 function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
-  const [error, setError] = useState()
+  const [error, setError] = useState(null)
   const signTransaction = useSignTransaction(web3)
 
   const infoDescriptions = useMemo(() => {
@@ -186,7 +186,7 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
         content: modalProps => (
           <React.Fragment>
             <DetailField title="Action requirements">
-              Unfortunately, you dont meet all the requirements to submit this
+              Unfortunately, you don't meet all the requirements to submit this
               action:
               <div
                 css={`

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -1,10 +1,13 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
-import { noop, GU } from '@aragon/ui'
+import { Info, noop, GU } from '@aragon/ui'
 import { addressesEqual } from '../../../web3-utils'
 import { AppType } from '../../../prop-types'
 import { getErrorMessage } from '../utils'
+import AnnotatedDescription from './AnnotatedDescription'
+import DetailField from '../DetailField'
 import MultiScreenModal from '../MultiScreenModal'
+import SignerButton from '../SignerButton'
 import {
   STEPPER_ERROR,
   STEPPER_SUCCESS,
@@ -138,7 +141,10 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
   const screens = useMemo(() => {
     const { actionPaths, intent, directPath } = reshapedBag
 
-    return [
+    const possible =
+      directPath || (Array.isArray(actionPaths) && actionPaths.length)
+
+    const transactionPrompt = [
       {
         title: 'Create transaction',
         content: modalProps => (
@@ -167,6 +173,34 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
         ),
       },
     ]
+
+    const impossibleAction = [
+      {
+        title: 'Create transaction',
+        content: modalProps => (
+          <React.Fragment>
+            <DetailField title="Action requirements">
+              Unfortunately, you dont meet all the requirements to submit this
+              action:
+              <div
+                css={`
+                  margin-top: ${0.5 * GU}px;
+                `}
+              >
+                <AnnotatedDescription intent={intent} />
+              </div>
+            </DetailField>
+            <Info mode="error" title="Action impossible">
+              The proposed action failed to execute. You may not have the
+              required permissions.
+            </Info>
+            <SignerButton onClick={modalProps.closeModal}>Close</SignerButton>
+          </React.Fragment>
+        ),
+      },
+    ]
+
+    return possible ? transactionPrompt : impossibleAction
   }, [transactionSteps, reshapedBag, apps, infoDescriptions])
 
   return (

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -92,17 +92,13 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
   })
 
   const getHandleSign = useCallback(
-    (transaction, intent, isPretransaction) => async ({
+    (transaction, intent) => async ({
       setStepHash,
       setStepSuccess,
       setStepError,
     }) => {
       try {
-        const transactionHash = await signTransaction(
-          transaction,
-          intent,
-          isPretransaction
-        )
+        const transactionHash = await signTransaction(transaction, intent)
 
         setStepHash(transactionHash)
         setStepSuccess()
@@ -134,16 +130,16 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
         ...stepDetails,
         handleSign: getHandleSign(
           directPath ? directTransaction : indirectTransaction,
-          intent,
-          false
+          intent
         ),
       },
     ]
 
+    // Pretransactions are handled separately from the intent itself, and are usually used to approve tokens for the intended action
     if (pretransaction) {
       steps.unshift({
         ...stepDetails,
-        handleSign: getHandleSign(pretransaction, intent, true),
+        handleSign: getHandleSign(pretransaction, intent),
       })
     }
 

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -156,6 +156,40 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
     const possible =
       directPath || (Array.isArray(actionPaths) && actionPaths.length)
 
+    if (walletError) {
+      return [{ title, content: walletError }]
+    }
+
+    const impossibleAction = [
+      {
+        title,
+        content: modalProps => (
+          <React.Fragment>
+            <DetailField title="Action requirements">
+              Unfortunately, you don't meet all the requirements to submit this
+              action:
+              <div
+                css={`
+                  margin-top: ${0.5 * GU}px;
+                `}
+              >
+                <AnnotatedDescription intent={intent} />
+              </div>
+            </DetailField>
+            <Info mode="error" title="Action impossible">
+              The proposed action failed to execute. You may not have the
+              required permissions.
+            </Info>
+            <SignerButton onClick={modalProps.closeModal}>Close</SignerButton>
+          </React.Fragment>
+        ),
+      },
+    ]
+
+    if (!possible) {
+      return impossibleAction
+    }
+
     const signTransactions = [
       {
         title,
@@ -185,40 +219,6 @@ function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
         ),
       },
     ]
-
-    const impossibleAction = [
-      {
-        title,
-        content: modalProps => (
-          <React.Fragment>
-            <DetailField title="Action requirements">
-              Unfortunately, you don't meet all the requirements to submit this
-              action:
-              <div
-                css={`
-                  margin-top: ${0.5 * GU}px;
-                `}
-              >
-                <AnnotatedDescription intent={intent} />
-              </div>
-            </DetailField>
-            <Info mode="error" title="Action impossible">
-              The proposed action failed to execute. You may not have the
-              required permissions.
-            </Info>
-            <SignerButton onClick={modalProps.closeModal}>Close</SignerButton>
-          </React.Fragment>
-        ),
-      },
-    ]
-
-    if (walletError) {
-      return [{ title, content: walletError }]
-    }
-
-    if (!possible) {
-      return impossibleAction
-    }
 
     return signTransactions
   }, [transactionSteps, reshapedBag, apps, infoDescriptions, walletError])

--- a/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
+++ b/src/components/SigningModal/SignTransactionFlow/SignTransactionFlow.js
@@ -6,6 +6,7 @@ import { AppType } from '../../../prop-types'
 import { getErrorMessage } from '../utils'
 import AnnotatedDescription from './AnnotatedDescription'
 import DetailField from '../DetailField'
+import { getProviderString } from '../../../ethereum-providers'
 import MultiScreenModal from '../MultiScreenModal'
 import SignerButton from '../SignerButton'
 import {
@@ -17,6 +18,7 @@ import {
 import TransactionDetails from './TransactionDetails'
 import TransactionStepper from '../TransactionStepper/TransactionStepper'
 import useSignTransaction from './useSignTransaction'
+import { useWallet } from '../../../wallet'
 import useWalletError from '../useWalletError'
 
 function getAppName(apps, proxyAddress) {
@@ -50,17 +52,21 @@ function shapeTransactionIntent(bag, apps) {
 function SignTransactionFlow({ transactionBag, web3, apps, visible, onClose }) {
   const [error, setError] = useState(null)
   const signTransaction = useSignTransaction(web3)
+  const { providerInfo } = useWallet()
 
   const infoDescriptions = useMemo(() => {
     return {
-      [STEPPER_WORKING]: `Open your Ethereum provider (Metamask or similar) to sign the transactions. Do not close the web browser window until the process is finished.`,
+      [STEPPER_WORKING]: `Open ${getProviderString(
+        'your Ethereum wallet',
+        providerInfo.id
+      )} to sign the transactions. Do not close the web browser window until the process is finished.`,
       [STEPPER_SUCCESS]: `Success! The transaction has been sent to the network for processing. You can close this window.`,
       [STEPPER_ERROR]: getErrorMessage(
         `Your transaction wasn't signed and no tokens were sent.`,
         error
       ),
     }
-  }, [error])
+  }, [error, providerInfo])
 
   // This is temporary to reshape the transaction bag
   // to the future format we expect from Aragon.js

--- a/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
+++ b/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
@@ -1,0 +1,283 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import { textStyle, Link, GU, Info, Button, useTheme } from '@aragon/ui'
+import AddressLink from '../AddressLink'
+import { AppType } from '../../../prop-types'
+import { getAppByProxyAddress } from '../utils'
+import LocalIdentityBadge from '../../../components/IdentityBadge/LocalIdentityBadge'
+import { modalProps } from '../prop-types'
+import TransactionJourney from '../TransactionJourney'
+import { useRouting } from '../../../routing'
+
+function TransactionDetails({
+  modalProps,
+  actionPaths,
+  intent,
+  directPath,
+  apps,
+}) {
+  const { nextScreen } = modalProps
+  const showPaths = !directPath
+
+  const pathItems = useMemo(
+    () =>
+      showPaths
+        ? actionPaths.map(({ name, description, to }, i) => {
+            return [
+              name,
+              {
+                app: getAppByProxyAddress(to, apps),
+                content: (
+                  <p>
+                    {/* Temporarily make last path description generic */}
+                    {i === actionPaths.length - 1
+                      ? 'The proposed action will be automatically executed if the previous step on the path is completed successfully'
+                      : description}
+                  </p>
+                ),
+              },
+            ]
+          })
+        : [
+            [
+              intent.name,
+              {
+                app: getAppByProxyAddress(intent.to, apps),
+                content: (
+                  <p>
+                    You are able to directly interact with the {intent.name}{' '}
+                    app.
+                  </p>
+                ),
+              },
+            ],
+          ],
+    [actionPaths, apps, showPaths, intent]
+  )
+
+  return (
+    <React.Fragment>
+      <InfoField title="Action requirements">
+        <p>
+          {showPaths
+            ? 'You have met the requirements to propose this action through the following transaction path.'
+            : 'The action is protected by a permission, and you hold that permission. '}
+        </p>
+      </InfoField>
+
+      <InfoField
+        title={
+          showPaths ? 'Indirect transaction path' : 'Direct transaction path'
+        }
+      >
+        <TransactionJourney
+          items={pathItems}
+          css={`
+            padding-top: ${0.5 * GU}px;
+            max-width: ${60 * GU}px;
+          `}
+        />
+      </InfoField>
+
+      <ActionToBeTriggered showPaths={showPaths} intent={intent} />
+
+      {intent.external && (
+        <ExternalMessage
+          installed={intent.installed}
+          to={intent.to}
+          css={`
+            margin-top: ${2 * GU}px;
+          `}
+        />
+      )}
+
+      <Button
+        wide
+        mode="strong"
+        onClick={nextScreen}
+        css={`
+          margin-top: ${2 * GU}px;
+        `}
+      >
+        Create transaction
+      </Button>
+    </React.Fragment>
+  )
+}
+
+TransactionDetails.propTypes = {
+  apps: PropTypes.arrayOf(AppType).isRequired,
+  modalProps: modalProps,
+  actionPaths: PropTypes.array,
+  intent: PropTypes.object,
+  directPath: PropTypes.bool,
+}
+
+/* eslint-disable react/prop-types */
+function InfoField({ title, children }) {
+  const theme = useTheme()
+  return (
+    <div
+      css={`
+        margin-bottom: ${3.5 * GU}px;
+      `}
+    >
+      <h2
+        css={`
+          ${textStyle('label2')}
+
+          color: ${theme.surfaceContentSecondary};
+          margin-bottom: ${1 * GU}px;
+        `}
+      >
+        {title}
+      </h2>
+      {children}
+    </div>
+  )
+}
+
+function ExternalMessage({ installed, to, className }) {
+  return (
+    <div className={className}>
+      <Info mode="warning" title="Warning">
+        {installed ? (
+          `Be aware that this is an attempt to execute a transaction on
+          another app that is installed in this organization. You may
+          want to double check that app’s functionality before
+          proceeding.`
+        ) : (
+          <React.Fragment>
+            Be aware that this is an attempt to execute a transaction on an{' '}
+            <strong css="font-weight: 800">external contract</strong> that may
+            not have been reviewed or audited. This means that it might behave
+            unexpectedly. Please{' '}
+            <strong css="font-weight: 800">
+              make sure you trust the contract at
+            </strong>{' '}
+            <LocalIdentityBadge
+              entity={to}
+              labelStyle={`
+                      ${textStyle('body3')}
+                    `}
+              compact
+            />{' '}
+            before proceeding.
+          </React.Fragment>
+        )}
+      </Info>
+    </div>
+  )
+}
+
+function ActionToBeTriggered({ showPaths, intent }) {
+  const routing = useRouting()
+  const { description, name, to, annotatedDescription } = intent
+
+  return (
+    <Info mode="description" title="Action to be triggered">
+      <p>This transaction will {showPaths ? 'eventually' : ''} perform</p>
+      <div
+        css={`
+          margin-top: ${0.5 * GU}px;
+          margin-bottom: ${0.5 * GU}px;
+          margin-left: ${1 * GU}px;
+        `}
+      >
+        {annotatedDescription
+          ? annotatedDescription.map(({ type, value }, index) => {
+              if (type === 'address' || type === 'any-account') {
+                return (
+                  <span
+                    key={index}
+                    css={`
+                      position: relative;
+                      display: inline-flex;
+                      vertical-align: middle;
+                      margin-right: ${0.5 * GU}px;
+                    `}
+                  >
+                    <LocalIdentityBadge
+                      entity={type === 'any-account' ? 'Any account' : value}
+                      labelStyle={`
+                            ${textStyle('body3')}
+                          `}
+                      compact
+                    />
+                  </span>
+                )
+              }
+              if (type === 'app') {
+                return (
+                  <Link
+                    key={index}
+                    href={`#${routing.path(({ mode }) => ({
+                      mode: {
+                        ...mode,
+                        name: 'org',
+                        instanceId: 'permissions',
+                        instancePath: `/app/${value.proxyAddress}`,
+                      },
+                    }))}`}
+                    focusRingSpacing={[3, 2]}
+                    css={`
+                      margin-right: ${0.25 * GU}px;
+                    `}
+                  >
+                    {value.name}
+                  </Link>
+                )
+              }
+              if (type === 'role' || type === 'kernelNamespace') {
+                return (
+                  <span
+                    key={index}
+                    css={`
+                      margin-right: ${0.5 * GU}px;
+                      font-style: italic;
+                    `}
+                  >
+                    “{value.name}”
+                  </span>
+                )
+              }
+              if (type === 'apmPackage') {
+                return (
+                  <span
+                    key={index}
+                    css={`
+                      display: inline-flex;
+                      vertical-align: middle;
+                      margin-right: ${0.5 * GU}px;
+                    `}
+                  >
+                    <LocalIdentityBadge
+                      entity={value.name}
+                      labelStyle={`${textStyle('body3')}`}
+                    />
+                  </span>
+                )
+              }
+              return (
+                <span
+                  key={index}
+                  css={`
+                    margin-right: ${0.5 * GU}px;
+                  `}
+                >
+                  {value}
+                </span>
+              )
+            })
+          : description || 'an action'}
+      </div>
+      <p>
+        {' on '}
+        <AddressLink to={to}>{name}</AddressLink>.
+      </p>
+    </Info>
+  )
+}
+/* eslint-enable react/prop-types */
+
+export default TransactionDetails

--- a/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
+++ b/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
@@ -1,43 +1,39 @@
 import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { textStyle, Link, GU, Info, Button, useTheme } from '@aragon/ui'
+import { textStyle, Link, GU, Info, Button, noop, useTheme } from '@aragon/ui'
 import AddressLink from '../AddressLink'
 import { AppType } from '../../../prop-types'
 import { getAppByProxyAddress } from '../utils'
 import LocalIdentityBadge from '../../../components/IdentityBadge/LocalIdentityBadge'
-import { modalProps } from '../prop-types'
 import TransactionJourney from '../TransactionJourney'
 import { useRouting } from '../../../routing'
 
 function TransactionDetails({
-  modalProps,
   actionPaths,
-  intent,
-  directPath,
   apps,
+  directPath,
+  intent,
+  onCreate,
 }) {
-  const { nextScreen } = modalProps
   const showPaths = !directPath
 
   const pathItems = useMemo(
     () =>
       showPaths
-        ? actionPaths.map(({ name, description, to }, i) => {
-            return [
-              name,
-              {
-                app: getAppByProxyAddress(to, apps),
-                content: (
-                  <p>
-                    {/* Temporarily make last path description generic */}
-                    {i === actionPaths.length - 1
-                      ? 'The proposed action will be automatically executed if the previous step on the path is completed successfully'
-                      : description}
-                  </p>
-                ),
-              },
-            ]
-          })
+        ? actionPaths.map(({ name, description, to }, i) => [
+            name,
+            {
+              app: getAppByProxyAddress(to, apps),
+              content: (
+                <p>
+                  {/* Make last path description generic */}
+                  {i === actionPaths.length - 1
+                    ? 'The proposed action will be automatically executed if the previous step on the path is completed successfully'
+                    : description}
+                </p>
+              ),
+            },
+          ])
         : [
             [
               intent.name,
@@ -57,15 +53,15 @@ function TransactionDetails({
 
   return (
     <React.Fragment>
-      <InfoField title="Action requirements">
+      <DetailField title="Action requirements">
         <p>
           {showPaths
             ? 'You have met the requirements to propose this action through the following transaction path.'
             : 'The action is protected by a permission, and you hold that permission. '}
         </p>
-      </InfoField>
+      </DetailField>
 
-      <InfoField
+      <DetailField
         title={
           showPaths ? 'Indirect transaction path' : 'Direct transaction path'
         }
@@ -77,7 +73,7 @@ function TransactionDetails({
             max-width: ${60 * GU}px;
           `}
         />
-      </InfoField>
+      </DetailField>
 
       <ActionToBeTriggered showPaths={showPaths} intent={intent} />
 
@@ -94,7 +90,7 @@ function TransactionDetails({
       <Button
         wide
         mode="strong"
-        onClick={nextScreen}
+        onClick={onCreate}
         css={`
           margin-top: ${2 * GU}px;
         `}
@@ -106,15 +102,19 @@ function TransactionDetails({
 }
 
 TransactionDetails.propTypes = {
-  apps: PropTypes.arrayOf(AppType).isRequired,
-  modalProps: modalProps,
   actionPaths: PropTypes.array,
-  intent: PropTypes.object,
-  directPath: PropTypes.bool,
+  apps: PropTypes.arrayOf(AppType).isRequired,
+  directPath: PropTypes.bool.isRequired,
+  intent: PropTypes.object.isRequired,
+  onCreate: PropTypes.func,
+}
+
+TransactionDetails.defaultProps = {
+  onCreate: noop,
 }
 
 /* eslint-disable react/prop-types */
-function InfoField({ title, children }) {
+function DetailField({ title, children }) {
   const theme = useTheme()
   return (
     <div

--- a/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
+++ b/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { textStyle, Link, GU, Info, Button, noop, useTheme } from '@aragon/ui'
-import AddressLink from '../AddressLink'
+import { textStyle, GU, Info, noop } from '@aragon/ui'
+import AnnotatedDescription from './AnnotatedDescription'
 import { AppType } from '../../../prop-types'
+import DetailField from '../DetailField'
 import { getAppByProxyAddress } from '../utils'
 import LocalIdentityBadge from '../../../components/IdentityBadge/LocalIdentityBadge'
+import SignerButton from '../SignerButton'
 import TransactionJourney from '../TransactionJourney'
-import { useRouting } from '../../../routing'
 
 function TransactionDetails({
   actionPaths,
@@ -75,7 +76,18 @@ function TransactionDetails({
         />
       </DetailField>
 
-      <ActionToBeTriggered showPaths={showPaths} intent={intent} />
+      <Info mode="description" title="Action to be triggered">
+        <p>This transaction will {showPaths ? 'eventually' : ''} perform</p>
+        <div
+          css={`
+            margin-top: ${0.5 * GU}px;
+            margin-bottom: ${0.5 * GU}px;
+            margin-left: ${1 * GU}px;
+          `}
+        >
+          <AnnotatedDescription intent={intent} />
+        </div>
+      </Info>
 
       {intent.external && (
         <ExternalMessage
@@ -87,16 +99,7 @@ function TransactionDetails({
         />
       )}
 
-      <Button
-        wide
-        mode="strong"
-        onClick={onCreate}
-        css={`
-          margin-top: ${2 * GU}px;
-        `}
-      >
-        Create transaction
-      </Button>
+      <SignerButton onClick={onCreate}>Create transaction</SignerButton>
     </React.Fragment>
   )
 }
@@ -114,29 +117,6 @@ TransactionDetails.defaultProps = {
 }
 
 /* eslint-disable react/prop-types */
-function DetailField({ title, children }) {
-  const theme = useTheme()
-  return (
-    <div
-      css={`
-        margin-bottom: ${3.5 * GU}px;
-      `}
-    >
-      <h2
-        css={`
-          ${textStyle('label2')}
-
-          color: ${theme.surfaceContentSecondary};
-          margin-bottom: ${1 * GU}px;
-        `}
-      >
-        {title}
-      </h2>
-      {children}
-    </div>
-  )
-}
-
 function ExternalMessage({ installed, to, className }) {
   return (
     <div className={className}>
@@ -167,115 +147,6 @@ function ExternalMessage({ installed, to, className }) {
         )}
       </Info>
     </div>
-  )
-}
-
-function ActionToBeTriggered({ showPaths, intent }) {
-  const routing = useRouting()
-  const { description, name, to, annotatedDescription } = intent
-
-  return (
-    <Info mode="description" title="Action to be triggered">
-      <p>This transaction will {showPaths ? 'eventually' : ''} perform</p>
-      <div
-        css={`
-          margin-top: ${0.5 * GU}px;
-          margin-bottom: ${0.5 * GU}px;
-          margin-left: ${1 * GU}px;
-        `}
-      >
-        {annotatedDescription
-          ? annotatedDescription.map(({ type, value }, index) => {
-              if (type === 'address' || type === 'any-account') {
-                return (
-                  <span
-                    key={index}
-                    css={`
-                      position: relative;
-                      display: inline-flex;
-                      vertical-align: middle;
-                      margin-right: ${0.5 * GU}px;
-                    `}
-                  >
-                    <LocalIdentityBadge
-                      entity={type === 'any-account' ? 'Any account' : value}
-                      labelStyle={`
-                            ${textStyle('body3')}
-                          `}
-                      compact
-                    />
-                  </span>
-                )
-              }
-              if (type === 'app') {
-                return (
-                  <Link
-                    key={index}
-                    href={`#${routing.path(({ mode }) => ({
-                      mode: {
-                        ...mode,
-                        name: 'org',
-                        instanceId: 'permissions',
-                        instancePath: `/app/${value.proxyAddress}`,
-                      },
-                    }))}`}
-                    focusRingSpacing={[3, 2]}
-                    css={`
-                      margin-right: ${0.25 * GU}px;
-                    `}
-                  >
-                    {value.name}
-                  </Link>
-                )
-              }
-              if (type === 'role' || type === 'kernelNamespace') {
-                return (
-                  <span
-                    key={index}
-                    css={`
-                      margin-right: ${0.5 * GU}px;
-                      font-style: italic;
-                    `}
-                  >
-                    “{value.name}”
-                  </span>
-                )
-              }
-              if (type === 'apmPackage') {
-                return (
-                  <span
-                    key={index}
-                    css={`
-                      display: inline-flex;
-                      vertical-align: middle;
-                      margin-right: ${0.5 * GU}px;
-                    `}
-                  >
-                    <LocalIdentityBadge
-                      entity={value.name}
-                      labelStyle={`${textStyle('body3')}`}
-                    />
-                  </span>
-                )
-              }
-              return (
-                <span
-                  key={index}
-                  css={`
-                    margin-right: ${0.5 * GU}px;
-                  `}
-                >
-                  {value}
-                </span>
-              )
-            })
-          : description || 'an action'}
-      </div>
-      <p>
-        {' on '}
-        <AddressLink to={to}>{name}</AddressLink>.
-      </p>
-    </Info>
   )
 }
 /* eslint-enable react/prop-types */

--- a/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
+++ b/src/components/SigningModal/SignTransactionFlow/TransactionDetails.js
@@ -18,39 +18,38 @@ function TransactionDetails({
 }) {
   const showPaths = !directPath
 
-  const pathItems = useMemo(
-    () =>
-      showPaths
-        ? actionPaths.map(({ name, description, to }, i) => [
-            name,
-            {
-              app: getAppByProxyAddress(to, apps),
-              content: (
-                <p>
-                  {/* Make last path description generic */}
-                  {i === actionPaths.length - 1
-                    ? 'The proposed action will be automatically executed if the previous step on the path is completed successfully'
-                    : description}
-                </p>
-              ),
-            },
-          ])
-        : [
-            [
-              intent.name,
-              {
-                app: getAppByProxyAddress(intent.to, apps),
-                content: (
-                  <p>
-                    You are able to directly interact with the {intent.name}{' '}
-                    app.
-                  </p>
-                ),
-              },
-            ],
-          ],
-    [actionPaths, apps, showPaths, intent]
-  )
+  const pathItems = useMemo(() => {
+    // Indirect paths
+    if (showPaths) {
+      return actionPaths.map(({ name, description, to }, i) => [
+        name,
+        {
+          app: getAppByProxyAddress(to, apps),
+          content: (
+            <p>
+              {/* Make last path description generic */}
+              {i === actionPaths.length - 1
+                ? 'The proposed action will be automatically executed if the previous step on the path is completed successfully'
+                : description}
+            </p>
+          ),
+        },
+      ])
+    }
+
+    // Direct path
+    return [
+      [
+        intent.name,
+        {
+          app: getAppByProxyAddress(intent.to, apps),
+          content: (
+            <p>You are able to directly interact with the {intent.name} app.</p>
+          ),
+        },
+      ],
+    ]
+  }, [showPaths, actionPaths, apps, intent])
 
   return (
     <React.Fragment>
@@ -138,8 +137,8 @@ function ExternalMessage({ installed, to, className }) {
             <LocalIdentityBadge
               entity={to}
               labelStyle={`
-                      ${textStyle('body3')}
-                    `}
+                ${textStyle('body3')}
+              `}
               compact
             />{' '}
             before proceeding.

--- a/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
+++ b/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
@@ -1,0 +1,102 @@
+import { useContext, useCallback } from 'react'
+import { ActivityContext } from '../../../contexts/ActivityContext'
+import { useWallet } from '../../../wallet'
+
+const RECIEPT_ERROR_STATUS = '0x0'
+const WEB3_TX_OBJECT_KEYS = new Set([
+  'from',
+  'to',
+  'value',
+  'gas',
+  'gasPrice',
+  'data',
+  'nonce',
+])
+
+function getPretransactionDescription(intent) {
+  return `Allow ${intent.name} to ${intent.description
+    .slice(0, 1)
+    .toLowerCase() + intent.description.slice(1)}`
+}
+
+// Clean up a transaction object removing all non-standard transaction parameters
+// https://web3js.readthedocs.io/en/v1.2.0/web3-eth.html#sendtransaction
+function sanitizeTxObject(tx) {
+  return Object.keys(tx)
+    .filter(key => WEB3_TX_OBJECT_KEYS.has(key))
+    .reduce((newTx, key) => ({ ...newTx, [key]: tx[key] }), {})
+}
+
+function useSignTransaction(web3) {
+  const { web3: walletWeb3 } = useWallet()
+
+  const {
+    addTransactionActivity,
+    setActivityConfirmed,
+    setActivityFailed,
+    setActivityNonce,
+  } = useContext(ActivityContext)
+
+  const signTransaction = useCallback(
+    (transaction, intent, isPretransaction = false, onSuccess) =>
+      new Promise((resolve, reject) => {
+        walletWeb3.eth
+          .sendTransaction(sanitizeTxObject(transaction))
+          .on('transactionHash', transactionHash => {
+            resolve(transactionHash)
+            // Get account count/nonce for the transaction and update the activity item.
+            // May be useful in case there are multiple pending transactions to detect when
+            // a pending transaction with a lower nonce was manually re-sent by the user
+            // (most likely done through their Ethereum wallet directly with a different
+            // gas price or transaction data that results in a different transaction hash).
+
+            web3.eth
+              .getTransaction(transactionHash)
+              .then(({ nonce }) => setActivityNonce({ transactionHash, nonce }))
+              .catch(console.error)
+
+            // Pretransactions are for so the app can get approval
+            const description = isPretransaction
+              ? getPretransactionDescription(intent)
+              : intent.description
+
+            const hasForwarder = intent.to !== intent.transaction.to
+
+            // Create new activiy
+            addTransactionActivity({
+              transactionHash,
+              from: intent.transaction.from,
+              targetAppProxyAddress: intent.to,
+              forwarderProxyAddress: hasForwarder ? intent.transaction.to : '',
+              description,
+            })
+          })
+          .on('receipt', receipt => {
+            if (receipt.status === RECIEPT_ERROR_STATUS) {
+              // Faliure based on EIP 658
+              setActivityFailed(receipt.transactionHash)
+            } else {
+              setActivityConfirmed(receipt.transactionHash)
+              onSuccess && onSuccess()
+            }
+          })
+          .on('error', err => {
+            // Called when signing failed
+            err && err.transactionHash && setActivityFailed(err.transactionHash)
+            reject(err)
+          })
+      }),
+    [
+      addTransactionActivity,
+      setActivityFailed,
+      setActivityNonce,
+      setActivityConfirmed,
+      walletWeb3,
+      web3,
+    ]
+  )
+
+  return signTransaction
+}
+
+export default useSignTransaction

--- a/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
+++ b/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
@@ -13,10 +13,14 @@ const WEB3_TX_OBJECT_KEYS = new Set([
   'nonce',
 ])
 
+function lowerCaseFirstCharacter(string) {
+  return string.slice(0, 1).toLowerCase() + string.slice(1)
+}
+
 function getPretransactionDescription(intent) {
-  return `Allow ${intent.name} to ${intent.description
-    .slice(0, 1)
-    .toLowerCase() + intent.description.slice(1)}`
+  return `Allow ${intent.name} to ${lowerCaseFirstCharacter(
+    intent.description
+  )}`
 }
 
 // Clean up a transaction object removing all non-standard transaction parameters

--- a/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
+++ b/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
@@ -55,7 +55,7 @@ function useSignTransaction(web3) {
               .then(({ nonce }) => setActivityNonce({ transactionHash, nonce }))
               .catch(console.error)
 
-            // Pretransactions are for so the app can get approval
+            // Pretransactions are handled separately from the intent itself, and are usually used to approve tokens for the intended action
             const description = isPretransaction
               ? getPretransactionDescription(intent)
               : intent.description

--- a/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
+++ b/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
@@ -38,7 +38,7 @@ function useSignTransaction(web3) {
   } = useContext(ActivityContext)
 
   const signTransaction = useCallback(
-    (transaction, intent, isPretransaction = false, onSuccess) =>
+    (transaction, intent, isPretransaction = false) =>
       new Promise((resolve, reject) => {
         walletWeb3.eth
           .sendTransaction(sanitizeTxObject(transaction))
@@ -77,7 +77,6 @@ function useSignTransaction(web3) {
               setActivityFailed(receipt.transactionHash)
             } else {
               setActivityConfirmed(receipt.transactionHash)
-              onSuccess && onSuccess()
             }
           })
           .on('error', err => {

--- a/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
+++ b/src/components/SigningModal/SignTransactionFlow/useSignTransaction.js
@@ -17,7 +17,7 @@ function lowerCaseFirstCharacter(string) {
   return string.slice(0, 1).toLowerCase() + string.slice(1)
 }
 
-function getPretransactionDescription(intent) {
+function getApprovalDescription(intent) {
   return `Allow ${intent.name} to ${lowerCaseFirstCharacter(
     intent.description
   )}`
@@ -42,7 +42,7 @@ function useSignTransaction(web3) {
   } = useContext(ActivityContext)
 
   const signTransaction = useCallback(
-    (transaction, intent, isPretransaction = false) =>
+    (transaction, intent) =>
       new Promise((resolve, reject) => {
         walletWeb3.eth
           .sendTransaction(sanitizeTxObject(transaction))
@@ -59,9 +59,11 @@ function useSignTransaction(web3) {
               .then(({ nonce }) => setActivityNonce({ transactionHash, nonce }))
               .catch(console.error)
 
-            // Pretransactions are handled separately from the intent itself, and are usually used to approve tokens for the intended action
-            const description = isPretransaction
-              ? getPretransactionDescription(intent)
+            // Adjust description for pretransaction approvals
+            const isApproval = transaction.data.startsWith('0x095ea7b3')
+
+            const description = isApproval
+              ? getApprovalDescription(intent)
               : intent.description
 
             const hasForwarder = intent.to !== intent.transaction.to

--- a/src/components/SigningModal/SignerButton.js
+++ b/src/components/SigningModal/SignerButton.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { Button, GU } from '@aragon/ui'
+
+const SignerButton = styled(Button).attrs({
+  mode: 'strong',
+  wide: true,
+})`
+  margin-top: ${2 * GU}px;
+`
+
+export default SignerButton

--- a/src/components/SigningModal/SigningModal.js
+++ b/src/components/SigningModal/SigningModal.js
@@ -1,0 +1,68 @@
+import React, { useState, useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
+import { AppType } from '../../prop-types'
+import SignMessageFlow from './SignMessageFlow'
+import SignTransactionFlow from './SignTransactionFlow/SignTransactionFlow'
+
+function SigningModal({ apps, transactionBag, signatureBag, web3 }) {
+  const [modalVisible, setModalVisible] = useState(false)
+  const [isTransaction, setIsTransaction] = useState(false)
+
+  const prevTxBag = useRef()
+  const prevSigBag = useRef()
+
+  const handleClose = () => setModalVisible(false)
+
+  const sigBagUpdate =
+    signatureBag && signatureBag !== prevSigBag.current && signatureBag
+  const txBagUpdate =
+    transactionBag && transactionBag !== prevTxBag.current && transactionBag
+
+  useEffect(() => {
+    if (txBagUpdate) {
+      setModalVisible(true)
+      setIsTransaction(true)
+      prevTxBag.current = txBagUpdate
+    }
+  }, [txBagUpdate])
+
+  useEffect(() => {
+    if (sigBagUpdate) {
+      setModalVisible(true)
+      setIsTransaction(false)
+      prevSigBag.current = sigBagUpdate
+    }
+  }, [sigBagUpdate])
+
+  return (
+    <React.Fragment>
+      {isTransaction
+        ? transactionBag && (
+            <SignTransactionFlow
+              apps={apps}
+              onClose={handleClose}
+              transactionBag={transactionBag}
+              visible={modalVisible}
+              web3={web3}
+            />
+          )
+        : signatureBag && (
+            <SignMessageFlow
+              apps={apps}
+              onClose={handleClose}
+              signatureBag={signatureBag}
+              visible={modalVisible}
+            />
+          )}
+    </React.Fragment>
+  )
+}
+
+SigningModal.propTypes = {
+  apps: PropTypes.arrayOf(AppType).isRequired,
+  transactionBag: PropTypes.object,
+  signatureBag: PropTypes.object,
+  web3: PropTypes.object.isRequired,
+}
+
+export default React.memo(SigningModal)

--- a/src/components/SigningModal/SigningModal.js
+++ b/src/components/SigningModal/SigningModal.js
@@ -11,26 +11,24 @@ function SigningModal({ apps, transactionBag, signatureBag, web3 }) {
   const prevTxBag = useRef()
   const prevSigBag = useRef()
 
-  const sigBagUpdate =
-    signatureBag && signatureBag !== prevSigBag.current && signatureBag
-  const txBagUpdate =
-    transactionBag && transactionBag !== prevTxBag.current && transactionBag
-
   useEffect(() => {
-    if (txBagUpdate) {
+    // Show modal only when a bag is updated with values
+    if (transactionBag !== prevTxBag.current && transactionBag) {
       setModalVisible(true)
       setIsTransaction(true)
-      prevTxBag.current = txBagUpdate
     }
-  }, [txBagUpdate])
+
+    prevTxBag.current = transactionBag
+  }, [transactionBag])
 
   useEffect(() => {
-    if (sigBagUpdate) {
+    if (signatureBag !== prevSigBag.current && signatureBag) {
       setModalVisible(true)
       setIsTransaction(false)
-      prevSigBag.current = sigBagUpdate
     }
-  }, [sigBagUpdate])
+
+    prevSigBag.current = signatureBag
+  }, [signatureBag])
 
   return (
     <React.Fragment>

--- a/src/components/SigningModal/SigningModal.js
+++ b/src/components/SigningModal/SigningModal.js
@@ -11,8 +11,6 @@ function SigningModal({ apps, transactionBag, signatureBag, web3 }) {
   const prevTxBag = useRef()
   const prevSigBag = useRef()
 
-  const handleClose = () => setModalVisible(false)
-
   const sigBagUpdate =
     signatureBag && signatureBag !== prevSigBag.current && signatureBag
   const txBagUpdate =
@@ -40,7 +38,7 @@ function SigningModal({ apps, transactionBag, signatureBag, web3 }) {
         ? transactionBag && (
             <SignTransactionFlow
               apps={apps}
-              onClose={handleClose}
+              onClose={() => setModalVisible(false)}
               transactionBag={transactionBag}
               visible={modalVisible}
               web3={web3}
@@ -49,7 +47,7 @@ function SigningModal({ apps, transactionBag, signatureBag, web3 }) {
         : signatureBag && (
             <SignMessageFlow
               apps={apps}
-              onClose={handleClose}
+              onClose={() => setModalVisible(false)}
               signatureBag={signatureBag}
               visible={modalVisible}
             />

--- a/src/components/SigningModal/TransactionStepper/Step/Step.js
+++ b/src/components/SigningModal/TransactionStepper/Step/Step.js
@@ -104,7 +104,6 @@ function Step({
             config={springs.smooth}
             items={desc}
             onStart={onAnimationStart}
-            immediate={immediateAnimation}
             from={{
               opacity: 0,
               transform: `translate3d(0, ${2 * GU}px, 0)`,

--- a/src/components/SigningModal/Web3Errors.js
+++ b/src/components/SigningModal/Web3Errors.js
@@ -1,0 +1,131 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Info, Link, GU } from '@aragon/ui'
+
+import AddressLink from './AddressLink'
+import SignerButton from './SignerButton'
+import { getProviderString } from '../../ethereum-providers'
+import { isElectron } from '../../utils'
+
+function Web3ProviderError({
+  intent: { description, name, to },
+  onClose,
+  neededText,
+  actionText,
+}) {
+  return (
+    <React.Fragment>
+      <Info mode="description" title="You can’t perform any action">
+        {neededText} in order to perform{' '}
+        {description ? `“${description}”` : 'this action'}
+        {name && (
+          <React.Fragment>
+            {' '}
+            on <AddressLink to={to}>{name}</AddressLink>
+          </React.Fragment>
+        )}
+        .
+        <p
+          css={`
+            margin-top: ${2 * GU}px;
+          `}
+        >
+          {actionText}
+        </p>
+      </Info>
+      <SignerButton onClick={onClose}>Close</SignerButton>
+    </React.Fragment>
+  )
+}
+
+Web3ProviderError.propTypes = {
+  actionText: PropTypes.node.isRequired,
+  intent: PropTypes.object.isRequired,
+  neededText: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+}
+
+export function NoWeb3Provider({ intent, onClose }) {
+  const onElectron = isElectron()
+  const neededText = onElectron
+    ? 'You need to have Frame installed and enabled'
+    : 'You need to have an Ethereum wallet installed and enabled'
+
+  const actionText = (
+    <span>
+      Please install and enable{' '}
+      <Link
+        href={onElectron ? 'https://frame.sh/' : 'https://metamask.io/'}
+        css="font-weight: 600"
+      >
+        {onElectron ? 'Frame' : 'Metamask'}
+      </Link>
+      .
+    </span>
+  )
+
+  return (
+    <Web3ProviderError
+      intent={intent}
+      onClose={onClose}
+      neededText={neededText}
+      actionText={actionText}
+    />
+  )
+}
+
+NoWeb3Provider.propTypes = {
+  intent: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+}
+
+export function AccountLocked({ intent, onClose, walletProviderId }) {
+  const providerMessage = getProviderString(
+    'your Ethereum wallet',
+    walletProviderId
+  )
+  return (
+    <Web3ProviderError
+      intent={intent}
+      onClose={onClose}
+      neededText={`You need to unlock and enable ${providerMessage}`}
+      actionText={<span>Please connect your account.</span>}
+    />
+  )
+}
+
+AccountLocked.propTypes = {
+  intent: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  walletProviderId: PropTypes.string.isRequired,
+}
+
+export function WrongNetwork({
+  intent,
+  networkType,
+  onClose,
+  walletProviderId,
+}) {
+  return (
+    <Web3ProviderError
+      intent={intent}
+      onClose={onClose}
+      neededText={`
+      You need to be connected to the ${networkType} network
+    `}
+      actionText={`
+      Please connect ${getProviderString(
+        'your Ethereum wallet',
+        walletProviderId
+      )} to the ${networkType} network.
+    `}
+    />
+  )
+}
+
+WrongNetwork.propTypes = {
+  intent: PropTypes.object.isRequired,
+  networkType: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  walletProviderId: PropTypes.string.isRequired,
+}

--- a/src/components/SigningModal/prop-types.js
+++ b/src/components/SigningModal/prop-types.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-export const ModalProps = PropTypes.shape({
+export const modalProps = PropTypes.shape({
   prevScreen: PropTypes.func,
   nextScreen: PropTypes.func,
   closeModal: PropTypes.func,

--- a/src/components/SigningModal/prop-types.js
+++ b/src/components/SigningModal/prop-types.js
@@ -1,7 +1,0 @@
-import PropTypes from 'prop-types'
-
-export const modalProps = PropTypes.shape({
-  prevScreen: PropTypes.func,
-  nextScreen: PropTypes.func,
-  closeModal: PropTypes.func,
-})

--- a/src/components/SigningModal/useWalletError.js
+++ b/src/components/SigningModal/useWalletError.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { AccountLocked, NoWeb3Provider, WrongNetwork } from './Web3Errors'
+import { network } from '../../environment'
+import { useWallet } from '../../wallet'
+
+function useWalletError({ intent, isTransaction }) {
+  const wallet = useWallet()
+  const { connected, web3, networkType: walletNetworkType } = wallet
+  const networkType = network.type
+  const hasWeb3 = Boolean(web3)
+  const walletProviderId = wallet.providerInfo.id
+
+  if (!hasWeb3) {
+    return modalProps => (
+      <NoWeb3Provider intent={intent} onClose={modalProps.closeModal} />
+    )
+  }
+
+  if (!connected) {
+    return modalProps => (
+      <AccountLocked
+        intent={intent}
+        onClose={modalProps.closeModal}
+        walletProviderId={walletProviderId}
+      />
+    )
+  }
+
+  if (isTransaction && walletNetworkType !== networkType) {
+    return modalProps => (
+      <WrongNetwork
+        intent={intent}
+        onClose={modalProps.closeModal}
+        networkType={networkType}
+        walletProviderId={walletProviderId}
+      />
+    )
+  }
+
+  return false
+}
+
+export default useWalletError

--- a/src/components/SigningModal/utils.js
+++ b/src/components/SigningModal/utils.js
@@ -1,0 +1,27 @@
+import { addressesEqual } from '../../web3-utils'
+
+// Temporarily clean the error messages coming from Aragon.js and Metamask
+const cleanErrorMessage = errorMsg =>
+  errorMsg
+    // Only use the first line if multiple lines are available.
+    // This makes sure we don't show the stack trace if it becomes part of the message.
+    .split('\n')[0]
+    .replace(/^Returned error: /, '')
+    .replace(/^Error: /, '')
+
+export function getErrorMessage(warning, error) {
+  const cleanedErrorMessage = cleanErrorMessage((error && error.message) || '')
+
+  return `${warning} ${
+    cleanedErrorMessage
+      ? `Error: ${cleanedErrorMessage}`
+      : `There may have been a problem with your Ethereum wallet.`
+  }`
+}
+
+export function getAppByProxyAddress(proxyAddress, apps) {
+  if (!proxyAddress) {
+    return null
+  }
+  return apps.find(app => addressesEqual(app.proxyAddress, proxyAddress))
+}


### PR DESCRIPTION
Apologies for length, it's worth going commit by commit.

Much of this code was adapted from the existing `SignerPanel`. The biggest change is the forking of the code path to not mix message signing state with transaction signing as I feel it's a little easier to reason about this way. I'm not super happy with parts of this due to working around some outstanding issues in the Modal and the way the data is provided and updated.

In general the whole "reshaping" of the bag just feels a bit.. odd, I'm sure there are historic reasons for it in the signer panel but i'd like some feedback on it.

Account connect prompt will come in a separate improvement.