### PR TITLE
DAO-239 initialize wrapper with Client network information

### DIFF
--- a/src/apps/Organization/Organization.js
+++ b/src/apps/Organization/Organization.js
@@ -285,7 +285,7 @@ const Organization = React.memo(function Organization({
                   ) : (
                     <span>
                       Unfortunately, importing into Tenderly is not available on
-                      the {sanitizeNetworkType(network.network)} network. Please
+                      the {sanitizeNetworkType(network.type)} network. Please
                       use Aragon on Ethereum mainnet instead.
                     </span>
                   )}

--- a/src/aragonjs-wrapper.js
+++ b/src/aragonjs-wrapper.js
@@ -20,7 +20,8 @@ import {
 import SandboxedWorker from './worker/SandboxedWorker'
 import WorkerSubscriptionPool from './worker/WorkerSubscriptionPool'
 import { getOrganizationByAddress } from './services/gql'
-import { getNetworkConfig } from './network-config'
+import { getNetworkConfig, getChainId } from './network-config'
+import { KNOWN_CHAINS } from './wallet'
 
 const POLL_DELAY_CONNECTIVITY = 2000
 
@@ -296,7 +297,9 @@ const initWrapper = async (
   })
 
   try {
+    const network = KNOWN_CHAINS.get(getChainId(networkType))
     await wrapper.init({
+      network,
       accounts: {
         providedAccounts: walletAccount ? [walletAccount] : [],
       },

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -169,6 +169,10 @@ export function getNetworkSettings(networkType) {
   return getNetworkConfig(networkType).settings
 }
 
+export function getChainId(networkType) {
+  return getNetworkSettings(networkType).chainId
+}
+
 export function useNetworkConfig() {
   const { networkType } = useWallet()
   return getNetworkConfig(networkType)

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -7,7 +7,7 @@ const DAI_RINKEBY_TOKEN_ADDRESS = '0x0527e400502d0cb4f214dd0d2f2a323fc88ff924'
 
 // connectGraphEndpoint is https://github.com/aragon/connect/tree/master/packages/connect-thegraph
 export const networkConfigs = {
-  [KNOWN_CHAINS.get(1).network]: {
+  [KNOWN_CHAINS.get(1).type]: {
     enableMigrateBanner: false,
     addresses: {
       ensRegistry:
@@ -26,7 +26,7 @@ export const networkConfigs = {
       live: true,
     },
   },
-  [KNOWN_CHAINS.get(4).network]: {
+  [KNOWN_CHAINS.get(4).type]: {
     enableMigrateBanner: true,
     addresses: {
       ensRegistry:
@@ -45,7 +45,7 @@ export const networkConfigs = {
       live: true,
     },
   },
-  [KNOWN_CHAINS.get(3).network]: {
+  [KNOWN_CHAINS.get(3).type]: {
     enableMigrateBanner: true,
     addresses: {
       ensRegistry:
@@ -62,7 +62,7 @@ export const networkConfigs = {
       live: true,
     },
   },
-  [KNOWN_CHAINS.get(1337).network]: {
+  [KNOWN_CHAINS.get(1337).type]: {
     enableMigrateBanner: true,
     addresses: {
       ensRegistry: localEnsRegistryAddress,
@@ -83,7 +83,7 @@ export const networkConfigs = {
   },
   // xDai is an experimental chain in the Aragon Client. It's possible
   // and expected that a few things will break.
-  [KNOWN_CHAINS.get(100).network]: {
+  [KNOWN_CHAINS.get(100).type]: {
     enableMigrateBanner: false,
     addresses: {
       ensRegistry:
@@ -100,7 +100,7 @@ export const networkConfigs = {
       live: true,
     },
   },
-  [KNOWN_CHAINS.get(80001).network]: {
+  [KNOWN_CHAINS.get(80001).type]: {
     enableMigrateBanner: false,
     addresses: {
       ensRegistry:

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -19,7 +19,7 @@ export const WALLET_STATUS = Object.freeze({
 })
 
 // default network is mainnet if user is not conncted
-const NETWORK_TYPE_DEFAULT = KNOWN_CHAINS.get(1)?.network
+const NETWORK_TYPE_DEFAULT = KNOWN_CHAINS.get(1)?.type
 
 const WalletContext = React.createContext()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14351,7 +14351,7 @@ use-token@^0.2.0:
 
 "use-wallet@https://github.com/aragon/use-wallet.git#multichain":
   version "0.9.0"
-  resolved "https://github.com/aragon/use-wallet.git#8e9b3a9356ff0768119bc90201822c9b6d15edf7"
+  resolved "https://github.com/aragon/use-wallet.git#6ed3bf85cc0bf49bea7a9c77ebf44e6d8c87ea9f"
   dependencies:
     "@aragon/provided-connector" "^6.0.8"
     "@typescript-eslint/parser" "^4.1.0"


### PR DESCRIPTION
@novaknole , these changes require the changes in https://github.com/aragon/aragon.js/tree/DAO-212-polygon-network-type.  I don't know how to make Client use the package in a monorepo.. so, I didn't update package.json to use the branch.. make sure you locally link it with that branch to do the testing.