### PR TITLE
Agreement: add feature deployments to agreement.aragon.org

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -1,9 +1,9 @@
-name: Mainnet deployment
+name: Agreement deployment
 
 on:
   push:
     branches:
-      - master
+      - agreement
 
 jobs:
   deploy:
@@ -22,6 +22,14 @@ jobs:
       run: >
         now
         -A now-mainnet.json
+        --confirm
+        --prod
+        --token=${{ secrets.ZEIT_TOKEN }}
+        --build-env NOW_GITHUB_COMMIT_SHA="$(git log --pretty=format:'%h' -n 1)"
+    - name: now
+      run: >
+        now
+        -A now
         --confirm
         --prod
         --token=${{ secrets.ZEIT_TOKEN }}

--- a/now-mainnet.json
+++ b/now-mainnet.json
@@ -2,7 +2,7 @@
   "version": 2,
   "public": true,
   "scope": "aragon",
-  "alias": "nightly.aragon.org",
+  "alias": "agreement.aragon.org",
   "build": {
     "env": {
       "ARAGON_ETH_NETWORK_TYPE": "main",

--- a/now.json
+++ b/now.json
@@ -2,7 +2,7 @@
   "version": 2,
   "public": true,
   "scope": "aragon",
-  "alias": "nightly-rinkeby.aragon.org",
+  "alias": "agreement-rinkeby.aragon.org",
   "github": {
     "silent": true
   },


### PR DESCRIPTION
The deployment github action is now targetting the `agreement` branch and deploying to `agreement.aragon.org` and `agreement-rinkeby.aragon.org`.